### PR TITLE
Move ADMIN_URL_PATTERN to default settings

### DIFF
--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -322,6 +322,8 @@ TRAVIS_CONFIG_URL = 'https://api.travis-ci.org/config'
 # TODO(cutwater): Consider removing wait_for from settings
 WAIT_FOR = []
 
+ADMIN_URL_PATTERN = r'^admin/'
+
 # =========================================================
 # Logging
 # =========================================================

--- a/galaxy/settings/development.py
+++ b/galaxy/settings/development.py
@@ -126,5 +126,3 @@ WAIT_FOR = [
     {'host': 'memcache', 'port': 11211},
     {'host': 'elastic', 'port': 9200}
 ]
-
-ADMIN_URL_PATTERN = r'^admin/'


### PR DESCRIPTION
Fix default settings. Move parameter ADMIN_URL_PATTERN
from development settings to default settings.