### PR TITLE
Revert "import six to support Python 3"

### DIFF
--- a/galaxy/api/base_views.py
+++ b/galaxy/api/base_views.py
@@ -20,8 +20,6 @@ import inspect
 import warnings
 import logging
 
-import six
-
 # Django
 from django.http import Http404
 from django.core.paginator import InvalidPage
@@ -149,8 +147,8 @@ class GenericAPIView(generics.GenericAPIView, APIView):
             self.format_kwarg = 'format'
         d = super(GenericAPIView, self).get_description_context()
         d.update({
-            'model_verbose_name': six.u(self.model._meta.verbose_name),
-            'model_verbose_name_plural': six.u(self.model._meta.verbose_name_plural),
+            'model_verbose_name': unicode(self.model._meta.verbose_name),
+            'model_verbose_name_plural': unicode(self.model._meta.verbose_name_plural),
             'serializer_fields': self.get_serializer().metadata(),
         })
         return d
@@ -307,8 +305,8 @@ class SubListAPIView(ListAPIView):
     def get_description_context(self):
         d = super(SubListAPIView, self).get_description_context()
         d.update({
-            'parent_model_verbose_name': six.u(self.parent_model._meta.verbose_name),
-            'parent_model_verbose_name_plural': six.u(self.parent_model._meta.verbose_name_plural),
+            'parent_model_verbose_name': unicode(self.parent_model._meta.verbose_name),
+            'parent_model_verbose_name_plural': unicode(self.parent_model._meta.verbose_name_plural),
         })
         return d
 

--- a/galaxy/api/filters.py
+++ b/galaxy/api/filters.py
@@ -17,8 +17,6 @@
 
 import re
 
-import six
-
 # Django
 from django.core.exceptions import FieldError, ValidationError, ObjectDoesNotExist
 from django.contrib.auth import get_user_model
@@ -88,7 +86,7 @@ class FieldLookupBackend(BaseFilterBackend):
         return field
 
     def to_python_boolean(self, value, allow_none=False):
-        value = six.u(value)
+        value = unicode(value)
         if value.lower() in ('true', '1'):
             return True
         elif value.lower() in ('false', '0'):
@@ -96,10 +94,10 @@ class FieldLookupBackend(BaseFilterBackend):
         elif allow_none and value.lower() in ('none', 'null'):
             return None
         else:
-            raise ValueError(u'Unable to convert "%s" to boolean' % six.u(value))
+            raise ValueError(u'Unable to convert "%s" to boolean' % unicode(value))
 
     def to_python_related(self, value):
-        value = six.u(value)
+        value = unicode(value)
         if value.lower() in ('none', 'null'):
             return None
         else:

--- a/galaxy/api/serializers.py
+++ b/galaxy/api/serializers.py
@@ -18,8 +18,6 @@
 import markdown
 import json
 
-import six
-
 from rest_framework import serializers
 
 from django.contrib.auth.models import AnonymousUser
@@ -139,9 +137,9 @@ class BaseSerializer(serializers.ModelSerializer):
         ret = super(BaseSerializer, self).get_fields()
         for key, field in ret.items():
             if key == 'id' and not getattr(field, 'help_text', None):
-                field.help_text = 'Database ID for this %s.' % six.u(opts.verbose_name)
+                field.help_text = 'Database ID for this %s.' % unicode(opts.verbose_name)
             elif key == 'url':
-                field.help_text = 'URL for this %s.' % six.u(opts.verbose_name)
+                field.help_text = 'URL for this %s.' % unicode(opts.verbose_name)
                 field.type_label = 'string'
             elif key == 'related':
                 field.help_text = 'Data structure with URLs of related resources.'
@@ -150,10 +148,10 @@ class BaseSerializer(serializers.ModelSerializer):
                 field.help_text = 'Data structure with name/description for related resources.'
                 field.type_label = 'object'
             elif key == 'created':
-                field.help_text = 'Timestamp when this %s was created.' % six.u(opts.verbose_name)
+                field.help_text = 'Timestamp when this %s was created.' % unicode(opts.verbose_name)
                 field.type_label = 'datetime'
             elif key == 'modified':
-                field.help_text = 'Timestamp when this %s was last modified.' % six.u(opts.verbose_name)
+                field.help_text = 'Timestamp when this %s was last modified.' % unicode(opts.verbose_name)
                 field.type_label = 'datetime'
         return ret
 

--- a/galaxy/main/celerytasks/tasks.py
+++ b/galaxy/main/celerytasks/tasks.py
@@ -21,7 +21,6 @@ import datetime
 import requests
 import logging
 import pytz
-import six
 
 from celery import task
 from github import Github
@@ -249,7 +248,7 @@ def strip_input(input):
     """
     if input is None:
         return ""
-    elif isinstance(input, six.string_types):
+    elif isinstance(input, basestring):
         return input.strip()
     else:
         return input
@@ -284,7 +283,7 @@ def get_readme(import_task, repo, branch, token):
         response.raise_for_status()
         readme_html = response.text
     except Exception as exc:
-        add_message(import_task, u"ERROR", u"Failed to get HTML version of README: %s" % six.u(exc))
+        add_message(import_task, u"ERROR", u"Failed to get HTML version of README: %s" % unicode(exc))
 
     readme = ''
     try:
@@ -312,7 +311,7 @@ def parse_yaml(import_task, file_name, file_contents):
     try:
         contents = yaml.safe_load(file_contents)
     except yaml.YAMLError as exc:
-        add_message(import_task, u"ERROR", u"YAML parse error: %s" % six.u(exc))
+        add_message(import_task, u"ERROR", u"YAML parse error: %s" % unicode(exc))
         fail_import_task(import_task, u"Failed to parse %s. Check YAML syntax." % file_name)
     return contents
 
@@ -326,7 +325,7 @@ def decode_file(import_task, repo, branch, file_name, return_yaml=False):
     try:
         contents = contents.content.decode('base64')
     except Exception as exc:
-        fail_import_task(import_task, u"Failed to decode %s - %s" % (file_name, six.u(exc)))
+        fail_import_task(import_task, u"Failed to decode %s - %s" % (file_name, unicode(exc)))
 
     if not return_yaml:
         return contents
@@ -336,7 +335,7 @@ def decode_file(import_task, repo, branch, file_name, return_yaml=False):
 def add_platforms(import_task, galaxy_info, role):
     add_message(import_task, u"INFO", u"Parsing platforms")
     meta_platforms = galaxy_info.get("platforms", None)
-    if isinstance(meta_platforms, six.string_types) or not hasattr(meta_platforms, '__iter__'):
+    if isinstance(meta_platforms, basestring) or not hasattr(meta_platforms, '__iter__'):
         add_message(import_task, u"ERROR", u"Expected platforms in meta data to be a list.")
         return
     platform_list = []
@@ -370,7 +369,7 @@ def add_platforms(import_task, galaxy_info, role):
                     add_message(import_task, u"ERROR", u"Invalid platform: %s-%s (skipping)" %
                                 (name, version))
         except Exception as exc:
-            add_message(import_task, u"ERROR", u"An unknown error occurred while adding platform: %s" % six.u(exc))
+            add_message(import_task, u"ERROR", u"An unknown error occurred while adding platform: %s" % unicode(exc))
 
     # Remove platforms/versions that are no longer listed in the metadata
     for platform in role.platforms.all():
@@ -382,7 +381,7 @@ def add_platforms(import_task, galaxy_info, role):
 def _add_cloud_platforms(import_task, galaxy_info, role):
     add_message(import_task, u"INFO", u"Parsing cloud platforms")
     cloud_platforms = galaxy_info.get('cloud_platforms', [])
-    if isinstance(cloud_platforms, six.string_types):
+    if isinstance(cloud_platforms, basestring):
         cloud_platforms = [cloud_platforms]
 
     if not cloud_platforms:
@@ -437,10 +436,10 @@ def add_dependencies(import_task, dependencies, role):
                 role.dependencies.add(dep_role)
                 dep_names.append(dep_parsed['name'])
             except Exception as exc:
-                logger.error("Error loading dependencies %s" % six.u(exc))
+                logger.error("Error loading dependencies %s" % unicode(exc))
                 raise Exception(u"Role dependency not found: %s.%s" % (namespace, name))
         except (AnsibleError, Exception) as exc:
-            add_message(import_task, u'ERROR', u'Error parsing dependency %s' % six.u(exc))
+            add_message(import_task, u'ERROR', u'Error parsing dependency %s' % unicode(exc))
 
     # Remove deps that are no longer listed in the metadata
     for dep in role.dependencies.all():
@@ -791,7 +790,7 @@ def import_role(task_id):
             rv.release_date = tag.commit.commit.author.date.replace(tzinfo=pytz.UTC)
             rv.save()
     except Exception as exc:
-        add_message(import_task, u"ERROR", u"An error occurred while importing repo tags: %s" % six.u(exc))
+        add_message(import_task, u"ERROR", u"An error occurred while importing repo tags: %s" % unicode(exc))
 
     add_message(import_task, u"INFO", u"Removing old tags")
     if git_tag_list:
@@ -806,23 +805,23 @@ def import_role(task_id):
                 if not found:
                     remove_versions.append(version.name)
         except Exception as exc:
-            fail_import_task(import_task, u"Error identifying tags to remove: %s" % six.u(exc))
+            fail_import_task(import_task, u"Error identifying tags to remove: %s" % unicode(exc))
 
         if remove_versions:
             try:
                 for version_name in remove_versions:
                     RoleVersion.objects.filter(name=version_name, role=role).delete()
             except Exception as exc:
-                fail_import_task(import_task, u"Error removing tags from role: %s" % six.u(exc))
+                fail_import_task(import_task, u"Error removing tags from role: %s" % unicode(exc))
     try:
         role.validate_char_lengths()
     except Exception as exc:
-        add_message(import_task, u"ERROR", six.u(exc))
+        add_message(import_task, u"ERROR", unicode(exc))
 
     try:
         import_task.validate_char_lengths()
     except Exception as exc:
-        add_message(import_task, u"ERROR", six.u(exc))
+        add_message(import_task, u"ERROR", unicode(exc))
 
     # determine state of import task
     error_count = import_task.messages.filter(message_type="ERROR").count()
@@ -863,7 +862,7 @@ def refresh_user_repos(user, token):
     except GithubException as exc:
         user.cache_refreshed = True
         user.save()
-        msg = u"User {0} Repo Cache Refresh Error: {1}".format(user.username, six.u(exc))
+        msg = u"User {0} Repo Cache Refresh Error: {1}".format(user.username, unicode(exc))
         logger.error(msg)
         raise Exception(msg)
 
@@ -872,7 +871,7 @@ def refresh_user_repos(user, token):
     except GithubException as exc:
         user.cache_refreshed = True
         user.save()
-        msg = u"User {0} Repo Cache Refresh Error: {1}".format(user.username, six.u(exc))
+        msg = u"User {0} Repo Cache Refresh Error: {1}".format(user.username, unicode(exc))
         logger.error(msg)
         raise Exception(msg)
 
@@ -881,7 +880,7 @@ def refresh_user_repos(user, token):
     except GithubException as exc:
         user.cache_refreshed = True
         user.save()
-        msg = u"User {0} Repo Cache Refresh Error: {1}".foramt(user.username, six.u(exc))
+        msg = u"User {0} Repo Cache Refresh Error: {1}".foramt(user.username, unicode(exc))
         logger.error(msg)
         raise Exception(msg)
 
@@ -902,21 +901,21 @@ def refresh_user_stars(user, token):
     try:
         gh_api = Github(token)
     except GithubException as exc:
-        msg = u"User {0} Refresh Stars: {1}".format(user.username, six.u(exc))
+        msg = u"User {0} Refresh Stars: {1}".format(user.username, unicode(exc))
         logger.error(msg)
         raise Exception(msg)
 
     try:
         ghu = gh_api.get_user()
     except GithubException as exc:
-        msg = u"User {0} Refresh Stars: {1}" % (user.username, six.u(exc))
+        msg = u"User {0} Refresh Stars: {1}" % (user.username, unicode(exc))
         logger.error(msg)
         raise Exception(msg)
 
     try:
         subscriptions = ghu.get_subscriptions()
     except GithubException as exc:
-        msg = u"User {0} Refresh Stars: {1]" % (user.username, six.u(exc))
+        msg = u"User {0} Refresh Stars: {1]" % (user.username, unicode(exc))
         logger.error(msg)
         raise Exception(msg)
 
@@ -937,7 +936,7 @@ def refresh_user_stars(user, token):
     try:
         starred = ghu.get_starred()
     except GithubException as exc:
-        msg = u"User {0} Refresh Stars: {1}".format(user.username, six.u(exc))
+        msg = u"User {0} Refresh Stars: {1}".format(user.username, unicode(exc))
         logger.error(msg)
         raise Exception(msg)
 
@@ -998,7 +997,7 @@ def refresh_role_counts(start, end, token, tracker):
             role.delete()
             deleted += 1
         except Exception as exc:
-            logger.error(u"FAILED: {0} - {1}".format(full_name, six.u(exc)))
+            logger.error(u"FAILED: {0} - {1}".format(full_name, unicode(exc)))
             failed += 1
 
     tracker.state = 'FINISHED'
@@ -1030,5 +1029,5 @@ def clear_stuck_imports():
             ri.save()
             transaction.commit()
     except Exception as exc:
-        logger.error(u"Clear Stuck Imports ERROR: {}".format(six.u(exc)))
+        logger.error(u"Clear Stuck Imports ERROR: {}".format(unicode(exc)))
         raise

--- a/galaxy/main/models.py
+++ b/galaxy/main/models.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-import six
-
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db import models
@@ -48,7 +46,7 @@ class BaseModel(models.Model, DirtyMixin):
 
     def __unicode__(self):
         if hasattr(self, 'name'):
-            return six.u("%s-%s" % (self.name, self.id))
+            return unicode("%s-%s" % (self.name, self.id))
         else:
             return u'%s-%s' % (self._meta.verbose_name, self.id)
 
@@ -214,7 +212,7 @@ class UserAlias(models.Model):
     )
 
     def __unicode__(self):
-        return six.u("%s (alias of %s)" % (self.alias_name, self.alias_of.username))
+        return unicode("%s (alias of %s)" % (self.alias_name, self.alias_of.username))
 
 
 class Video(PrimordialModel):
@@ -494,7 +492,7 @@ class Role(CommonModelNameNotUnique):
     def validate_char_lengths(self):
         for field in self._meta.get_fields():
             if not field.is_relation and field.get_internal_type() == 'CharField':
-                if isinstance(getattr(self, field.name), six.string_types) and len(getattr(self, field.name)) > field.max_length:
+                if isinstance(getattr(self, field.name), basestring) and len(getattr(self, field.name)) > field.max_length:
                     raise Exception("Role %s value exceeeds max length of %s." % (field.name, field.max_length))
 
 
@@ -694,7 +692,7 @@ class ImportTask(PrimordialModel):
         for field in self._meta.get_fields():
             if not field.is_relation and field.get_internal_type() == 'CharField':
                 # print "%s %s" % (field.name, field.max_length)
-                if isinstance(getattr(self, field.name), six.string_types) and len(getattr(self, field.name)) > field.max_length:
+                if isinstance(getattr(self, field.name), basestring) and len(getattr(self, field.name)) > field.max_length:
                     raise Exception("Import Task %s value exceeeds max length of %s." % (field.name, field.max_length))
 
 

--- a/galaxy/main/utils/memcache_lock.py
+++ b/galaxy/main/utils/memcache_lock.py
@@ -27,11 +27,10 @@ instead use a distributed/replicated store like couchbase.
 This allows us to guarantee that
 """
 
-import contextlib
-import logging
-import random
 import time
-
+import logging
+import contextlib
+import random
 from django.core.cache import cache as django_cache
 
 
@@ -54,7 +53,7 @@ def memcache_lock(key, attempts=1, expires=120):
 
 
 def _acquire_lock(key, attempts, expires):
-    for i in range(0, attempts):
+    for i in xrange(0, attempts):
         stored = django_cache.add(key, 1, expires)
         if stored:
             return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ PyGithub
 markdown==2.4.1
 requests
 requests-oauthlib
-six
 bleach
 rst2html5-tools
 setuptools


### PR DESCRIPTION
Reverting PR #326 due to improper `six.u` usage. `six.u()` function is not a direct replacement for `unicode()` function call. It is designed to be used only with string literals and raises an exception `TypeError: decoding Unicode is not supported` when unicode object is passed as an argument.

Since explicit unicode literal is supported from Python 3.3 [1], `six.u` usage is no longer required.

[1] https://www.python.org/dev/peps/pep-0414/