### PR TITLE
import six to support Python 3

### DIFF
--- a/galaxy/api/base_views.py
+++ b/galaxy/api/base_views.py
@@ -20,6 +20,8 @@ import inspect
 import warnings
 import logging
 
+import six
+
 # Django
 from django.http import Http404
 from django.core.paginator import InvalidPage
@@ -147,8 +149,8 @@ class GenericAPIView(generics.GenericAPIView, APIView):
             self.format_kwarg = 'format'
         d = super(GenericAPIView, self).get_description_context()
         d.update({
-            'model_verbose_name': unicode(self.model._meta.verbose_name),
-            'model_verbose_name_plural': unicode(self.model._meta.verbose_name_plural),
+            'model_verbose_name': six.u(self.model._meta.verbose_name),
+            'model_verbose_name_plural': six.u(self.model._meta.verbose_name_plural),
             'serializer_fields': self.get_serializer().metadata(),
         })
         return d
@@ -305,8 +307,8 @@ class SubListAPIView(ListAPIView):
     def get_description_context(self):
         d = super(SubListAPIView, self).get_description_context()
         d.update({
-            'parent_model_verbose_name': unicode(self.parent_model._meta.verbose_name),
-            'parent_model_verbose_name_plural': unicode(self.parent_model._meta.verbose_name_plural),
+            'parent_model_verbose_name': six.u(self.parent_model._meta.verbose_name),
+            'parent_model_verbose_name_plural': six.u(self.parent_model._meta.verbose_name_plural),
         })
         return d
 

--- a/galaxy/api/filters.py
+++ b/galaxy/api/filters.py
@@ -17,6 +17,8 @@
 
 import re
 
+import six
+
 # Django
 from django.core.exceptions import FieldError, ValidationError, ObjectDoesNotExist
 from django.contrib.auth import get_user_model
@@ -86,7 +88,7 @@ class FieldLookupBackend(BaseFilterBackend):
         return field
 
     def to_python_boolean(self, value, allow_none=False):
-        value = unicode(value)
+        value = six.u(value)
         if value.lower() in ('true', '1'):
             return True
         elif value.lower() in ('false', '0'):
@@ -94,10 +96,10 @@ class FieldLookupBackend(BaseFilterBackend):
         elif allow_none and value.lower() in ('none', 'null'):
             return None
         else:
-            raise ValueError(u'Unable to convert "%s" to boolean' % unicode(value))
+            raise ValueError(u'Unable to convert "%s" to boolean' % six.u(value))
 
     def to_python_related(self, value):
-        value = unicode(value)
+        value = six.u(value)
         if value.lower() in ('none', 'null'):
             return None
         else:

--- a/galaxy/api/serializers.py
+++ b/galaxy/api/serializers.py
@@ -18,6 +18,8 @@
 import markdown
 import json
 
+import six
+
 from rest_framework import serializers
 
 from django.contrib.auth.models import AnonymousUser
@@ -137,9 +139,9 @@ class BaseSerializer(serializers.ModelSerializer):
         ret = super(BaseSerializer, self).get_fields()
         for key, field in ret.items():
             if key == 'id' and not getattr(field, 'help_text', None):
-                field.help_text = 'Database ID for this %s.' % unicode(opts.verbose_name)
+                field.help_text = 'Database ID for this %s.' % six.u(opts.verbose_name)
             elif key == 'url':
-                field.help_text = 'URL for this %s.' % unicode(opts.verbose_name)
+                field.help_text = 'URL for this %s.' % six.u(opts.verbose_name)
                 field.type_label = 'string'
             elif key == 'related':
                 field.help_text = 'Data structure with URLs of related resources.'
@@ -148,10 +150,10 @@ class BaseSerializer(serializers.ModelSerializer):
                 field.help_text = 'Data structure with name/description for related resources.'
                 field.type_label = 'object'
             elif key == 'created':
-                field.help_text = 'Timestamp when this %s was created.' % unicode(opts.verbose_name)
+                field.help_text = 'Timestamp when this %s was created.' % six.u(opts.verbose_name)
                 field.type_label = 'datetime'
             elif key == 'modified':
-                field.help_text = 'Timestamp when this %s was last modified.' % unicode(opts.verbose_name)
+                field.help_text = 'Timestamp when this %s was last modified.' % six.u(opts.verbose_name)
                 field.type_label = 'datetime'
         return ret
 

--- a/galaxy/main/models.py
+++ b/galaxy/main/models.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
+import six
+
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db import models
@@ -46,7 +48,7 @@ class BaseModel(models.Model, DirtyMixin):
 
     def __unicode__(self):
         if hasattr(self, 'name'):
-            return unicode("%s-%s" % (self.name, self.id))
+            return six.u("%s-%s" % (self.name, self.id))
         else:
             return u'%s-%s' % (self._meta.verbose_name, self.id)
 
@@ -212,7 +214,7 @@ class UserAlias(models.Model):
     )
 
     def __unicode__(self):
-        return unicode("%s (alias of %s)" % (self.alias_name, self.alias_of.username))
+        return six.u("%s (alias of %s)" % (self.alias_name, self.alias_of.username))
 
 
 class Video(PrimordialModel):
@@ -492,7 +494,7 @@ class Role(CommonModelNameNotUnique):
     def validate_char_lengths(self):
         for field in self._meta.get_fields():
             if not field.is_relation and field.get_internal_type() == 'CharField':
-                if isinstance(getattr(self, field.name), basestring) and len(getattr(self, field.name)) > field.max_length:
+                if isinstance(getattr(self, field.name), six.string_types) and len(getattr(self, field.name)) > field.max_length:
                     raise Exception("Role %s value exceeeds max length of %s." % (field.name, field.max_length))
 
 
@@ -692,7 +694,7 @@ class ImportTask(PrimordialModel):
         for field in self._meta.get_fields():
             if not field.is_relation and field.get_internal_type() == 'CharField':
                 # print "%s %s" % (field.name, field.max_length)
-                if isinstance(getattr(self, field.name), basestring) and len(getattr(self, field.name)) > field.max_length:
+                if isinstance(getattr(self, field.name), six.string_types) and len(getattr(self, field.name)) > field.max_length:
                     raise Exception("Import Task %s value exceeeds max length of %s." % (field.name, field.max_length))
 
 

--- a/galaxy/main/utils/memcache_lock.py
+++ b/galaxy/main/utils/memcache_lock.py
@@ -27,10 +27,11 @@ instead use a distributed/replicated store like couchbase.
 This allows us to guarantee that
 """
 
-import time
-import logging
 import contextlib
+import logging
 import random
+import time
+
 from django.core.cache import cache as django_cache
 
 
@@ -53,7 +54,7 @@ def memcache_lock(key, attempts=1, expires=120):
 
 
 def _acquire_lock(key, attempts, expires):
-    for i in xrange(0, attempts):
+    for i in range(0, attempts):
         stored = django_cache.add(key, 1, expires)
         if stored:
             return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ PyGithub
 markdown==2.4.1
 requests
 requests-oauthlib
+six
 bleach
 rst2html5-tools
 setuptools


### PR DESCRIPTION
* Add __[six](https://pythonhosted.org/six)__ module to __requirements.txt__ (deploy/ec2/ec2.py was already using six)
* Replace instances of __basestring__ with __[six.string_types](https://pythonhosted.org/six/#six.string_types)__
* Replace instances of __unicode()__ with __[six.u()](https://pythonhosted.org/six/#six.u)__
* Run isort on the imports
