### PR TITLE
Remove automatic filter on 'active' attribute

### DIFF
--- a/galaxy/api/access.py
+++ b/galaxy/api/access.py
@@ -266,6 +266,9 @@ class StargazerAccess(BaseAccess):
 
 
 class NamespaceAccess(BaseAccess):
+    def can_read(self, obj):
+        return True
+
     def can_add(self, data):
         return self.user.is_authenticated()
 

--- a/galaxy/api/views/base_views.py
+++ b/galaxy/api/views/base_views.py
@@ -128,10 +128,6 @@ class GenericAPIView(generics.GenericAPIView, APIView):
 
     def get_queryset(self):
         qs = self.model.objects.all().distinct()
-        if hasattr(self.model, "is_active"):
-            return qs.filter(is_active=True)
-        elif hasattr(self.model, "active"):
-            return qs.filter(active=True)
         return qs
 
     def get_description_context(self):


### PR DESCRIPTION
- Removes automatic filter on `active` attribute from the base view class.
- Allows anonymous read of Namespace, even when `active=False`