### PR TITLE
Remove via shell

### DIFF
--- a/deploy/roles/galaxy-dist/tasks/main.yml
+++ b/deploy/roles/galaxy-dist/tasks/main.yml
@@ -2,11 +2,7 @@
 ---
 
 - name: Remove old wheel files
-  file:
-    path: '{{ item }}'
-    state: absent
-  with_fileglob:
-  - '/tmp/galaxy-*-none-any.whl'
+  shell: rm -f /tmp/galaxy-*-none-any.whl
 
 - name: Copy the file
   copy:


### PR DESCRIPTION
Remove any pre-existing wheel files using `shell`, as `with_fileglob` doesn't seem to be working.