### PR TITLE
Selinux fix so containers get build on CentOS/RHEL

### DIFF
--- a/ansible/container.yml
+++ b/ansible/container.yml
@@ -3,6 +3,7 @@ services:
   django:
     image: centos:7
     working_dir: /galaxy
+    privileged: yes
     environment:
       - PGPASSWORD={{ galaxy_postgres_password }}
     volumes:
@@ -25,7 +26,7 @@ services:
     environment:
       - POSTGRES_PASSWORD={{ galaxy_postgres_password }}
       - POSTGRES_USER={{ galaxy_postgres_user }}
-      - POSTGRES_DB={{ galaxy_postgres_db }} 
+      - POSTGRES_DB={{ galaxy_postgres_db }}
 
   elastic:
     image: elasticsearch:latest


### PR DESCRIPTION
When running a make build (or make refresh) the docker volume ${PWD}:/galaxy was not accessible because of a selinux issue on cents 7.x or rhel 7.x. Result the build fails with the following issue:

[Errno 13] Permission denied: '/galaxy/requirements.txt

A complete output of the issue:
```
ansible-container_1  | TASK [Clear yum cache] *********************************************************
ansible-container_1  | changed: [django]
ansible-container_1  |  [WARNING]: Consider using yum module rather than running yum
ansible-container_1  | 
ansible-container_1  | TASK [Install python packages] *************************************************
ansible-container_1  | fatal: [django]: FAILED! => {"changed": false, "cmd": "/usr/bin/pip install -r /galaxy/requirements.txt", "failed": true, "msg": "\n:stderr: You are using pip version 7.1.0, however version 8.1.2 is available.\nYou should consider upgrading via the 'pip install --upgrade pip' command.\nCould not open requirements file: [Errno 13] Permission denied: '/galaxy/requirements.txt'\n"}
ansible-container_1  |  [WARNING]: Could not create retry file 'main.retry'.         [Errno 2] No such
ansible-container_1  | file or directory: ''
ansible-container_1  | 
```

The docker inspect command shows:  /galaxy:rw , connecting with _make shell_ and trying to access the /galaxy directory will result in a permission denied. This could be fixed by adding option behind the /galaxy volume. This works but the next selinux problem occurs:

```
ansible-container_1  | TASK [Create the /etc/galaxy directory] ****************************************
ansible-container_1  | fatal: [django]: FAILED! => {"changed": false, "failed": true, "gid": 0, "group": "root", "mode": "0755", "msg": "chgrp failed", "owner": "root", "path": "/etc/galaxy", "size": 6, "state": "directory", "uid": 0}
ansible-container_1  |  [WARNING]: Could not create retry file 'main.retry'.         [Errno 2] No such
ansible-container_1  | file or directory: ''
```

So we need another fix then the z option described in [see volumes selinux for more info](http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/)

**By adding more privileges in the container.yml file everything gets build without problems. So adding privileged: yes appears to be the solution.**

My system is up to date and running:
CentOS Linux release 7.2.1511 (Core) 
No packages marked for update