### PR TITLE
Ignore W503 - an invalid flake8 warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,7 @@
 # E501 - Line too long
 # E722 - Do not use bare except
 # E731 - Prefer def over lambda
-ignore=E221,E231,E241,E251,E265,E501,E722,E731
+# W503 - line break before binary operator, to be replaced with W504.
+#        Refer to https://github.com/PyCQA/pycodestyle/issues/498
+ignore=E221,E231,E241,E251,E265,E501,E722,E731,W503
 exclude=config,galaxy/*/migrations,galaxy/*/south_migrations,galaxy/static,provisioning


### PR DESCRIPTION
W503 is an outdated warning which doesn't reflect actual PEP8[1] version
after update[2].
Will be replaced in future pycodestyle release[3].

[1] https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator
[2] https://hg.python.org/peps/rev/3857909d7956
[3] PyCQA/pycodestyle#498