### PR TITLE
Fix django container failure on restart

### DIFF
--- a/roles/django-role/files/start-development.sh
+++ b/roles/django-role/files/start-development.sh
@@ -2,22 +2,22 @@
 set +x
 
 # remove any lingering log files that might be owned by root
-rm -f /galaxy_logs/*.log 
+rm -f /galaxy_logs/*.log
 
 if [ ! -f /setup/dbinit.completed ]; then
      cd /setup
      /venv/bin/ansible-playbook -i inventory dbinit.yml
-     if [ "$?" != "0" ]; then 
+     if [ "$?" != "0" ]; then
          exit 1
      fi
-     cd - 
+     cd -
 else
-     /venv/bin/galaxy-manage makemigrations
-     if [ "$?" != "0" ]; then 
+     /venv/bin/python ./manage.py makemigrations
+     if [ "$?" != "0" ]; then
          exit 1
      fi
-     /venv/bin/galaxy-manage migrate --noinput
-     if [ "$?" != "0" ]; then 
+     /venv/bin/python ./manage.py migrate --noinput
+     if [ "$?" != "0" ]; then
          exit 1
      fi
 fi


### PR DESCRIPTION
Use manage.py script from project directory for
executing database migrations on container restart.