### PR TITLE
Deploy wheel file

### DIFF
--- a/deploy/ec2/deploy-galaxy-ec2.yml
+++ b/deploy/ec2/deploy-galaxy-ec2.yml
@@ -34,7 +34,7 @@
         chdir: ../..  
 
     - name: Get the name of the local distribution file
-      shell: ls -1 $(pwd)/dist/galaxy-*.tar.gz
+      shell: ls -1 $(pwd)/dist/galaxy-*-none-any.whl
       args:
         chdir: ../.. 
       register: dist_file 

--- a/deploy/roles/galaxy-deploy/tasks/main.yml
+++ b/deploy/roles/galaxy-deploy/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- name: Check for the tar file
-  shell: ls -1 {{ galaxy_dist_dir }}/galaxy-*.tar.gz
-  register: app_tar
+- name: Check for the wheel file
+  shell: ls -1 {{ galaxy_dist_dir }}/galaxy-*-none-any.whl
+  register: whl_file
 
 - name: File should exist 
   assert:
-    that: "'tar.gz' in app_tar.stdout"
+    that: "'none-any.whl' in whl_file.stdout"
 
 - name: Remove the existing app
   pip:
@@ -15,7 +15,7 @@
 
 - name: Install the Galaxy app
   pip:
-    name: "{{ app_tar.stdout }}"
+    name: "{{ whl_file.stdout }}"
     state: present
 
 - name: Deploy settings file


### PR DESCRIPTION
Not sure what changed, but deploying the `tar.gz` file results in the following error:

```
pip install galaxy-2.3.1.dev78+gad2c2cb.tar.gz
Processing ./galaxy-2.3.1.dev78+gad2c2cb.tar.gz
    Complete output from command python setup.py egg_info:
    fatal: Not a git repository (or any of the parent directories): .git
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-IBPjeF-build/setup.py", line 82, in <module>
        version=version.get_git_version(),
      File "galaxy/common/version.py", line 49, in get_git_version
        'git', 'describe', '--match', TAG_PREFIX + '*']
      File "/usr/lib64/python2.7/subprocess.py", line 575, in check_output
        raise CalledProcessError(retcode, cmd, output=output)
    subprocess.CalledProcessError: Command '['git', 'describe', '--match', 'v*']' returned non-zero exit status 128
```

Using the wheel file seems to work.