### PR TITLE
Minor cleanup

### DIFF
--- a/DCO_1_1.md
+++ b/DCO_1_1.md
@@ -1,0 +1,46 @@
+DCO
+===
+
+All contributors must use `git commit --signoff` for any
+commit to be merged, and agree that usage of --signoff constitutes
+agreement with the terms of DCO 1.1, which appears below:
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+

--- a/galaxy/settings/development.py
+++ b/galaxy/settings/development.py
@@ -126,3 +126,6 @@ WAIT_FOR = [
     {'host': 'memcache', 'port': 11211},
     {'host': 'elastic', 'port': 9200}
 ]
+
+ADMIN_URL_PATTERN = r'^admin/'
+

--- a/galaxy/settings/production.py
+++ b/galaxy/settings/production.py
@@ -39,6 +39,7 @@ The following environment variables are supported:
 * GALAXY_RABBITMQ_PORT
 * GALAXY_RABBITMQ_USER
 * GALAXY_RABBITMQ_PASSWORD
+* GALAXY_ADMIN_PATH
 """
 
 import os
@@ -239,6 +240,8 @@ WAIT_FOR = [
         'port': int(os.environ.get('GALAXY_ELASTICSEARCH_PORT', 9200)),
     }
 ]
+
+ADMIN_URL_PATTERN = r'^%s/' % os.environ.get('GALAXY_ADMIN_PATH', 'admin')
 
 # =========================================================
 # Logging

--- a/galaxy/urls.py
+++ b/galaxy/urls.py
@@ -34,7 +34,7 @@ urlpatterns = patterns(
     url(r'^api/', include('galaxy.api.urls', namespace='api', app_name='api')),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     # url(r'^avatar/', include('avatar.urls')),
-    url(r'^galaxy__admin__site/', include(admin.site.urls)),
+    url(settings.ADMIN_URL_PATTERN, include(admin.site.urls)),
     url(r'^robots\.txt$', TemplateView.as_view(template_name="robots.txt", content_type='text/plain')),
     url(r'', include('galaxy.main.urls', namespace='main', app_name='main')),
 )


### PR DESCRIPTION
- Adds DCO_1_1 doc
- Makes site admin path dynamic. Defaults to 'admin'. Override with GALAXY_ADMIN_PATH var.