### PR TITLE
Fix license identifiers in project metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "galaxy",
   "version": "0.0.0",
+  "private": true,
   "description": "Find, reuse and share the best Ansible content",
   "main": "\\",
   "scripts": {
@@ -16,7 +17,7 @@
     "Ansibleworks"
   ],
   "author": "Chris Houseknecht",
-  "license": "Commercial",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ansible/galaxy/issues"
   },

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup(
     author_email='support@ansible.com',
     description='Galaxy: Find, reuse and share the best Ansible content.',
     long_description='Galaxy is a web site and command line tool for creating and sharing Ansible roles.',
-    license='Apache v2',
+    license='Apache-2.0',
     keywords='ansible galaxy',
     url='http://github.com/ansible/galaxy',
     packages=['galaxy'],
@@ -147,7 +147,7 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',
         'Intended Audience :: System Administrators'
-        'License :: Apache v2',
+        'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Operating System :: POSIX',


### PR DESCRIPTION
* Use a valid SPDX license identifier in package.json and setup.py
  files, refer to https://spdx.org/licenses/
* Use a valid PyPi license classifier, refer to
  https://pypi.python.org/pypi?%3Aaction=list_classifiers
  for more details.
* Set 'private' property in package.json

Issue #58 