### PR TITLE
Fix issue 234

### DIFF
--- a/ansible/container.yml
+++ b/ansible/container.yml
@@ -14,6 +14,7 @@ services:
       - "8000:8000"
     environment: 
       - C_FORCE_ROOT=1
+      - PYTHONPATH=/galaxy
     dev_overrides:
       volumes:
         - ${PWD}:/galaxy:z

--- a/ansible/roles/django-role/tasks/setup_galaxy.yml
+++ b/ansible/roles/django-role/tasks/setup_galaxy.yml
@@ -22,6 +22,6 @@
     mode: 0660
 
 - name: Install galaxy
-  command: "{{ galaxy_venv }}/bin/python ./setup.py develop"
+  command: "{{ galaxy_venv }}/bin/python /galaxy/setup.py develop"
   args:
-    chdir: /galaxy
+    chdir: /

--- a/ansible/roles/gulp-role/tasks/main.yml
+++ b/ansible/roles/gulp-role/tasks/main.yml
@@ -15,7 +15,7 @@
     group: root
     mode: 755
 
-name: Create galaxy directory
+- name: Create galaxy directory
   file: 
     path: /galaxy
     state: directory

--- a/ansible/roles/gulp-role/tasks/main.yml
+++ b/ansible/roles/gulp-role/tasks/main.yml
@@ -15,6 +15,22 @@
     group: root
     mode: 755
 
+name: Create galaxy directory
+  file: 
+    path: /galaxy
+    state: directory
+    owner: root
+    group: root
+    mode: 775 
+
+- name: Copy package.json
+  copy:
+    src: "{{ lookup('pipe','dirname `pwd`') }}/package.json"
+    dest: /galaxy/package.json
+    owner: root
+    group: root
+    mode: 775
+
 - name: Install node packages
   npm: path=/galaxy state=latest
 


### PR DESCRIPTION
Fix issue 234 (https://github.com/ansible/galaxy-issues/issues/234)
* Copy package.json to /galaxy to fix ansible_gulp_1 "Install node packages" task.
* Install galaxy egg-info outside of mounted dir to fix ansible_django_1 "galaxy-manage" call.