### PR TITLE
Fixing broken deployment bits

### DIFF
--- a/deploy/roles/galaxy-deploy/tasks/celery.yml
+++ b/deploy/roles/galaxy-deploy/tasks/celery.yml
@@ -1,3 +1,23 @@
+- name: Stop supervisord 
+  service: 
+    name: supervisord 
+    state: stopped 
+
+- name: Make sure /var/lib/galaxy exists
+  file:
+    path: /var/lib/galaxy
+    state: directory
+    owner: root
+    group: root
+    mode: 0775
+
+- name: Remove django logs
+  command: 'rm -f /var/log/{{ item }}'
+  with_items:
+  - allauth.log 
+  - django.log
+  - galaxy.log 
+
 - name: Restart and enable supervisord
   service:
     name: supervisord

--- a/deploy/roles/galaxy-deploy/tasks/web.yml
+++ b/deploy/roles/galaxy-deploy/tasks/web.yml
@@ -15,6 +15,18 @@
   command: galaxy-manage collectstatic --clear --noinput
   environment:
     DJANGO_SETTINGS_MODULE: 'galaxy.settings.custom'
+
+- name: Copy wsgi.py
+  copy:
+    src: /usr/lib/python2.7/site-packages/galaxy/wsgi.py
+    dest: /var/lib/galaxy/wsgi.py
+    remote_src: yes
+
+- name: Copy favicon.ico
+  copy:
+    src: /var/lib/galaxy/public/static/img/favicon.ico
+    dest: /var/lib/galaxy/favicon.ico
+    remote_src: yes
   notify:
     - restart apache
 

--- a/deploy/roles/galaxy-deploy/tasks/web.yml
+++ b/deploy/roles/galaxy-deploy/tasks/web.yml
@@ -27,6 +27,17 @@
     src: /var/lib/galaxy/public/static/img/favicon.ico
     dest: /var/lib/galaxy/favicon.ico
     remote_src: yes
-  notify:
-    - restart apache
 
+- name: Stop apache
+  service: 
+    name: httpd
+    state: stopped
+
+- name: Set log file ownership
+  command: chown apache:apache /var/log/galaxy/*
+
+- name: Start apache 
+  service:
+    name: httpd
+    state: started
+    enabled: yes

--- a/galaxy/wsgi.py
+++ b/galaxy/wsgi.py
@@ -24,8 +24,8 @@ from django.core.wsgi import get_wsgi_application
 
 from galaxy import prepare_env
 
-
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'galaxy.settings.production')
+# For public Galaxy, we need to default /etc/galaxy/settings.py 
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'galaxy.settings.custom')
 
 # Prepare the galaxy environment.
 prepare_env()

--- a/galaxy/wsgi.py
+++ b/galaxy/wsgi.py
@@ -24,7 +24,7 @@ from django.core.wsgi import get_wsgi_application
 
 from galaxy import prepare_env
 
-# For public Galaxy, we need to default /etc/galaxy/settings.py 
+# For public Galaxy, we need to default /etc/galaxy/settings.py
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'galaxy.settings.custom')
 
 # Prepare the galaxy environment.


### PR DESCRIPTION
- Perhaps because we're installing the wheel file, not sure, but `wsgi.py` is not ending up in the public static directory. Same with `favicon.ico`. Adding tasks to take care of these. 
- There are a set of things that are always broken after a deployment. Adding tasks to take care of these. 