### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/deploy/ec2/ec2.py
+++ b/deploy/ec2/ec2.py
@@ -127,6 +127,7 @@ destination_format_tags: Name,clusterid,deployment,private_dns_name
 These settings would produce a destination_format as the following:
 'webserver-ansible-blue-172.31.0.1'
 '''
+from __future__ import print_function
 
 # (c) 2012, Peter Sankauskas
 #

--- a/deploy/ec2/ec2.py
+++ b/deploy/ec2/ec2.py
@@ -127,7 +127,6 @@ destination_format_tags: Name,clusterid,deployment,private_dns_name
 These settings would produce a destination_format as the following:
 'webserver-ansible-blue-172.31.0.1'
 '''
-from __future__ import print_function
 
 # (c) 2012, Peter Sankauskas
 #
@@ -147,6 +146,8 @@ from __future__ import print_function
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 ######################################################################
+
+from __future__ import print_function
 
 import sys
 import os

--- a/galaxy/api/base_views.py
+++ b/galaxy/api/base_views.py
@@ -377,7 +377,7 @@ class SubListCreateAPIView(SubListAPIView, ListCreateAPIView):
             if not serializer.is_valid():
                 # logger.debug('SubListCreateAPIView.create: serializer failed validation')
                 return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-        except Exception, e:
+        except Exception as e:
             # logger.debug('SubListCreateAPIView.create: serializer threw an error')
             return Response("serializer errors", status=status.HTTP_400_BAD_REQUEST)
 
@@ -394,9 +394,9 @@ class SubListCreateAPIView(SubListAPIView, ListCreateAPIView):
             self.pre_save(serializer.validated_data)
             obj = serializer.save()
             data = self.serializer_class(obj).data
-        except IntegrityError, e:
+        except IntegrityError as e:
             return Response("database integrity conflict", status=status.HTTP_409_CONFLICT)
-        except Exception, e:
+        except Exception as e:
             return Response("unknown error: %s" % str(e), status=status.HTTP_400_BAD_REQUEST)
 
         return Response(data, status=status.HTTP_201_CREATED)

--- a/galaxy/api/filters.py
+++ b/galaxy/api/filters.py
@@ -125,7 +125,7 @@ class FieldLookupBackend(BaseFilterBackend):
         elif lookup.endswith('__regex') or lookup.endswith('__iregex'):
             try:
                 re.compile(value)
-            except re.error, e:
+            except re.error as e:
                 raise ValueError(e.args[0])
             return value
         else:
@@ -142,7 +142,7 @@ class FieldLookupBackend(BaseFilterBackend):
             try:
                 # try and lookup the user first, to see if it exists
                 GalaxyUser.objects.get(username=request.GET['owner__username'])
-            except ObjectDoesNotExist, e:
+            except ObjectDoesNotExist as e:
                 # if not, check to see if there's an alias for it
                 try:
                     alias_obj = UserAlias.objects.get(alias_name=request.GET['owner__username'])
@@ -157,7 +157,7 @@ class FieldLookupBackend(BaseFilterBackend):
                     # same object is being used with the overridden param.
                     # This may be fixed in later DRF versions?
                     request.GET = qp
-                except Exception, e:
+                except Exception as e:
                     # if not, we don't care, the later filtering
                     # means an empty set will be returned for this
                     pass
@@ -229,9 +229,9 @@ class FieldLookupBackend(BaseFilterBackend):
                         q = Q(**{k: v})
                     queryset = queryset.filter(q)
             return queryset.distinct()
-        except (FieldError, FieldDoesNotExist, ValueError), e:
+        except (FieldError, FieldDoesNotExist, ValueError) as e:
             raise ParseError(e.args[0])
-        except ValidationError, e:
+        except ValidationError as e:
             raise ParseError(e.messages)
 
 
@@ -258,7 +258,7 @@ class OrderByBackend(BaseFilterBackend):
                 except IndexError:
                     pass
             return queryset
-        except FieldError, e:
+        except FieldError as e:
             # Return a 400 for invalid field names.
             raise ParseError(*e.args)
 
@@ -277,6 +277,6 @@ class HaystackFilter(HaystackFilter):
             if order_by:
                 qs = qs.order_by(*order_by)
             return qs
-        except FieldError, e:
+        except FieldError as e:
             # Return a 400 for invalid field names.
             raise ParseError(*e.args)

--- a/galaxy/api/permissions.py
+++ b/galaxy/api/permissions.py
@@ -128,7 +128,7 @@ class ModelAccessPermission(permissions.BasePermission):
         #             view.__class__.__name__, obj)
         try:
             response = self.check_permissions(request, view, obj)
-        except Exception, e:
+        except Exception as e:
             logger.debug('has_permission raised %r', e, exc_info=True)
             raise
         else:

--- a/galaxy/api/throttling.py
+++ b/galaxy/api/throttling.py
@@ -52,7 +52,7 @@ class RoleDownloadCountThrottle(ScopedRateThrottle):
                         return True
                     role.download_count += 1
                     role.save()
-                except Exception, e:
+                except Exception as e:
                     self.logger.error('Error finding role %s.%s - %s' % (role_namespace,
                                                                          role_name,
                                                                          str(e.args)))

--- a/galaxy/api/utils.py
+++ b/galaxy/api/utils.py
@@ -41,9 +41,9 @@ def get_object_or_400(klass, *args, **kwargs):
     queryset = _get_queryset(klass)
     try:
         return queryset.get(*args, **kwargs)
-    except queryset.model.DoesNotExist, e:
+    except queryset.model.DoesNotExist as e:
         raise ParseError(*e.args)
-    except queryset.model.MultipleObjectsReturned, e:
+    except queryset.model.MultipleObjectsReturned as e:
         raise ParseError(*e.args)
 
 
@@ -56,9 +56,9 @@ def get_object_or_403(klass, *args, **kwargs):
     queryset = _get_queryset(klass)
     try:
         return queryset.get(*args, **kwargs)
-    except queryset.model.DoesNotExist, e:
+    except queryset.model.DoesNotExist as e:
         raise PermissionDenied(*e.args)
-    except queryset.model.MultipleObjectsReturned, e:
+    except queryset.model.MultipleObjectsReturned as e:
         raise PermissionDenied(*e.args)
 
 

--- a/galaxy/api/views.py
+++ b/galaxy/api/views.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # (c) 2012-2018, Ansible by Red Hat
 #
 # This file is part of Ansible Galaxy
@@ -533,14 +534,14 @@ class StargazerList(ListCreateAPIView):
         try:
             gh_api = Github(token.token)
             gh_api.get_api_status()
-        except GithubException, e:
+        except GithubException as e:
             msg = "Failed to connect to GitHub API. This is most likely a temporary error, " + \
                   "please try again in a few minutes. {0} - {1}".format(e.data, e.status)
             raise ValidationError(dict(detail=msg))
 
         try:
             gh_repo = gh_api.get_repo(github_user + '/' + github_repo)
-        except GithubException, e:
+        except GithubException as e:
             msg = "GitHub API failed to return repo for {0}/{1}. {2} - {3}".format(github_user,
                                                                                    github_repo,
                                                                                    e.data,
@@ -591,7 +592,7 @@ class StargazerDetail(RetrieveUpdateDestroyAPIView):
         try:
             gh_api = Github(token.token)
             gh_api.get_api_status()
-        except GithubException, e:
+        except GithubException as e:
             msg = "Failed to connect to GitHub API. This is most likely a temporary " + \
                 "error, please try again in a few minutes. {0} - {1}".format(e.data, e.status)
             raise ValidationError(dict(detail=msg))
@@ -599,7 +600,7 @@ class StargazerDetail(RetrieveUpdateDestroyAPIView):
         try:
             gh_repo = gh_api.get_repo(
                 obj.role.github_user + '/' + obj.role.github_repo)
-        except GithubException, e:
+        except GithubException as e:
             msg = "GitHub API failed to return repo for {0}/{1}. {2} - {3}".format(obj.github_user,
                                                                                    obj.github_repo,
                                                                                    e.data,
@@ -608,13 +609,13 @@ class StargazerDetail(RetrieveUpdateDestroyAPIView):
 
         try:
             gh_user = gh_api.get_user()
-        except GithubException, e:
+        except GithubException as e:
             msg = "GitHub API failed to return authorized user. {0} - {1}".format(e.data, e.status)
             raise ValidationError(dict(detail=msg))
 
         try:
             gh_user.remove_from_starred(gh_repo)
-        except GithubException, e:
+        except GithubException as e:
             msg = "GitHub API failed to remove user {0} from stargazers ".format(request.user.github_user) + \
                 "for {0}/{1}. {2} - {3}".format(obj.github_user, obj.github_repo, e.data, e.status)
             raise ValidationError(dict(detail=msg))
@@ -650,14 +651,14 @@ class SubscriptionList(ListCreateAPIView):
         try:
             gh_api = Github(token.token)
             gh_api.get_api_status()
-        except GithubException, e:
+        except GithubException as e:
             msg = "Failed to connect to GitHub API. This is most likely a temporary error, please try " + \
                   "again in a few minutes. {0} - {1}".format(e.data, e.status)
             raise ValidationError(dict(detail=msg))
 
         try:
             gh_repo = gh_api.get_repo(github_user + '/' + github_repo)
-        except GithubException, e:
+        except GithubException as e:
             msg = "GitHub API failed to return repo for {0}/{1}. {2} - {3}".format(github_user,
                                                                                    github_repo,
                                                                                    e.data,
@@ -666,13 +667,13 @@ class SubscriptionList(ListCreateAPIView):
 
         try:
             gh_user = gh_api.get_user()
-        except GithubException, e:
+        except GithubException as e:
             msg = "GitHub API failed to return authorized user. {0} - {1}".format(e.data, e.status)
             raise ValidationError(dict(detail=msg))
 
         try:
             gh_user.add_to_subscriptions(gh_repo)
-        except GithubException, e:
+        except GithubException as e:
             msg = "GitHub API failed to subscribe user {0} to for {1}/{2}".format(request.user.github_user,
                                                                                   github_user,
                                                                                   github_repo)
@@ -723,14 +724,14 @@ class SubscriptionDetail(RetrieveUpdateDestroyAPIView):
         try:
             gh_api = Github(token.token)
             gh_api.get_api_status()
-        except GithubException, e:
+        except GithubException as e:
             msg = "Failed to connect to GitHub API. This is most likely a temporary error, " + \
                   "please try again in a few minutes. {0} - {1}".format(e.data, e.status)
             raise ValidationError(dict(detail=msg))
 
         try:
             gh_repo = gh_api.get_repo(obj.github_user + '/' + obj.github_repo)
-        except GithubException, e:
+        except GithubException as e:
             msg = "GitHub API failed to return repo for {0}/{1}. {2} - {3}".format(obj.github_user,
                                                                                    obj.github_repo,
                                                                                    e.data,
@@ -739,13 +740,13 @@ class SubscriptionDetail(RetrieveUpdateDestroyAPIView):
 
         try:
             gh_user = gh_api.get_user()
-        except GithubException, e:
+        except GithubException as e:
             msg = "GitHub API failed to return authorized user. {0} - {1}".format(e.data, e.status)
             raise ValidationError(dict(detail=msg))
 
         try:
             gh_user.remove_from_subscriptions(gh_repo)
-        except GithubException, e:
+        except GithubException as e:
             msg = "GitHub API failed to unsubscribe {0} from {1}/{2}. {3} - {4}".format(request.user.github_user,
                                                                                         obj.github_user,
                                                                                         obj.github_repo,
@@ -1288,7 +1289,7 @@ class RemoveRole(APIView):
             try:
                 gh_api = Github(token.token)
                 gh_api.get_api_status()
-            except GithubException, e:
+            except GithubException as e:
                 msg = "Failed to connect to GitHub API. This is most likely a temporary error, " + \
                       "please try again in a few minutes. {0} - {1}".format(e.data, e.status)
                 raise ValidationError(dict(detail=msg))
@@ -1389,7 +1390,7 @@ class RefreshUserRepos(APIView):
         try:
             gh_api = Github(token.token)
             gh_api.get_api_status()
-        except GithubException, e:
+        except GithubException as e:
             msg = "Failed to connect to GitHub API. This is most likely a temporary error, " + \
                   "please try again in a few minutes. {0} - {1}".format(e.data, e.status)
             logger.error(msg)

--- a/galaxy/api/views.py
+++ b/galaxy/api/views.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # (c) 2012-2018, Ansible by Red Hat
 #
 # This file is part of Ansible Galaxy
@@ -17,6 +16,8 @@ from __future__ import print_function
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
 # standard python libraries
+from __future__ import print_function
+
 import sys
 import math
 import requests

--- a/galaxy/main/celerytasks/tasks.py
+++ b/galaxy/main/celerytasks/tasks.py
@@ -840,7 +840,7 @@ def import_role(task_id):
         role.is_valid = True
         role.save()
         transaction.commit()
-    except Exception, e:
+    except Exception as e:
         fail_import_task(import_task, u"Error saving role: %s" % e.message)
 
     # Update ES indexes

--- a/galaxy/main/management/commands/refresh_role_counts.py
+++ b/galaxy/main/management/commands/refresh_role_counts.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # (c) 2012-2016, Ansible by Red Hat
 #
 # This file is part of Ansible Galaxy
@@ -87,14 +88,14 @@ class Command(BaseCommand):
                 if not obj.state == 'FINISHED':
                     finished = False
                 else:
-                    print u"{0} Total: {1} Passed: {2} Failed: {3} Deleted: {4} Updated: {5}".format(
+                    print(u"{0} Total: {1} Passed: {2} Failed: {3} Deleted: {4} Updated: {5}".format(
                         obj.description,
                         obj.failed + obj.passed + obj.deleted + obj.updated,
                         obj.passed,
                         obj.failed,
                         obj.deleted,
                         obj.updated
-                    )
+                    ))
                     obj.state = 'COMPLETED'
                     obj.save()
             time.sleep(60)

--- a/galaxy/main/management/commands/refresh_role_counts.py
+++ b/galaxy/main/management/commands/refresh_role_counts.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # (c) 2012-2016, Ansible by Red Hat
 #
 # This file is part of Ansible Galaxy
@@ -15,6 +14,8 @@ from __future__ import print_function
 #
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+from __future__ import print_function
 
 import time
 import logging

--- a/galaxy/main/south_migrations/0018_remove_ansible_from_role_name.py
+++ b/galaxy/main/south_migrations/0018_remove_ansible_from_role_name.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 import datetime
 from south.db import db
 from south.v2 import DataMigration
@@ -22,7 +23,7 @@ class Migration(DataMigration):
                         role.original_name = new_name
                         role.save()
             except:
-                print "failed to rename role: %s/%s (id=%d)" % (role.name, role.owner.username, role.pk) 
+                print("failed to rename role: %s/%s (id=%d)" % (role.name, role.owner.username, role.pk)) 
 
 
     def backwards(self, orm):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django==1.8.3
 djangorestframework==3.0.5
 pexpect
 decorator
-django-allauth
+django-allauth==0.34.0
 django-autofixture
 # django-avatar
 celery==3.1.24


### PR DESCRIPTION
Make the minimal, safe changes required to convert the code to be syntax compatible with both Python 2 and Python 3. There would definitely be more work required to complete the port of the code to Python 3 but this is a minimal, safe first step.

    Run: futurize --stage1 -w **/*.py

See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes

$ pip install future
$ git checkout -b modernize-python2-code
$ futurize --stage1 -w **/*.py # done in zsh for ** globbing
$ git commit --all -m "Modernize Python 2 code to get ready for Python 3"
$ git push --set-upstream origin modernize-python2-code