### PR TITLE
Drop deprecated patterns() function usage

### DIFF
--- a/galaxy/accounts/admin.py
+++ b/galaxy/accounts/admin.py
@@ -84,11 +84,11 @@ class CustomUserAdmin(admin.ModelAdmin):
         return super(CustomUserAdmin, self).get_form(request, obj, **defaults)
 
     def get_urls(self):
-        from django.conf.urls import patterns
-        return patterns(
-            '', (r'^(\d+)/password/$',
-                 self.admin_site.admin_view(self.user_change_password))
-        ) + super(CustomUserAdmin, self).get_urls()
+        from django.conf.urls import url
+        return [
+            url(r'^(\d+)/password/$', self.admin_site.admin_view(
+                self.user_change_password))
+        ] + super(CustomUserAdmin, self).get_urls()
 
     def lookup_allowed(self, lookup, value):
         # See #20078: we don't want to allow any lookups involving passwords.

--- a/galaxy/accounts/urls.py
+++ b/galaxy/accounts/urls.py
@@ -15,12 +15,10 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from . import views
 
 
-urlpatters = patterns(
-    '',
+urlpatters = [
     url(r'^dashboard/$', views.dashboard, name='accounts_dashboard'),
-
-)
+]

--- a/galaxy/api/urls.py
+++ b/galaxy/api/urls.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-from django.conf.urls import include, patterns, url as original_url
+from django.conf.urls import include, url as original_url
 from rest_framework import routers
 from .views import (RoleSearchView,
                     PlatformsSearchView,
@@ -27,6 +27,7 @@ from .views import (RoleSearchView,
                     TokenView,
                     RemoveRole,
                     RefreshUserRepos)
+from galaxy.api import views
 
 router = routers.DefaultRouter()
 router.register('v1/search/roles', RoleSearchView, base_name="search-roles")
@@ -39,106 +40,123 @@ def url(regex, view, kwargs=None, name=None, prefix=''):
     return original_url(regex, view, kwargs, name, prefix)
 
 
-user_urls = patterns(
-    'galaxy.api.views',
-    url(r'^$', 'user_list'),
-    url(r'^(?P<pk>[0-9]+)/$', 'user_detail'),
-    url(r'^(?P<pk>[0-9]+)/repos/$', 'user_repositories_list'),
-    url(r'^(?P<pk>[0-9]+)/subscriptions/$', 'user_subscription_list'),
-    url(r'^(?P<pk>[0-9]+)/starred/$', 'user_starred_list'),
-    url(r'^(?P<pk>[0-9]+)/secrets/$', 'user_notification_secret_list'),
-)
+user_urls = [
+    url(r'^$', views.UserList.as_view(), name='user_list'),
+    url(r'^(?P<pk>[0-9]+)/$', views.UserDetail.as_view(), name='user_detail'),
+    url(r'^(?P<pk>[0-9]+)/repos/$', views.UserRepositoriesList.as_view(),
+        name='user_repositories_list'),
+    url(r'^(?P<pk>[0-9]+)/subscriptions/$',
+        views.UserSubscriptionList.as_view(), name='user_subscription_list'),
+    url(r'^(?P<pk>[0-9]+)/starred/$', views.UserStarredList.as_view(),
+        name='user_starred_list'),
+    url(r'^(?P<pk>[0-9]+)/secrets/$',
+        views.UserNotificationSecretList.as_view(),
+        name='user_notification_secret_list'),
+]
 
-role_urls = patterns(
-    'galaxy.api.views',
-    url(r'^$', 'role_list'),
-    url(r'^(?P<pk>[0-9]+)/$', 'role_detail'),
-    url(r'^(?P<pk>[0-9]+)/users/$', 'role_users_list'),
-    url(r'^(?P<pk>[0-9]+)/dependencies/$', 'role_dependencies_list'),
-    url(r'^(?P<pk>[0-9]+)/imports/$', 'role_import_task_list'),
-    url(r'^(?P<pk>[0-9]+)/versions/$', 'role_versions_list'),
-    url(r'^(?P<pk>[0-9]+)/notifications/$', 'role_notification_list')
-)
+role_urls = [
+    url(r'^$', views.RoleList.as_view(), name='role_list'),
+    url(r'^(?P<pk>[0-9]+)/$', views.RoleDetail.as_view(), name='role_detail'),
+    url(r'^(?P<pk>[0-9]+)/users/$', views.RoleUsersList.as_view(),
+        name='role_users_list'),
+    url(r'^(?P<pk>[0-9]+)/dependencies/$',
+        views.RoleDependenciesList.as_view(), name='role_dependencies_list'),
+    url(r'^(?P<pk>[0-9]+)/imports/$',
+        views.RoleImportTaskList.as_view(), name='role_import_task_list'),
+    url(r'^(?P<pk>[0-9]+)/versions/$',
+        views.RoleVersionsList.as_view(), name='role_versions_list'),
+    url(r'^(?P<pk>[0-9]+)/notifications/$',
+        views.RoleNotificationList.as_view(), name='role_notification_list')
+]
 
-platform_urls = patterns(
-    'galaxy.api.views',
-    url(r'^$', 'platform_list'),
-    url(r'^(?P<pk>[0-9]+)/$', 'platform_detail'),
-)
+platform_urls = [
+    url(r'^$', views.PlatformList.as_view(), name='platform_list'),
+    url(r'^(?P<pk>[0-9]+)/$', views.PlatformDetail.as_view(),
+        name='platform_detail'),
+]
 
-cloud_platform_urls = patterns(
-    'galaxy.api.views',
-    url(r'^$', 'cloud_platform_list'),
-    url(r'^(?P<pk>[0-9]+)/$', 'cloud_platform_detail'),
-)
+cloud_platform_urls = [
+    url(r'^$', views.CloudPlatformList.as_view(), name='cloud_platform_list'),
+    url(r'^(?P<pk>[0-9]+)/$', views.CloudPlatformDetail.as_view(),
+        name='cloud_platform_detail'),
+]
 
-category_urls = patterns(
-    'galaxy.api.views',
-    url(r'^$', 'category_list'),
-    url(r'^(?P<pk>[0-9]+)/$', 'category_detail'),
-)
+category_urls = [
+    url(r'^$', views.CategoryList.as_view(), name='category_list'),
+    url(r'^(?P<pk>[0-9]+)/$', views.CategoryDetail.as_view(),
+        name='category_detail'),
+]
 
-tag_urls = patterns(
-    'galaxy.api.views',
-    url(r'^$', 'tag_list'),
-    url(r'^(?P<pk>[0-9]+)/$', 'tag_detail'),
-)
+tag_urls = [
+    url(r'^$', views.TagList.as_view(), name='tag_list'),
+    url(r'^(?P<pk>[0-9]+)/$', views.TagDetail.as_view(), name='tag_detail'),
+]
 
-search_urls = patterns(
-    'galaxy.api.views',
+search_urls = [
     url(r'^$', ApiV1SearchView.as_view(), name="search_view"),
     # url(r'facetedplatforms/$',           FacetedView.as_view(),
     #    kwargs={u'facet_key': u'platforms', u'model': u'Role'}, name="faceted_platforms_view"),
     # url(r'facetedtags/$',                FacetedView.as_view(),
     #    kwargs={u'facet_key': u'tags', u'model': u'Role'}, name="faceted_tags_view"),
-    url(r'^platforms/$', PlatformsSearchView.as_view(), name='platforms_search_view'),
-    url(r'^cloud_platforms/$', CloudPlatformsSearchView.as_view(), name='cloud_platforms_search_view'),
+    url(r'^platforms/$', PlatformsSearchView.as_view(),
+        name='platforms_search_view'),
+    url(r'^cloud_platforms/$', CloudPlatformsSearchView.as_view(),
+        name='cloud_platforms_search_view'),
     url(r'^tags/$', TagsSearchView.as_view(), name='tags_search_view'),
     url(r'^users/$', UserSearchView.as_view(), name='user_search_view'),
-    url(r'^top_contributors/$', 'top_contributors_list', name='top_contributors_list'),
-)
+    url(r'^top_contributors/$', views.TopContributorsList.as_view(),
+        name='top_contributors_list'),
+]
 
-import_task_urls = patterns(
-    'galaxy.api.views',
-    url(r'^$', 'import_task_list'),
-    url(r'latest/$', 'import_task_latest_list'),
-    url(r'^(?P<pk>[0-9]+)/$', 'import_task_detail'),
-    url(r'^(?P<pk>[0-9]+)/notifications/$', 'import_task_notification_list'),
-)
+import_task_urls = [
+    url(r'^$', views.ImportTaskList.as_view(), name='import_task_list'),
+    url(r'latest/$', views.ImportTaskLatestList.as_view(),
+        name='import_task_latest_list'),
+    url(r'^(?P<pk>[0-9]+)/$', views.ImportTaskDetail.as_view(),
+        name='import_task_detail'),
+    url(r'^(?P<pk>[0-9]+)/notifications/$',
+        views.ImportTaskNotificationList.as_view(),
+        name='import_task_notification_list'),
+]
 
-notification_secret_urls = patterns(
-    'galaxy.api.views',
-    url(r'^$', 'notification_secret_list'),
-    url(r'^(?P<pk>[0-9]+)/$', 'notification_secret_detail'),
-)
+notification_secret_urls = [
+    url(r'^$', views.NotificationSecretList.as_view(),
+        name='notification_secret_list'),
+    url(r'^(?P<pk>[0-9]+)/$', views.NotificationSecretDetail.as_view(),
+        name='notification_secret_detail'),
+]
 
-notification_urls = patterns(
-    'galaxy.api.views',
-    url(r'^$', 'notification_list'),
-    url(r'^(?P<pk>[0-9]+)/$', 'notification_detail'),
-    url(r'^(?P<pk>[0-9]+)/roles/$', 'notification_roles_list'),
-    url(r'^(?P<pk>[0-9]+)/imports/$', 'notification_imports_list'),
-)
+notification_urls = [
+    url(r'^$', views.NotificationList.as_view(), name='notification_list'),
+    url(r'^(?P<pk>[0-9]+)/$', views.NotificationDetail.as_view(),
+        name='notification_detail'),
+    url(r'^(?P<pk>[0-9]+)/roles/$', views.NotificationRolesList.as_view(),
+        name='notification_roles_list'),
+    url(r'^(?P<pk>[0-9]+)/imports/$', views.NotificationImportsList.as_view(),
+        name='notification_imports_list'),
+]
 
-repo_urls = patterns(
-    'galaxy.api.views',
+repo_urls = [
     url(r'^$', ApiV1ReposView.as_view(), name="repos_view"),
-    url(r'list/$', 'repository_list'),
-    url(r'list/(?P<pk>[0-9]+)/$', 'repository_detail'),
+    url(r'list/$', views.RepositoryList.as_view(), name='repository_list'),
+    url(r'list/(?P<pk>[0-9]+)/$', views.RepositoryDetail.as_view(),
+        name='repository_detail'),
     url(r'refresh/$', RefreshUserRepos.as_view(), name='refresh_user_repos'),
-    url(r'stargazers/$', 'stargazer_list'),
-    url(r'stargazers/(?P<pk>[0-9]+)/$', 'stargazer_detail'),
-    url(r'subscriptions/$', 'subscription_list'),
-    url(r'subscriptions/(?P<pk>[0-9]+)/$', 'subscription_detail'),
-)
+    url(r'stargazers/$', views.StargazerList.as_view(), name='stargazer_list'),
+    url(r'stargazers/(?P<pk>[0-9]+)/$', views.StargazerDetail.as_view(),
+        name='stargazer_detail'),
+    url(r'subscriptions/$', views.SubscriptionList.as_view(),
+        name='subscription_list'),
+    url(r'subscriptions/(?P<pk>[0-9]+)/$', views.SubscriptionDetail.as_view(),
+        name='subscription_detail'),
+]
 
-v1_urls = patterns(
-    'galaxy.api.views',
-    url(r'^$', 'api_v1_root_view'),
-    url(r'^me/$', 'user_me_list'),
+v1_urls = [
+    url(r'^$', views.ApiV1RootView.as_view(), name='api_v1_root_view'),
+    url(r'^me/$', views.UserMeList.as_view(), name='user_me_list'),
     url(r'^users/', include(user_urls)),
     url(r'^roles/', include(role_urls)),
-    url(r'^role_types/', 'role_types'),
+    url(r'^role_types/', views.RoleTypes.as_view(), name='role_types'),
     url(r'^categories/', include(category_urls)),
     url(r'^tags/', include(tag_urls)),
     url(r'^platforms/', include(platform_urls)),
@@ -150,12 +168,11 @@ v1_urls = patterns(
     url(r'^notifications/', include(notification_urls)),
     url(r'^repos/', include(repo_urls)),
     url(r'^search/', include(search_urls)),
-)
+]
 
-urlpatterns = patterns(
-    'galaxy.api.views',
-    url(r'^$', 'api_root_view'),
+urlpatterns = [
+    url(r'^$', views.ApiRootView.as_view(), name='api_root_view'),
     url(r'^v1/', include(v1_urls)),
-)
+]
 
 urlpatterns += router.urls

--- a/galaxy/api/urls.py
+++ b/galaxy/api/urls.py
@@ -15,29 +15,14 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-from django.conf.urls import include, url as original_url
+from django.conf.urls import include, url
 from rest_framework import routers
-from .views import (RoleSearchView,
-                    PlatformsSearchView,
-                    CloudPlatformsSearchView,
-                    TagsSearchView,
-                    ApiV1SearchView,
-                    ApiV1ReposView,
-                    UserSearchView,
-                    TokenView,
-                    RemoveRole,
-                    RefreshUserRepos)
+
 from galaxy.api import views
 
 router = routers.DefaultRouter()
-router.register('v1/search/roles', RoleSearchView, base_name="search-roles")
-
-
-def url(regex, view, kwargs=None, name=None, prefix=''):
-    # Set default name from view name (if a string).
-    if isinstance(view, basestring) and name is None:
-        name = view
-    return original_url(regex, view, kwargs, name, prefix)
+router.register('v1/search/roles', views.RoleSearchView,
+                base_name="search-roles")
 
 
 user_urls = [
@@ -93,17 +78,17 @@ tag_urls = [
 ]
 
 search_urls = [
-    url(r'^$', ApiV1SearchView.as_view(), name="search_view"),
+    url(r'^$', views.ApiV1SearchView.as_view(), name="search_view"),
     # url(r'facetedplatforms/$',           FacetedView.as_view(),
     #    kwargs={u'facet_key': u'platforms', u'model': u'Role'}, name="faceted_platforms_view"),
     # url(r'facetedtags/$',                FacetedView.as_view(),
     #    kwargs={u'facet_key': u'tags', u'model': u'Role'}, name="faceted_tags_view"),
-    url(r'^platforms/$', PlatformsSearchView.as_view(),
+    url(r'^platforms/$', views.PlatformsSearchView.as_view(),
         name='platforms_search_view'),
-    url(r'^cloud_platforms/$', CloudPlatformsSearchView.as_view(),
+    url(r'^cloud_platforms/$', views.CloudPlatformsSearchView.as_view(),
         name='cloud_platforms_search_view'),
-    url(r'^tags/$', TagsSearchView.as_view(), name='tags_search_view'),
-    url(r'^users/$', UserSearchView.as_view(), name='user_search_view'),
+    url(r'^tags/$', views.TagsSearchView.as_view(), name='tags_search_view'),
+    url(r'^users/$', views.UserSearchView.as_view(), name='user_search_view'),
     url(r'^top_contributors/$', views.TopContributorsList.as_view(),
         name='top_contributors_list'),
 ]
@@ -137,11 +122,12 @@ notification_urls = [
 ]
 
 repo_urls = [
-    url(r'^$', ApiV1ReposView.as_view(), name="repos_view"),
+    url(r'^$', views.ApiV1ReposView.as_view(), name="repos_view"),
     url(r'list/$', views.RepositoryList.as_view(), name='repository_list'),
     url(r'list/(?P<pk>[0-9]+)/$', views.RepositoryDetail.as_view(),
         name='repository_detail'),
-    url(r'refresh/$', RefreshUserRepos.as_view(), name='refresh_user_repos'),
+    url(r'refresh/$', views.RefreshUserRepos.as_view(),
+        name='refresh_user_repos'),
     url(r'stargazers/$', views.StargazerList.as_view(), name='stargazer_list'),
     url(r'stargazers/(?P<pk>[0-9]+)/$', views.StargazerDetail.as_view(),
         name='stargazer_detail'),
@@ -162,8 +148,8 @@ v1_urls = [
     url(r'^platforms/', include(platform_urls)),
     url(r'^cloud_platforms/', include(cloud_platform_urls)),
     url(r'^imports/', include(import_task_urls)),
-    url(r'^tokens/', TokenView.as_view(), name='token'),
-    url(r'^removerole/', RemoveRole.as_view(), name='remove_role'),
+    url(r'^tokens/', views.TokenView.as_view(), name='token'),
+    url(r'^removerole/', views.RemoveRole.as_view(), name='remove_role'),
     url(r'^notification_secrets/', include(notification_secret_urls)),
     url(r'^notifications/', include(notification_urls)),
     url(r'^repos/', include(repo_urls)),

--- a/galaxy/main/urls.py
+++ b/galaxy/main/urls.py
@@ -15,35 +15,39 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.conf import settings
 from django.views.decorators.cache import never_cache
 from django.contrib.staticfiles.views import serve as serve_staticfiles
 from django.views.static import serve as serve_static
 
 from galaxy.main.views import RoleListView, RoleDetailView, NamespaceListView
+from galaxy.main import views
 
-urlpatterns = patterns(
-    'galaxy.main.views',
+urlpatterns = [
     # Non-secure URLs
-    url(r'^$', 'home', name='home'),
-    url(r'^explore$', 'explore', name='explore'),
-    url(r'^intro$', 'intro', name='intro'),
-    url(r'^accounts/landing[/]?$', 'accounts_landing', name='accounts-landing'),
-    url(r'^list$', 'list_category', name='list-category'),
-    url(r'^detail$', 'detail_category', name='detail-category'),
-    url(r'^roleadd$', 'role_add_view', name='role-add-category'),
-    url(r'^imports$', 'import_status_view', name='import-status'),
+    url(r'^$', views.home, name='home'),
+    url(r'^explore$', views.explore, name='explore'),
+    url(r'^intro$', views.intro, name='intro'),
+    url(r'^accounts/landing[/]?$', views.accounts_landing,
+        name='accounts-landing'),
+    url(r'^list$', views.list_category, name='list-category'),
+    url(r'^detail$', views.detail_category, name='detail-category'),
+    url(r'^roleadd$', views.role_add_view, name='role-add-category'),
+    url(r'^imports$', views.import_status_view, name='import-status'),
 
     # Logged in/secured URLs
-    url(r'^accounts/connect/$', 'accounts_connect'),
-    url(r'^accounts/connect/success/$', 'accounts_connect_success', name='accounts-connect-success'),
-    url(r'^accounts/profile/$', 'accounts_profile', name='accounts-profile'),
+    url(r'^accounts/connect/$', views.accounts_connect),
+    url(r'^accounts/connect/success/$', views.accounts_connect_success,
+        name='accounts-connect-success'),
+    url(r'^accounts/profile/$', views.accounts_profile,
+        name='accounts-profile'),
 
     url(r'^authors/$', NamespaceListView.as_view(), name='namespace-list'),
     url(r'^([\w\-._+]+)/$', RoleListView.as_view(), name='role-list'),
-    url(r'^([\w\-._+]+)/([\w\-._+]+)/$', RoleDetailView.as_view(), name='role-detail'),
-)
+    url(r'^([\w\-._+]+)/([\w\-._+]+)/$', RoleDetailView.as_view(),
+        name='role-detail'),
+]
 
 # FIX
 if settings.DEBUG:

--- a/galaxy/urls.py
+++ b/galaxy/urls.py
@@ -16,33 +16,35 @@
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
 from django.conf import settings
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.generic import TemplateView
 import autofixture
 
-handler404 = 'galaxy.main.views.handle_404_view'
-handler400 = 'galaxy.main.views.handle_400_view'
-handler500 = 'galaxy.main.views.handle_500_view'
+from galaxy.main import views
+
+handler404 = views.handle_404_view
+handler400 = views.handle_400_view
+handler500 = views.handle_500_view
 
 admin.autodiscover()
 autofixture.autodiscover()
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^accounts/', include('allauth.urls')),
     url(r'^api/', include('galaxy.api.urls', namespace='api', app_name='api')),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    url(r'^api-auth/', include('rest_framework.urls',
+                               namespace='rest_framework')),
     # url(r'^avatar/', include('avatar.urls')),
     url(settings.ADMIN_URL_PATTERN, include(admin.site.urls)),
-    url(r'^robots\.txt$', TemplateView.as_view(template_name="robots.txt", content_type='text/plain')),
+    url(r'^robots\.txt$', TemplateView.as_view(template_name="robots.txt",
+                                               content_type='text/plain')),
     url(r'', include('galaxy.main.urls', namespace='main', app_name='main')),
-)
+]
 
 if settings.DEBUG:
     import debug_toolbar
-    urlpatterns += patterns(
-        '',
+    urlpatterns += [
         url(r'^__debug__/', include(debug_toolbar.urls))
-    )
+    ]
     url(r'^galaxy__admin__site/', include(admin.site.urls)),

--- a/galaxy/urls.py
+++ b/galaxy/urls.py
@@ -21,11 +21,10 @@ from django.contrib import admin
 from django.views.generic import TemplateView
 import autofixture
 
-from galaxy.main import views
 
-handler404 = views.handle_404_view
-handler400 = views.handle_400_view
-handler500 = views.handle_500_view
+handler404 = 'galaxy.main.views.handle_404_view'
+handler400 = 'galaxy.main.views.handle_400_view'
+handler500 = 'galaxy.main.views.handle_500_view'
 
 admin.autodiscover()
 autofixture.autodiscover()


### PR DESCRIPTION
Function django.conf.urls.patterns() is deprecated as got removed
in Django 1.10.
Issue: #33 