### PR TITLE
Selinux issue on centos7/rhel7 with docker volume

### DIFF
--- a/ansible/container.yml
+++ b/ansible/container.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - PGPASSWORD={{ galaxy_postgres_password }}
     volumes:
-      - ${PWD}:/galaxy
+      - ${PWD}:/galaxy:z
       - {{ galaxy_log_dir }}:/galaxy_logs
       - {{ galaxy_config_path }}:/etc/galaxy
     links:
@@ -25,7 +25,7 @@ services:
     environment:
       - POSTGRES_PASSWORD={{ galaxy_postgres_password }}
       - POSTGRES_USER={{ galaxy_postgres_user }}
-      - POSTGRES_DB={{ galaxy_postgres_db }} 
+      - POSTGRES_DB={{ galaxy_postgres_db }}
 
   elastic:
     image: elasticsearch:latest


### PR DESCRIPTION
When running a make build (or make refresh) the docker volume ${PWD}:/galaxy was not accessible because of a selinux issue on cents 7.x or rhel 7.x. Result the build fails with the following issue:

[Errno 13] Permission denied: '/galaxy/requirements.txt

A complete output of the issue:
```
ansible-container_1  | TASK [Clear yum cache] *********************************************************
ansible-container_1  | changed: [django]
ansible-container_1  |  [WARNING]: Consider using yum module rather than running yum
ansible-container_1  | 
ansible-container_1  | TASK [Install python packages] *************************************************
ansible-container_1  | fatal: [django]: FAILED! => {"changed": false, "cmd": "/usr/bin/pip install -r /galaxy/requirements.txt", "failed": true, "msg": "\n:stderr: You are using pip version 7.1.0, however version 8.1.2 is available.\nYou should consider upgrading via the 'pip install --upgrade pip' command.\nCould not open requirements file: [Errno 13] Permission denied: '/galaxy/requirements.txt'\n"}
ansible-container_1  |  [WARNING]: Could not create retry file 'main.retry'.         [Errno 2] No such
ansible-container_1  | file or directory: ''
ansible-container_1  | 
```

When using SELinux for controlling processes within a container, you need to make sure any content that gets volume mounted into the container is readable, and potentially writable, depending on the use case. (The docker inspect command shows:  /galaxy:rw , connecting with _make shell_ and trying to access the /galaxy directory will result in a permission denied).

By default, Docker container processes run with the system_u:system_r:svirt_lxc_net_t:s0 label. The svirt_lxc_net_t type is allowed to read/execute most content under /usr, but it is not allowed to use most other types on the system.

 [see volumes selinux for more info](http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/)