### PR TITLE
Fixes broken features of 'My Content', 'My Imports'

### DIFF
--- a/galaxyui/src/app/app.component.html
+++ b/galaxyui/src/app/app.component.html
@@ -45,7 +45,7 @@
             </ul>
         </div>
     </pfng-vertical-navigation>
-    <div #contentContainer class="app-container container-fluid container-pf-nav-pf-vertical" (window:resize)="onResize($event)">
+    <div #contentContainer class="app-container container-fluid container-pf-nav-pf-vertical">
         <router-outlet></router-outlet>
         <user-notifications></user-notifications>
     </div>

--- a/galaxyui/src/app/app.component.ts
+++ b/galaxyui/src/app/app.component.ts
@@ -77,7 +77,6 @@ export class AppComponent {
     redirectUrl:   string = null;
 
     ngOnInit(): void {
-        console.log('init!');
         // TODO add unsecured API endpoint for retrieving Galaxy version
         this.aboutConfig = {
             additionalInfo: '',
@@ -148,12 +147,7 @@ export class AppComponent {
             }
         );
     }
-
-    onResize($event): void {
-        console.log('window resized');
-        console.log($event);
-    }
-
+    
     onItemClicked($event: NavigationItemConfig): void {
         console.log('item clicked');
         console.log($event);

--- a/galaxyui/src/app/my-content/add-repository-modal/add-repository-modal.component.html
+++ b/galaxyui/src/app/my-content/add-repository-modal/add-repository-modal.component.html
@@ -12,10 +12,13 @@
                 <div class="form-group add-repo-modal-dropdown-group">
                     <div class="dropdown btn-group" dropdown>
                         <button dropdownToggle id="add-repo-modal-dropdown-button" type="button" class="btn btn-default add-repo-modal-dropdown-button">
-                            {{ selectedPNS.name }} <span class="caret"></span>
+                            <i class="fa fa-github" *ngIf="selectedPNS.provider_name == 'github'"></i> {{ selectedPNS.name }} <span class="caret"></span>
                         </button>
                         <ul *dropdownMenu class="dropdown-menu" role="menu" aria-labelledby="single-button">
-                            <li role="menuitem" *ngFor="let pns of providerNamespaces"><a (click)="selectProviderNamespace(pns)">{{ pns.name }}</a></li>
+                            <li role="menuitem" disabled><i>Select provider namespace...</i></li>
+                            <li role="menuitem" *ngFor="let pns of providerNamespaces">
+                                <a (click)="selectProviderNamespace(pns)"><i class="fa fa-github" *ngIf="pns.provider_name == 'github'"></i> {{ pns.name }}</a>
+                            </li>
                         </ul>
                     </div>
                 </div>
@@ -35,11 +38,11 @@
             </div>
             <div class="list-group-item" *ngFor="let repo of selectedPNS.displaySources">
                 <div class="list-view-pf-checkbox">
-                    <input type="checkbox"
+                    <input type="checkbox" [(ngModel)]="repo.isSelected" #ctrl="ngModel"
                            name="selected-repos-{{ selectedPNS.provider_name }}-{{ selectedPNS.name }}-{{ repo.name }}"
                            (change)="selectRepo(repo)">
                 </div>
-                <div class="list-view-pf-main-info">
+                <div class="list-view-pf-main-info" (click)="selectRepo(repo)">
                     <div class="list-view-pf-left">
                         <i class="pficon-repository"></i>
                     </div>

--- a/galaxyui/src/app/my-content/add-repository-modal/add-repository-modal.component.html
+++ b/galaxyui/src/app/my-content/add-repository-modal/add-repository-modal.component.html
@@ -33,7 +33,7 @@
             <div class="loading-repos-spinner-container" *ngIf="selectedPNS.loading">
                 <i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i>
             </div>
-            <div class="list-group-item" *ngFor="let repo of selectedPNS.repoSources">
+            <div class="list-group-item" *ngFor="let repo of selectedPNS.displaySources">
                 <div class="list-view-pf-checkbox">
                     <input type="checkbox"
                            name="selected-repos-{{ selectedPNS.provider_name }}-{{ selectedPNS.name }}-{{ repo.name }}"
@@ -60,3 +60,4 @@
     <button class="btn btn-warning" type="button" (click)="bsModalRef.hide()">Cancel</button>
 </div>
 
+<app-page-loading [loading]="saveInProgress"></app-page-loading>

--- a/galaxyui/src/app/my-content/add-repository-modal/add-repository-modal.component.less
+++ b/galaxyui/src/app/my-content/add-repository-modal/add-repository-modal.component.less
@@ -16,3 +16,14 @@
         border-bottom-color: #ededed
     }
 }
+
+#add-repo-modal-filter {
+    width: 200px;
+}
+
+@media (min-width: 768px) {
+    .toolbar-pf .form-group {
+        padding-left: 0;
+        padding-right: 20px;
+    }
+}

--- a/galaxyui/src/app/my-content/my-content.module.ts
+++ b/galaxyui/src/app/my-content/my-content.module.ts
@@ -27,12 +27,14 @@ import { RepositoriesContentComponent }       from './namespace-list/content/rep
 import { OwnersContentComponent }             from './namespace-list/content/owners-content/owners-content.component';
 import { ProviderNamespacesContentComponent } from './namespace-list/content/provider-namespaces-content/provider-namespaces-content.component';
 import { AddRepositoryModalComponent }        from './add-repository-modal/add-repository-modal.component';
+import { AlternateNameModalComponent }        from './namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component';
 import { PageHeaderModule }                   from '../page-header/page-header.module';
-import { PageLoadingModule }                   from '../page-loading/page-loading.module';
+import { PageLoadingModule }                  from '../page-loading/page-loading.module';
 
 @NgModule({
     entryComponents: [
-        AddRepositoryModalComponent
+        AddRepositoryModalComponent,
+        AlternateNameModalComponent,
     ],
     declarations: [
         NamespaceListComponent,
@@ -40,7 +42,8 @@ import { PageLoadingModule }                   from '../page-loading/page-loadin
         RepositoriesContentComponent,
         OwnersContentComponent,
         ProviderNamespacesContentComponent,
-        AddRepositoryModalComponent
+        AddRepositoryModalComponent,
+        AlternateNameModalComponent
     ],
     imports: [
         ActionModule,

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.html
@@ -1,0 +1,41 @@
+<div class="modal-header">
+    <h4 class="modal-title pull-left">Change Repository Name</h4>
+    <button type="button" class="close pull-right" aria-label="Close" (click)="bsModalRef.hide()">
+        <span aria-hidden="true">&times;</span>
+    </button>
+</div>
+<div class="modal-body alternate-name-modal-body" id="alternate-name-modal-body">
+    <div class="container-fluid">
+        <h3>{{ repository.summary_fields.provider_namespace.name }}/{{ repository.original_name }}</h3>
+        <p>Override the respository name. If this repository is an Ansible role (i.e., it contains a meta/main.yml file), the role will be imported with the name defined here.</p>
+        <form>
+            <div class="form-group">
+                <label for="name">Repository Name</label>
+                <input type="text" class="form-control" id="name" [formControl]="name" required>
+                <div *ngIf="name.invalid && (name.dirty || name.touched)" class="alert alert-danger">
+                    <div *ngIf="name.errors.required">
+                        A value is required.
+                    </div>
+                    <div *ngIf="name.errors.minlength">
+                        Must be at least 3 characters long.
+                    </div>
+                    <div *ngIf="name.errors.forbiddenChar">
+                        Contains invalid characters. Valid characters are 'a-zA-Z0-9-_'
+                    </div>
+                    <div *ngIf="name.errors.forbiddenFirstChar">
+                        Must start with 'a-zA-Z0-9'
+                    </div>
+                    <div *ngIf="name.errors.forbiddenLastChar">
+                        Must end with 'a-zA-Z0-9'
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+<div class="modal-footer">
+    <button class="btn btn-primary" type="button" (click)="updateRepoName()" [disabled]="okIsDisabled()">OK</button>
+    <button class="btn btn-warning" type="button" (click)="bsModalRef.hide()">Cancel</button>
+</div>
+
+<app-page-loading [loading]="saveInProgress"></app-page-loading>

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.less
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.less
@@ -1,0 +1,14 @@
+// alternate-name-modal.component.less
+
+#alternate-name-modal-body {
+	h3 {
+		font-weight: 600;
+		margin-bottom: 15px;
+	}
+	.form-group {
+		margin-top: 15px;
+	}
+	.alert.alert-danger {
+		margin-top: 10px;
+	}
+}

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AddRepositoryModalComponent } from './alternate-name-modal.component';
+
+describe('AlternateNameModalComponent', () => {
+  let component: AlternateNameModalComponent;
+  let fixture: ComponentFixture<AlternateNameModalComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AlternateNameModalComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AlternateNameModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.ts
@@ -1,0 +1,104 @@
+import {
+    Component,
+    Input,
+    OnInit 
+    } from '@angular/core';
+
+import {
+    FormControl,
+    Validators,
+    ValidatorFn,
+    AbstractControl
+    } from '@angular/forms';
+
+import { BsModalRef }              from 'ngx-bootstrap';
+
+import { Subject }                 from 'rxjs';
+import { forkJoin }                from 'rxjs/observable/forkJoin';
+import { Observable }              from 'rxjs/Observable';
+
+import { RepositoryService }       from '../../../../../resources/respositories/repository.service';
+import { Repository }              from '../../../../../resources/respositories/repository';
+import { RepositoryImportService } from '../../../../../resources/repository-imports/repository-import.service';
+
+
+export function forbiddenCharValidator(): ValidatorFn {
+    let charRE = new RegExp('[^0-9A-Za-z-_]');
+    return (control: AbstractControl): { [key: string]: any } => {
+        const forbidden = charRE.test(control.value);
+        return forbidden ? { 'forbiddenChar': { value: control.value } } : null;
+    };
+}
+
+export function forbiddenFirstCharValidator(): ValidatorFn {
+    let charRE = new RegExp('^[A-Za-z0-9]');
+    return (control: AbstractControl): { [key: string]: any } => {
+        const forbidden = !charRE.test(control.value);
+        return forbidden ? { 'forbiddenFirstChar': { value: control.value } } : null;
+    };
+}
+
+export function forbiddenLastCharValidator(): ValidatorFn {
+    let charRE = new RegExp('[A-Za-z0-9]$');
+    return (control: AbstractControl): { [key: string]: any } => {
+        const forbidden = !charRE.test(control.value);
+        return forbidden ? { 'forbiddenLastChar': { value: control.value } } : null;
+    };
+}
+
+@Component({
+    selector: 'alternate-name-modale',
+    templateUrl: './alternate-name-modal.component.html',
+    styleUrls: ['./alternate-name-modal.component.less']
+})
+export class AlternateNameModalComponent implements OnInit {
+    
+    saveInProgress: boolean = false;
+    repository: Repository;
+    startedImport: boolean = false;
+
+    name: FormControl = new FormControl(
+        '', [
+        Validators.required,
+        Validators.minLength(3),
+        forbiddenCharValidator(),
+        forbiddenFirstCharValidator(),
+        forbiddenLastCharValidator()
+        ]);
+
+    
+    constructor(
+        public bsModalRef: BsModalRef,
+        private repositoryService: RepositoryService,
+        private repositoryImportService: RepositoryImportService) {}
+
+    ngOnInit() {
+        this.name.setValue(this.repository.name);
+    }
+
+    okIsDisabled(): boolean {
+        return !this.name.valid;
+    }
+
+    updateRepoName(): void {
+        this.saveInProgress = true;
+        if (this.name.value != this.repository.name) {
+            let repo: Repository = new Repository();
+            repo.id = this.repository.id;
+            repo.name = this.name.value;
+            repo.original_name = this.repository.original_name;
+            repo.description = this.repository.description;
+            repo.import_branch = this.repository.import_branch;
+            repo.is_enabled = this.repository.is_enabled;
+            this.repositoryService.save(repo).subscribe(_ => {
+                this.repositoryImportService
+                    .save({'repository_id': this.repository.id}).subscribe(_ => {
+                        console.log(`Started import for ${this.repository.name}`);
+                        this.saveInProgress = true;
+                        this.startedImport = true;
+                        this.bsModalRef.hide();
+                    });
+            });
+        }
+    }
+}

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.html
@@ -1,41 +1,54 @@
 <div class="repos-container">
-    <div class="loading-repos-spinner-container" *ngIf="loading">
-        <i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i>
-    </div>
-    <div *ngIf="!loading">
-        <pfng-list
-            [actionTemplate]="actionTemplate"
-            [config]="listConfig"
-            [items]="items"
-            [itemTemplate]="itemTemplate"
-            (onActionSelect)="handleAction($event, null)"
-            (onClick)="handleClick($event)"
-            (onDblClick)="handleDblClick($event)"
-            (onSelectionChange)="handleSelectionChange($event)">
-            <ng-template #itemTemplate let-item="item" let-index="index">
-                <div class="list-pf-left">
-                    <span class="pficon-repository list-pf-icon list-pf-icon-small"></span>
+    <pfng-list
+        [actionTemplate]="actionTemplate"
+        [config]="listConfig"
+        [items]="items"
+        [itemTemplate]="itemTemplate"
+        (onActionSelect)="handleAction($event, null)">
+        <ng-template #itemTemplate let-item="item" let-index="index">
+            <div class="list-pf-left">
+                <span class="pficon-repository list-pf-icon list-pf-icon-small"></span>
+            </div>
+            <div class="list-pf-content-wrapper">
+                <div class="list-pf-main-content">
+                    <div class="list-pf-title">{{ item.name }}</div>
+                    <div class="list-pf-description text-overflow-pf">{{ item.description }}</div>
                 </div>
-                <div class="list-pf-content-wrapper">
-                    <div class="list-pf-main-content">
-                        <div class="list-pf-title">{{ item.name }}</div>
-                        <div class="list-pf-description text-overflow-pf">{{ item.description }}</div>
+                <div class="list-pf-additional-content">
+                    <div *ngIf="item['latest_import'] && (item['latest_import']['state'] == 'PENDING' || item['latest_import']['state'] == 'RUNNING')">
+                        <a [routerLink]="['/my-imports']" [queryParams]="{namespace: namespace.name, repository_name: item.name}" class="running">
+                            <i class="fa fa-spin fa-spinner"></i> 
+                            <span class="text">{{ item['latest_import']['state'][0] + item['latest_import']['state'].substring(1, item['latest_import']['state'].length).toLowerCase() }} 
+                            {{ item['latest_import']['as_of_dt'] }}</span>
+                        </a>
                     </div>
-                    <div class="list-pf-additional-content"></div>
+                    <div *ngIf="item['latest_import'] && item['latest_import']['state'] == 'SUCCESS'">
+                        <a [routerLink]="['/my-imports']" [queryParams]="{namespace: namespace.name, repository_name: item.name}" class="succeeded">
+                            <i class="fa fa-circle"></i> <span class="text">Succeeded {{ item['latest_import']['as_of_dt'] }}</span>
+                        </a> 
+                    </div>   
+                    <div *ngIf="item['latest_import'] && item['latest_import']['state'] == 'FAILED'">
+                        <a [routerLink]="['/my-imports']" [queryParams]="{namespace: namespace.name, repository_name: item.name}" class="failed">
+                            <i class="fa fa-circle"></i> <span class="text">Failed {{ item['latest_import']['as_of_dt'] }}</span>
+                        </a>
+                    </div>   
                 </div>
-            </ng-template>
-            <ng-template #actionTemplate let-item="item" let-index="index">
-                <pfng-action class="list-pf-actions"
-                             [config]="getActionConfig(item, actionButtonTemplate, startButtonTemplate)"
-                             (onActionSelect)="handleAction($event, item)">
-                    <ng-template #actionButtonTemplate let-action="action">
-                        <span class="fa fa-plus">&nbsp;</span>{{action.title}}
-                    </ng-template>
-                    <ng-template #importButtonTemplate let-action="action">
-                        {{item.importing === true ? "Importing" : action.title}}
-                    </ng-template>
-                </pfng-action>
-            </ng-template>
+            </div>
+        </ng-template>
+        <ng-template #actionTemplate let-item="item" let-index="index">
+            <pfng-action class="list-pf-actions"
+                         [config]="getActionConfig(item, actionButtonTemplate, importButtonTemplate)"
+                         (onActionSelect)="handleAction($event, item)">
+                <ng-template #actionButtonTemplate let-action="action">
+                    <i class="fa fa-plus"></i> {{action.title}}
+                </ng-template>
+                <ng-template #importButtonTemplate let-action="action">
+                    <i class="fa fa-upload"></i> {{item.importing === true ? "Importing" : action.title}}
+                </ng-template>
+            </pfng-action>
+        </ng-template>
         </pfng-list>
-    </div>
+</div>
+<div class="content-loader" *ngIf="loading">
+    <i class="fa fa-spinner fa-spin fa-3x"></i>
 </div>

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.html
@@ -1,54 +1,59 @@
 <div class="repos-container">
-    <pfng-list
-        [actionTemplate]="actionTemplate"
-        [config]="listConfig"
-        [items]="items"
-        [itemTemplate]="itemTemplate"
-        (onActionSelect)="handleAction($event, null)">
-        <ng-template #itemTemplate let-item="item" let-index="index">
-            <div class="list-pf-left">
-                <span class="pficon-repository list-pf-icon list-pf-icon-small"></span>
-            </div>
-            <div class="list-pf-content-wrapper">
-                <div class="list-pf-main-content">
-                    <div class="list-pf-title">{{ item.name }}</div>
-                    <div class="list-pf-description text-overflow-pf">{{ item.description }}</div>
+    <!--div class="content-refresh" [ngClass]="{'hide-content': !refreshing}"><i class="fa fa-spinner fa-spin"></i>  Refreshing...</div-->
+    <div *ngIf="namespace.active">
+        <pfng-list
+            [actionTemplate]="actionTemplate"
+            [config]="listConfig"
+            [items]="items"
+            [itemTemplate]="itemTemplate"
+            (onActionSelect)="handleAction($event, null)">
+            <ng-template #itemTemplate let-item="item" let-index="index">
+                <div class="list-pf-left">
+                    <span class="pficon-repository list-pf-icon list-pf-icon-small"></span>
                 </div>
-                <div class="list-pf-additional-content">
-                    <div *ngIf="item['latest_import'] && (item['latest_import']['state'] == 'PENDING' || item['latest_import']['state'] == 'RUNNING')">
-                        <a [routerLink]="['/my-imports']" [queryParams]="{namespace: namespace.name, repository_name: item.name}" class="running">
-                            <i class="fa fa-spin fa-spinner"></i> 
-                            <span class="text">{{ item['latest_import']['state'][0] + item['latest_import']['state'].substring(1, item['latest_import']['state'].length).toLowerCase() }} 
-                            {{ item['latest_import']['as_of_dt'] }}</span>
-                        </a>
+                <div class="list-pf-content-wrapper">
+                    <div class="list-pf-main-content">
+                        <div class="list-pf-title">{{ item.name }}</div>
+                        <div class="list-pf-description text-overflow-pf">{{ item.description | slice:0:60 }}</div>
                     </div>
-                    <div *ngIf="item['latest_import'] && item['latest_import']['state'] == 'SUCCESS'">
-                        <a [routerLink]="['/my-imports']" [queryParams]="{namespace: namespace.name, repository_name: item.name}" class="succeeded">
-                            <i class="fa fa-circle"></i> <span class="text">Succeeded {{ item['latest_import']['as_of_dt'] }}</span>
-                        </a> 
-                    </div>   
-                    <div *ngIf="item['latest_import'] && item['latest_import']['state'] == 'FAILED'">
-                        <a [routerLink]="['/my-imports']" [queryParams]="{namespace: namespace.name, repository_name: item.name}" class="failed">
-                            <i class="fa fa-circle"></i> <span class="text">Failed {{ item['latest_import']['as_of_dt'] }}</span>
-                        </a>
-                    </div>   
+                    <div class="list-pf-additional-content">
+                        <div *ngIf="item['latest_import'] && (item['latest_import']['state'] == 'PENDING' || item['latest_import']['state'] == 'RUNNING')">
+                            <a [routerLink]="['/my-imports']" [queryParams]="{namespace: namespace.name, repository_name: item.name}" class="running">
+                                <i class="fa fa-spin fa-spinner"></i> 
+                                <span class="text">{{ item['latest_import']['state'][0] + item['latest_import']['state'].substring(1, item['latest_import']['state'].length).toLowerCase() }} 
+                                {{ item['latest_import']['as_of_dt'] }}</span>
+                            </a>
+                        </div>
+                        <div *ngIf="item['latest_import'] && item['latest_import']['state'] == 'SUCCESS'">
+                            <a [routerLink]="['/my-imports']" [queryParams]="{namespace: namespace.name, repository_name: item.name}" class="succeeded">
+                                <i class="fa fa-circle"></i> <span class="text">Succeeded {{ item['latest_import']['as_of_dt'] }}</span>
+                            </a> 
+                        </div>   
+                        <div *ngIf="item['latest_import'] && item['latest_import']['state'] == 'FAILED'">
+                            <a [routerLink]="['/my-imports']" [queryParams]="{namespace: namespace.name, repository_name: item.name}" class="failed">
+                                <i class="fa fa-circle"></i> <span class="text">Failed {{ item['latest_import']['as_of_dt'] }}</span>
+                            </a>
+                        </div>   
+                    </div>
                 </div>
+            </ng-template>
+            <ng-template #actionTemplate let-item="item" let-index="index">
+                <pfng-action class="list-pf-actions"
+                             [config]="getActionConfig(item, importButtonTemplate)"
+                             (onActionSelect)="handleAction($event, item)">
+                    <ng-template #importButtonTemplate let-action="action">
+                        <i class="fa fa-upload"></i> {{item.importing === true ? "Importing" : action.title}}
+                    </ng-template>
+                </pfng-action>
+            </ng-template>
+            </pfng-list>
+        <div class="content-loader" [ngClass]="{'hide-content': !loading}">
+            <div class="content-loader-inner">
+                <i class="fa fa-spinner fa-spin fa-3x"></i>
             </div>
-        </ng-template>
-        <ng-template #actionTemplate let-item="item" let-index="index">
-            <pfng-action class="list-pf-actions"
-                         [config]="getActionConfig(item, actionButtonTemplate, importButtonTemplate)"
-                         (onActionSelect)="handleAction($event, item)">
-                <ng-template #actionButtonTemplate let-action="action">
-                    <i class="fa fa-plus"></i> {{action.title}}
-                </ng-template>
-                <ng-template #importButtonTemplate let-action="action">
-                    <i class="fa fa-upload"></i> {{item.importing === true ? "Importing" : action.title}}
-                </ng-template>
-            </pfng-action>
-        </ng-template>
-        </pfng-list>
-</div>
-<div class="content-loader" *ngIf="loading">
-    <i class="fa fa-spinner fa-spin fa-3x"></i>
+        </div>
+    </div>
+    <div *ngIf="!namespace.active">
+        <pfng-empty-state [config]="disabledStateConfig"></pfng-empty-state>
+    </div>
 </div>

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.less
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.less
@@ -5,14 +5,39 @@
 .content-loader {
 	position: absolute;
     top: 0;
+    bottom: 0;
     left: 0;
+    right: 0;
     width: 100%;
     height: 100%;
-    z-index: 9999;
+    z-index: +1;
     background:rgba(255,255,255,0.5);
     text-align: center;
-    padding-top: 15%;
+    opacity: 1;
+    transition: 2s ease;
+    .content-loader-inner {
+        position: absolute;
+        top: 45%;
+        left: 45%;
+        text-align: center;
+    }
 }
+
+.content-loader.hide-content {
+    opacity: 0;
+    z-index: -1;
+}
+
+/*.content-refresh {
+    position: relative;
+    top: -10px;
+    opacity: 1;
+    transition: 2s ease;
+}
+
+.content-refresh.hide-content {
+    opacity: 0;
+}*/
 
 .list-pf-additional-content a:hover {
     text-decoration: none;

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.less
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.less
@@ -1,3 +1,19 @@
 .loading-repos-spinner-container {
     text-align: center;
 }
+
+.content-loader {
+	position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 9999;
+    background:rgba(255,255,255,0.5);
+    text-align: center;
+    padding-top: 15%;
+}
+
+.list-pf-additional-content a:hover {
+    text-decoration: none;
+}

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.less
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.less
@@ -28,17 +28,6 @@
     z-index: -1;
 }
 
-/*.content-refresh {
-    position: relative;
-    top: -10px;
-    opacity: 1;
-    transition: 2s ease;
-}
-
-.content-refresh.hide-content {
-    opacity: 0;
-}*/
-
 .list-pf-additional-content a:hover {
     text-decoration: none;
 }

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list-resolver.service.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list-resolver.service.ts
@@ -1,16 +1,26 @@
 import { Injectable }                                                   from '@angular/core';
-import { ActivatedRouteSnapshot, Resolve, Router, RouterStateSnapshot } from "@angular/router";
-import { Observable }                                                   from "rxjs/Observable";
-import { NamespaceService }                                             from "../../resources/namespaces/namespace.service";
-import { Namespace }                                                    from "../../resources/namespaces/namespace";
+
+import {
+	ActivatedRouteSnapshot,
+	Resolve,
+	Router,
+	RouterStateSnapshot
+} from "@angular/router";
+
+import { Observable }            from "rxjs/Observable";
+import { NamespaceService }      from "../../resources/namespaces/namespace.service";
+import { Namespace }             from "../../resources/namespaces/namespace";
+import { AuthService }           from "../../auth/auth.service";
 
 @Injectable()
 export class NamespaceListResolver implements Resolve<Namespace[]> {
 
-    constructor(private namespaceService: NamespaceService, private router: Router) {
-    }
+    constructor(
+    	private namespaceService: NamespaceService,
+    	private router: Router,
+    	private authService: AuthService) {}
 
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Namespace[]> {
-        return this.namespaceService.query();
+        return this.namespaceService.query({'page_size': 1000, 'owners__username': this.authService.meCache.username});
     }
 }

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.html
@@ -7,8 +7,6 @@
                               [actionTemplate]="toolbarActionTemplate"
                               (onActionSelect)="handleToolbarAction($event)"
                               (onFilterChange)="filterChanged($event)"
-                              (onFilterFieldSelect)="filterFieldSelected($event)"
-                              (onFilterTypeAhead)="filterQueries($event)"
                               (onSortChange)="sortChanged($event)"
                               (onViewSelect)="viewSelected($event)">
                     <ng-template #toolbarActionTemplate>
@@ -65,10 +63,18 @@
                         </div>
                     </ng-template>
                     <ng-template #listActionTemplate let-item="item" let-index="index">
-                        <pfng-action class="list-pf-actions"
-                                     [config]="listActionConfig"
-                                     (onActionSelect)="handleListAction($event, item)">
-                        </pfng-action>
+                        <div *ngIf="item.active">
+                            <pfng-action class="list-pf-actions"
+                                         [config]="listActionConfig"
+                                         (onActionSelect)="handleListAction($event, item)">
+                            </pfng-action>
+                        </div>
+                        <div *ngIf="!item.active">
+                            <pfng-action class="list-pf-actions"
+                                         [config]="listActionConfigEnable"
+                                         (onActionSelect)="handleListAction($event, item)">
+                            </pfng-action>
+                        </div>
                     </ng-template>
                     <ng-template #listExpandTemplate let-item="item" let-index="index">
                         <repositories-content [namespace]="item" *ngIf="item.expandId === undefined"></repositories-content>

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.html
@@ -44,7 +44,7 @@
                         <div class="list-pf-content-wrapper">
                             <div class="list-pf-main-content">
                                 <div class="list-pf-title">{{item.name}}</div>
-                                <div class="list-pf-description text-overflow-pf">{{item.description}}</div>
+                                <div class="list-pf-description text-overflow-pf">{{item.description }}</div>
                             </div>
                             <div class="list-pf-additional-content">
                                 <pfng-list-expand-toggle [expandId]="'owners'" [item]="item" [template]="ownersTemplate">
@@ -63,18 +63,13 @@
                         </div>
                     </ng-template>
                     <ng-template #listActionTemplate let-item="item" let-index="index">
-                        <div *ngIf="item.active">
-                            <pfng-action class="list-pf-actions"
-                                         [config]="listActionConfig"
-                                         (onActionSelect)="handleListAction($event, item)">
-                            </pfng-action>
-                        </div>
-                        <div *ngIf="!item.active">
-                            <pfng-action class="list-pf-actions"
-                                         [config]="listActionConfigEnable"
-                                         (onActionSelect)="handleListAction($event, item)">
-                            </pfng-action>
-                        </div>
+                        <pfng-action class="list-pf-actions"
+                            [config]="getActionConfig(item, addContentButtonTemplate)"
+                            (onActionSelect)="handleListAction($event, item)">
+                            <ng-template #addContentButtonTemplate let-action="action">
+                                <i class="fa fa-plus"></i> {{ action.title }}
+                            </ng-template>
+                        </pfng-action>
                     </ng-template>
                     <ng-template #listExpandTemplate let-item="item" let-index="index">
                         <repositories-content [namespace]="item" *ngIf="item.expandId === undefined"></repositories-content>

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.html
@@ -28,7 +28,7 @@
 <div>
     <div class="row">
         <div class="col-sm-12">
-            <div>
+            <div id="my-content-list">
                 <pfng-list
                     [actionTemplate]="listActionTemplate"
                     [config]="listConfig"
@@ -72,7 +72,7 @@
                         </pfng-action>
                     </ng-template>
                     <ng-template #listExpandTemplate let-item="item" let-index="index">
-                        <repositories-content [namespace]="item" *ngIf="item.expandId === undefined"></repositories-content>
+                        <repositories-content [namespace]="item" [contentAdded]="contentAdded" *ngIf="item.expandId === undefined"></repositories-content>
                         <owners-content [namespace]="item" *ngIf="item.expandId === 'owners'"></owners-content>
                         <provider-namespaces-content [namespace]="item" *ngIf="item.expandId === 'provider-namespaces'"></provider-namespaces-content>
                     </ng-template>

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.less
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.less
@@ -26,23 +26,25 @@
     min-width: 86.5312px;
 }
 
-.list-pf, .list-pf-item, .list-pf-container, .list-pf-content {
-    max-width: 100%;
-}
-.list-pf-main-content {
-    flex-basis: 50%;
-    flex-grow: 0;
-}
-.list-pf-additional-content {
-    flex-basis: 30%;
-    flex-grow: 0;
-}
+#my-content-list {
+    .list-pf, .list-pf-item, .list-pf-container, .list-pf-content {
+        max-width: 100%;
+    }
+    .list-pf-main-content {
+        flex-basis: 50%;
+        flex-grow: 0;
+    }
+    .list-pf-additional-content {
+        flex-basis: 30%;
+        flex-grow: 0;
+    }
 
-.list-pf-content-wrapper {
-    max-width: 100%;
-}
+    .list-pf-content-wrapper {
+        max-width: 100%;
+    }
 
-.list-pf-title, .list-pf-description {
-    flex-grow: 0;
-    flex-basis: 50%;
+    .list-pf-title, .list-pf-description {
+        flex-grow: 0;
+        flex-basis: 50%;
+    }
 }

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.less
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.less
@@ -25,3 +25,24 @@
 .primary-action-btn {
     min-width: 86.5312px;
 }
+
+.list-pf, .list-pf-item, .list-pf-container, .list-pf-content {
+    max-width: 100%;
+}
+.list-pf-main-content {
+    flex-basis: 50%;
+    flex-grow: 0;
+}
+.list-pf-additional-content {
+    flex-basis: 30%;
+    flex-grow: 0;
+}
+
+.list-pf-content-wrapper {
+    max-width: 100%;
+}
+
+.list-pf-title, .list-pf-description {
+    flex-grow: 0;
+    flex-basis: 50%;
+}

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.less
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.less
@@ -21,3 +21,7 @@
         border-top: 1px solid #ededed;
     }
 }
+
+.primary-action-btn {
+    min-width: 86.5312px;
+}

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
@@ -59,12 +59,21 @@ export class NamespaceListComponent implements OnInit {
     listConfig: ListConfig;
     bsModalRef: BsModalRef;
 
+    contentAdded: number = 0;
+
     constructor(
         private route: ActivatedRoute,
         private router: Router,
         private modalService: BsModalService,
         private namespaceService: NamespaceService
-    ) {}
+    ) {
+        this.modalService.onHidden.subscribe(_ => {
+            if (this.bsModalRef && this.bsModalRef.content.repositoriesAdded) {
+                console.log('Content added.');
+                this.contentAdded++;
+            }
+        });
+    }
 
     ngOnInit(): void {
         this.route.data
@@ -137,7 +146,7 @@ export class NamespaceListComponent implements OnInit {
     // Action Button and Menu 
 
     getActionConfig(item: Namespace, addContentButtonTemplate: TemplateRef<any>): ActionConfig {
-        let actionConfig = {
+        let config = {
             primaryActions: [{
                 id: 'addContent',
                 title: 'Add Content',
@@ -160,15 +169,15 @@ export class NamespaceListComponent implements OnInit {
 
         // Set disabled options
         if (!item.active) {
-            actionConfig.primaryActions[0].disabled = true;
-            actionConfig.moreActions[0].disabled = true;
-            actionConfig.moreActions[1] = {
+            config.primaryActions[0].disabled = true;
+            config.moreActions[0].disabled = true;
+            config.moreActions[1] = {
                 id: 'enableNamespace',
                 title: 'Enable',
                 tooltip: 'Enable namespace'    
             };
         }
-        return actionConfig;
+        return config;
     }
 
     // Actions
@@ -283,9 +292,6 @@ export class NamespaceListComponent implements OnInit {
 
     private prepForList(namespaces: Namespace[]): Namespace[] {
         let clonedNamespaces = cloneDeep(namespaces);
-
-        //TODO transform
-
         return clonedNamespaces;
     }
 
@@ -293,7 +299,7 @@ export class NamespaceListComponent implements OnInit {
         const initialState = {
             namespace: namespace
         };
-        this.bsModalRef = this.modalService.show(AddRepositoryModalComponent, {initialState});
+        this.bsModalRef = this.modalService.show(AddRepositoryModalComponent, {initialState: initialState, keyboard: true, animated: true});
     }
 
     private enableDisableNamespace(namespace: Namespace) {

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
@@ -40,13 +40,14 @@ import { FilterEvent }                 from "patternfly-ng/filter/filter-event";
     styleUrls: ['./namespace-list.component.less']
 })
 export class NamespaceListComponent implements OnInit {
-    items: Namespace[];
-    namespaces: Namespace[];
+    items: Namespace[] = [];
+    namespaces: Namespace[] = [];
 
     pageTitle: string = "My Content";
     pageLoading: boolean = true;
 
     toolbarActionConfig: ActionConfig;
+    listActionConfigEnable: ActionConfig;
     filterConfig: FilterConfig;
     filtersText: string = '';
     isAscendingSort: boolean = true;
@@ -70,26 +71,42 @@ export class NamespaceListComponent implements OnInit {
         this.route.data
             .subscribe((data: { namespaces: Namespace[] }) => {
                 this.items = this.prepForList(data.namespaces);
+                this.namespaces = JSON.parse(JSON.stringify(this.items));
                 this.pageLoading = false;
             });
 
         this.filterConfig = {
-            fields: [{
-                id: 'name',
-                title: 'Name',
-                placeholder: 'Filter by Name...',
-                type: FilterType.TEXT
-            }] as FilterField[],
+            fields: [
+                {
+                    id: 'name',
+                    title: 'Name',
+                    placeholder: 'Filter by Name...',
+                    type: FilterType.TEXT
+                },
+                {
+                    id: 'description',
+                    title: 'Description',
+                    placeholder: 'Filter by Description...',
+                    type: FilterType.TEXT
+                }
+            ] as FilterField[],
             resultsCount: this.items.length,
             appliedFilters: []
         } as FilterConfig;
 
         this.sortConfig = {
-            fields: [{
-                id: 'name',
-                title: 'Name',
-                sortType: 'alpha'
-            }],
+            fields: [
+                {
+                    id: 'name',
+                    title: 'Name',
+                    sortType: 'alpha'
+                },
+                {
+                    id: 'description',
+                    title: 'Description',
+                    sortType: 'alpha'
+                }
+            ],
             isAscending: this.isAscendingSort
         } as SortConfig;
 
@@ -108,7 +125,7 @@ export class NamespaceListComponent implements OnInit {
         this.listActionConfig = {
             primaryActions: [{
                 id: 'addContent',
-                styleClass: 'btn-primary',
+                styleClass: 'btn-primary primary-action-btn',
                 title: 'Add Content',
                 tooltip: 'Add roles, modules, apbs and other content from repositories'
             }],
@@ -117,12 +134,32 @@ export class NamespaceListComponent implements OnInit {
                 title: 'Edit Properties',
                 tooltip: 'Edit namespace properties'
             }, {
-                id: 'deleteNamespace',
-                title: 'Delete',
-                tooltip: 'Delete Namespace'
+                id: 'disableNamespace',
+                title: 'Disable',
+                tooltip: 'Disable namespace'
             }],
             moreActionsDisabled: false,
             moreActionsVisible: true
+        } as ActionConfig;
+
+        this.listActionConfigEnable = {
+            primaryActions: [{
+                id: 'enableNamespace',
+                styleClass: 'btn-primary primary-action-btn',
+                title: 'Enable',
+                tooltip: 'Enable namespace'
+            }],
+            moreActions: [{
+                id: 'editNamespaceProps',
+                title: 'Edit Properties',
+                tooltip: 'Edit namespace properties'
+            }, {
+                id: 'disableNamespace',
+                title: 'Disable',
+                tooltip: 'Disable namespace'
+            }],
+            moreActionsDisabled: true,
+            moreActionsVisible: false
         } as ActionConfig;
 
         this.listConfig = {
@@ -140,8 +177,13 @@ export class NamespaceListComponent implements OnInit {
     // Actions
 
     refreshNamespaces(): void {
+        this.pageLoading = true;
         this.namespaceService.query()
-            .subscribe(namespaces => this.items = namespaces);
+            .subscribe(namespaces => {
+                this.items = this.prepForList(namespaces);
+                this.namespaces = JSON.parse(JSON.stringify(this.items));
+                this.pageLoading = false;
+            });
     }
 
     handleToolbarAction(action: Action): void {
@@ -150,11 +192,10 @@ export class NamespaceListComponent implements OnInit {
 
     optionSelected(option: number): void {
         this.actionsText = 'Option ' + option + ' selected\n' + this.actionsText;
-        this.actionsText = 'Option ' + option + ' selected\n' + this.actionsText;
     }
 
-
     handleListAction($event: Action, item: any): void {
+        console.log($event);
         switch ($event.id) {
             case 'addContent': {
                 this.addContent(item);
@@ -164,8 +205,9 @@ export class NamespaceListComponent implements OnInit {
                 this.router.navigate([`/my-content/namespaces/${item.id}`]);
                 break;
             }
-            case 'deleteNamespace': {
-                this.deleteNamespace(item);
+            case 'disableNamespace': 
+            case 'enableNamespace': {
+                this.enableDisableNamespace(item);
                 break;
             }
             default: {
@@ -180,47 +222,34 @@ export class NamespaceListComponent implements OnInit {
         this.actionsText = $event.item.name + ' clicked\r\n' + this.actionsText;
     }
 
-    // Filter
-
-    applyFilters(filters: Filter[]): void {
+    filterChanged($event: FilterEvent): void {
+        // Handle filter changes
+        let filters = $event.appliedFilters;
         this.items = [];
-        if (filters && filters.length > 0) {
+        if (filters && filters.length > 0 && this.namespaces.length > 0) {
             this.namespaces.forEach((item) => {
                 if (this.matchesFilters(item, filters)) {
-                    this.items.push(item);
+                    this.items.push(JSON.parse(JSON.stringify(item)));
                 }
             });
         } else {
-            this.items = this.namespaces;
+            this.items = JSON.parse(JSON.stringify(this.namespaces));
         }
         this.toolbarConfig.filterConfig.resultsCount = this.items.length;
-    }
-
-    // Handle filter changes
-    filterChanged($event: FilterEvent): void {
-        this.filtersText = '';
-        $event.appliedFilters.forEach((filter) => {
-            this.filtersText += filter.field.title + ' : ' + filter.value + '\n';
-        });
-        this.applyFilters($event.appliedFilters);
-        this.filterFieldSelected($event);
-    }
-
-    // Reset filtered queries
-    filterFieldSelected($event: FilterEvent): void {
-        //TODO
     }
 
     matchesFilter(item: any, filter: Filter): boolean {
         let match = true;
         if (filter.field.id === 'name') {
-            match = item.name.match(filter.value) !== null;
+            match = item.name.toLowerCase().match(filter.value.toLowerCase()) !== null;
+        } else if (filter.field.id == 'description') {
+            match = item.description.toLowerCase().match(filter.value.toLowerCase()) !== null;
         }
-
         return match;
     }
 
     matchesFilters(item: any, filters: Filter[]): boolean {
+        // Return true if all filters match the item. 
         let matches = true;
         filters.forEach((filter) => {
             if (!this.matchesFilter(item, filter)) {
@@ -231,19 +260,11 @@ export class NamespaceListComponent implements OnInit {
         return matches;
     }
 
-    // Filter queries for type ahead
-    filterQueries($event: FilterEvent) {
-        return true;
-    }
 
     // Sort
-
     compare(item1: any, item2: any): number {
         let compValue = 0;
-        if (this.currentSortField.id === 'name') {
-            compValue = item1.name.localeCompare(item2.name);
-        }
-
+        compValue = item1[this.currentSortField.id].localeCompare(item2[this.currentSortField.id]);
         if (!this.isAscendingSort) {
             compValue = compValue * -1;
         }
@@ -281,10 +302,9 @@ export class NamespaceListComponent implements OnInit {
         this.bsModalRef = this.modalService.show(AddRepositoryModalComponent, {initialState});
     }
 
-    private deleteNamespace(namespace: Namespace) {
-        this.namespaceService.delete(namespace)
-            .subscribe(namespaces => {
-                this.refreshNamespaces()
-            });
+    private enableDisableNamespace(namespace: Namespace) {
+        namespace.active = !namespace.active;
+        this.namespaceService.save(namespace)
+            .subscribe(_ => { this.refreshNamespaces() });
     }
 }

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
@@ -1,6 +1,6 @@
 import {
     Component,
-    OnInit,,
+    OnInit,
     TemplateRef,
     ViewEncapsulation
 } from '@angular/core';

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
@@ -1,6 +1,7 @@
 import {
     Component,
-    OnInit,
+    OnInit,,
+    TemplateRef,
     ViewEncapsulation
 } from '@angular/core';
 
@@ -47,7 +48,6 @@ export class NamespaceListComponent implements OnInit {
     pageLoading: boolean = true;
 
     toolbarActionConfig: ActionConfig;
-    listActionConfigEnable: ActionConfig;
     filterConfig: FilterConfig;
     filtersText: string = '';
     isAscendingSort: boolean = true;
@@ -55,7 +55,6 @@ export class NamespaceListComponent implements OnInit {
     currentSortField: SortField;
     toolbarConfig: ToolbarConfig;
 
-    listActionConfig: ActionConfig;
     actionsText: string = '';
     listConfig: ListConfig;
     bsModalRef: BsModalRef;
@@ -72,7 +71,7 @@ export class NamespaceListComponent implements OnInit {
             .subscribe((data: { namespaces: Namespace[] }) => {
                 this.items = this.prepForList(data.namespaces);
                 this.namespaces = JSON.parse(JSON.stringify(this.items));
-                this.pageLoading = false;
+                this.cancelPageLoading();
             });
 
         this.filterConfig = {
@@ -122,12 +121,29 @@ export class NamespaceListComponent implements OnInit {
             views: []
         } as ToolbarConfig;
 
-        this.listActionConfig = {
+        this.listConfig = {
+            dblClick: false,
+            multiSelect: false,
+            selectItems: false,
+            selectionMatchProp: 'name',
+            showCheckbox: false,
+            useExpandItems: true
+        } as ListConfig;
+    }
+
+    ngDoCheck(): void {}
+
+    
+    // Action Button and Menu 
+
+    getActionConfig(item: Namespace, addContentButtonTemplate: TemplateRef<any>): ActionConfig {
+        let actionConfig = {
             primaryActions: [{
                 id: 'addContent',
-                styleClass: 'btn-primary primary-action-btn',
                 title: 'Add Content',
-                tooltip: 'Add roles, modules, apbs and other content from repositories'
+                styleClass: 'btn-primary',
+                tooltip: 'Add roles, modules, APBs and other content from repositories',
+                template: addContentButtonTemplate 
             }],
             moreActions: [{
                 id: 'editNamespaceProps',
@@ -142,37 +158,18 @@ export class NamespaceListComponent implements OnInit {
             moreActionsVisible: true
         } as ActionConfig;
 
-        this.listActionConfigEnable = {
-            primaryActions: [{
+        // Set disabled options
+        if (!item.active) {
+            actionConfig.primaryActions[0].disabled = true;
+            actionConfig.moreActions[0].disabled = true;
+            actionConfig.moreActions[1] = {
                 id: 'enableNamespace',
-                styleClass: 'btn-primary primary-action-btn',
                 title: 'Enable',
-                tooltip: 'Enable namespace'
-            }],
-            moreActions: [{
-                id: 'editNamespaceProps',
-                title: 'Edit Properties',
-                tooltip: 'Edit namespace properties'
-            }, {
-                id: 'disableNamespace',
-                title: 'Disable',
-                tooltip: 'Disable namespace'
-            }],
-            moreActionsDisabled: true,
-            moreActionsVisible: false
-        } as ActionConfig;
-
-        this.listConfig = {
-            dblClick: false,
-            multiSelect: false,
-            selectItems: false,
-            selectionMatchProp: 'name',
-            showCheckbox: false,
-            useExpandItems: true
-        } as ListConfig;
+                tooltip: 'Enable namespace'    
+            };
+        }
+        return actionConfig;
     }
-
-    ngDoCheck(): void {}
 
     // Actions
 
@@ -182,7 +179,7 @@ export class NamespaceListComponent implements OnInit {
             .subscribe(namespaces => {
                 this.items = this.prepForList(namespaces);
                 this.namespaces = JSON.parse(JSON.stringify(this.items));
-                this.pageLoading = false;
+                this.cancelPageLoading();
             });
     }
 
@@ -195,7 +192,6 @@ export class NamespaceListComponent implements OnInit {
     }
 
     handleListAction($event: Action, item: any): void {
-        console.log($event);
         switch ($event.id) {
             case 'addContent': {
                 this.addContent(item);
@@ -211,9 +207,7 @@ export class NamespaceListComponent implements OnInit {
                 break;
             }
             default: {
-                console.log(`handle action "${$event.id}" not found`, $event, item);
-                console.log($event);
-                console.log(item);
+                console.log(`handle action "${$event.id}" not found`);
             }
         }
     }
@@ -307,4 +301,10 @@ export class NamespaceListComponent implements OnInit {
         this.namespaceService.save(namespace)
             .subscribe(_ => { this.refreshNamespaces() });
     }
+
+    private cancelPageLoading(): void {
+        setTimeout(_ => {
+            this.pageLoading = false;
+        }, 2000);
+    } 
 }

--- a/galaxyui/src/app/my-imports/import-detail/import-detail.component.html
+++ b/galaxyui/src/app/my-imports/import-detail/import-detail.component.html
@@ -1,4 +1,4 @@
-<div class="import-details-container" *ngIf="importTask">
+<div id="import-details-container" *ngIf="importTask">
     <h5 class="title">{{ importTask.summary_fields.namespace.name + '.' + importTask.summary_fields.repository.name }}</h5>
     <div class="title-bar" >
         <div class="branch">

--- a/galaxyui/src/app/my-imports/import-detail/import-detail.component.less
+++ b/galaxyui/src/app/my-imports/import-detail/import-detail.component.less
@@ -1,6 +1,9 @@
 @import '../../../variables';
 
-.import-details-container {
+#import-details-container {
+    max-height: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
     h5 {
         font-weight: 600;
         font-size: 14px;

--- a/galaxyui/src/app/my-imports/import-detail/import-detail.component.less
+++ b/galaxyui/src/app/my-imports/import-detail/import-detail.component.less
@@ -28,7 +28,7 @@
         margin-top: 22px;
         margin-bottom: 20px;
         background-color: #f0f0f0;
-        min-height: 90px;
+        height: 97px;
         padding: 10px;
         border: 1px solid #e1e1e1;
         border-radius: 2px;

--- a/galaxyui/src/app/my-imports/import-list/import-list.component.html
+++ b/galaxyui/src/app/my-imports/import-list/import-list.component.html
@@ -1,11 +1,13 @@
 <app-page-header [headerTitle]="pageTitle"></app-page-header>
 <div class="row padding-15" id="import-list-page">
     <div class="col-sm-4 list-column">
-        <pfng-filter
-             [config]="filterConfig"
-             (onChange)="applyFilters($event)">
-        </pfng-filter>
-        <div class="import-list">
+        <div id="import-filter">
+            <pfng-filter
+                 [config]="filterConfig"
+                 (onChange)="applyFilters($event)">
+            </pfng-filter>
+        </div>
+        <div id="import-list" (window:resize)="onResize($event)">
             <pfng-list
                 [config]="listConfig"
                 [items]="items"

--- a/galaxyui/src/app/my-imports/import-list/import-list.component.html
+++ b/galaxyui/src/app/my-imports/import-list/import-list.component.html
@@ -1,31 +1,34 @@
 <app-page-header [headerTitle]="pageTitle"></app-page-header>
-<div class="row padding-15">
+<div class="row padding-15" id="import-list-page">
     <div class="col-sm-4 list-column">
         <pfng-filter
-             [config]="filterConfig">
+             [config]="filterConfig"
+             (onChange)="applyFilters($event)">
         </pfng-filter>
-        <pfng-list
-            [config]="listConfig"
-            [items]="items"
-            [itemTemplate]="itemTemplate"
-            (onActionSelect)="handleAction($event, null)"
-            (onClick)="handleClick($event)">
-            <ng-template #itemTemplate let-item="item">
-                <div class="list-pf-left">
-                    <span class="fa fa-circle"
-                          [ngClass]="{'color-green': item.state == 'Success' || item.state == 'Running', 'color-red': item.state == 'Failed', 'color-orange': item.state == 'Pending'}"></span>
-                </div>
-                <div class="list-pf-content-wrapper">
-                    <div class="list-pf-main-content">
-                        <div class="list-pf-title">
-                            {{ item.namespace + '.' + item.repository_name }}
-                            <p *ngIf="item.state == 'Success' || item.state == 'Failed'">Status: {{ item.state + ' ' + item.finished }}</p>
-                            <p *ngIf="item.state != 'Success' && item.state != 'Failed'">Status: {{ item.state }}</p>
+        <div class="import-list">
+            <pfng-list
+                [config]="listConfig"
+                [items]="items"
+                [itemTemplate]="itemTemplate"
+                (onActionSelect)="handleAction($event, null)"
+                (onClick)="handleClick($event)">
+                <ng-template #itemTemplate let-item="item">
+                    <div class="list-pf-left">
+                        <span class="fa fa-circle"
+                              [ngClass]="{'color-green': item.state == 'Success' || item.state == 'Running', 'color-red': item.state == 'Failed', 'color-orange': item.state == 'Pending'}"></span>
+                    </div>
+                    <div class="list-pf-content-wrapper">
+                        <div class="list-pf-main-content">
+                            <div class="list-pf-title">
+                                {{ item.namespace + '.' + item.repository_name }}
+                                <p *ngIf="item.state == 'Success' || item.state == 'Failed'">Status: {{ item.state + ' ' + item.finished }}</p>
+                                <p *ngIf="item.state != 'Success' && item.state != 'Failed'">Status: {{ item.state }}</p>
+                            </div>
                         </div>
                     </div>
-                </div>
-            </ng-template>
-        </pfng-list>
+                </ng-template>
+            </pfng-list>
+        </div>
     </div>
     <div class="col-sm-8">
         <app-import-detail [importTask]="selected"></app-import-detail>

--- a/galaxyui/src/app/my-imports/import-list/import-list.component.less
+++ b/galaxyui/src/app/my-imports/import-list/import-list.component.less
@@ -11,6 +11,9 @@
     border-right: 1px solid #ccc;
 }
 
-.import-list {
+#import-list {
 	padding-top: 7px;
+	max-height: 100%;
+	overflow-y: auto;
+	overflow-x: hidden;
 }

--- a/galaxyui/src/app/my-imports/import-list/import-list.component.less
+++ b/galaxyui/src/app/my-imports/import-list/import-list.component.less
@@ -10,3 +10,7 @@
 .list-column {
     border-right: 1px solid #ccc;
 }
+
+.import-list {
+	padding-top: 7px;
+}

--- a/galaxyui/src/app/my-imports/import-list/import-list.component.ts
+++ b/galaxyui/src/app/my-imports/import-list/import-list.component.ts
@@ -65,7 +65,7 @@ export class ImportListComponent implements OnInit, AfterViewInit {
                 if (this.items.length) {
                     this.getImport(this.items[0].id);
                 } else {
-                    this.pageLoading = false;
+                    this.cancelPageLoading();
                 }
             }
         );
@@ -143,7 +143,6 @@ export class ImportListComponent implements OnInit, AfterViewInit {
             result => {
                 let deselectId = this.selected  ? this.selected.id : null;
                 this.selected = result;
-                this.pageLoading = false;
                 if (!this.selected.import_branch) {
                     // TODO: a default value for import branch should be set on the backend
                     this.selected.import_branch = "master";
@@ -163,6 +162,7 @@ export class ImportListComponent implements OnInit, AfterViewInit {
                 if (this.pfList) {
                     this.selectItem(this.selected.id, deselectId);
                 }
+                this.cancelPageLoading();
             });
     }
 
@@ -195,8 +195,8 @@ export class ImportListComponent implements OnInit, AfterViewInit {
             if (this.items.length) {
                 this.getImport(this.items[0].id);
             } else {
-                this.pageLoading = false;
-            }
+                this.cancelPageLoading();
+            
         });
     }
 
@@ -205,5 +205,11 @@ export class ImportListComponent implements OnInit, AfterViewInit {
             item.finished = moment(item.modified).fromNow();
             item.state = item.state.charAt(0).toUpperCase() + item.state.slice(1).toLowerCase();
         });
+    }
+
+    private cancelPageLoading(): void {
+        setTimeout(_ => {
+            this.pageLoading = false;
+        }, 2000);
     }
 }

--- a/galaxyui/src/app/my-imports/import-list/import-list.component.ts
+++ b/galaxyui/src/app/my-imports/import-list/import-list.component.ts
@@ -196,7 +196,7 @@ export class ImportListComponent implements OnInit, AfterViewInit {
                 this.getImport(this.items[0].id);
             } else {
                 this.cancelPageLoading();
-            
+            }    
         });
     }
 

--- a/galaxyui/src/app/my-imports/import-list/import-list.component.ts
+++ b/galaxyui/src/app/my-imports/import-list/import-list.component.ts
@@ -31,6 +31,7 @@ import { FilterType }    from 'patternfly-ng/filter/filter-type';
 import { Filter }        from "patternfly-ng/filter/filter";
 
 import * as moment       from 'moment';
+import * as $            from 'jquery';
 
 @Component({
     selector: 'import-list',
@@ -111,6 +112,7 @@ export class ImportListComponent implements OnInit, AfterViewInit {
     }
 
     ngAfterViewInit() {
+        this.setVerticalScroll(); 
         if (this.selected) {
             this.selectItem(this.selected.id);
         }
@@ -167,7 +169,6 @@ export class ImportListComponent implements OnInit, AfterViewInit {
     }
 
     applyFilters(filters: FilterEvent): void {
-        console.log(filters);
         if (filters.appliedFilters.length) {
             let query = '';
             filters.appliedFilters.forEach((filter: Filter, idx: number) => {
@@ -184,7 +185,32 @@ export class ImportListComponent implements OnInit, AfterViewInit {
         }
     }
 
+    onResize($event): void {
+        // On browser resize
+        this.setVerticalScroll();    
+    }
+
     // private 
+
+    private setVerticalScroll(): void {
+        let windowHeight = window.innerHeight;
+        let windowWidth = window.innerWidth;
+        if (windowWidth > 768) {
+            let headerh = $('.page-header').outerHeight(true);
+            let navbarh = $('.navbar-pf-vertical').outerHeight(true);
+            let filterh = $('#import-filter').outerHeight(true);
+            let listHeight = windowHeight - headerh - navbarh - filterh - 60;
+            if (!isNaN(listHeight))
+                $('#import-list').css('height', listHeight);
+ 
+            let detailHeight = windowHeight - headerh - navbarh - 60;
+            if (!isNaN(detailHeight))
+                $('#import-details-container').css('height', detailHeight);
+        } else {
+            $('#import-list').css('height', '100%');
+            $('#import-details-container').css('height', '100%');
+        }
+    }
 
     private searchImports(query?: string): void {
         this.pageLoading = true;
@@ -196,7 +222,8 @@ export class ImportListComponent implements OnInit, AfterViewInit {
                 this.getImport(this.items[0].id);
             } else {
                 this.cancelPageLoading();
-            }    
+            }
+            this.setVerticalScroll();
         });
     }
 

--- a/galaxyui/src/app/my-imports/import-list/import-list.resolver.service.ts
+++ b/galaxyui/src/app/my-imports/import-list/import-list.resolver.service.ts
@@ -25,14 +25,21 @@ export class ImportListResolver implements Resolve<ImportLatest[]> {
     ){}
 
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<ImportLatest[]> {
-        return this.importsService.latest().map(
-            results => {
-                results.forEach(item => {
-                    item.finished = moment(item.modified).fromNow();
-                    item.state = item.state.charAt(0).toUpperCase() + item.state.slice(1).toLowerCase();
-                });
-                return results;
+        console.log(route.queryParams);
+        let query = null;
+        if (route.queryParams) {
+            let namespace = route.queryParams['namespace'];
+            let repositoryName = route.queryParams['repository_name'];
+            query = '';
+            if (namespace) {
+                query += (query == '') ? '' : '&';
+                query += `repository__provider_namespace__namespace__name=${namespace}`;
             }
-        );
+            if (repositoryName) {
+                query += (query == '') ? '' : '&';
+                query += `repository__name=${repositoryName}`;
+            }
+        }
+        return this.importsService.latest(query);
     }
 }

--- a/galaxyui/src/app/page-loading/page-loading.component.html
+++ b/galaxyui/src/app/page-loading/page-loading.component.html
@@ -1,3 +1,3 @@
-<div class="page-loader" *ngIf="loading">
-    <div class="icon"><span class="fa fa-spinner fa-spin fa-5x"></span></div>
+<div class="page-loader" [ngClass]="{'hide-content': !loading}">
+    <div class="page-loading-inner"><span class="fa fa-spinner fa-spin fa-5x"></span></div>
 </div>

--- a/galaxyui/src/app/page-loading/page-loading.component.less
+++ b/galaxyui/src/app/page-loading/page-loading.component.less
@@ -10,8 +10,8 @@
     background:rgba(255,255,255,0.5);
     .page-loading-inner {
         position: absolute;
-        top: 45%;
-        left: 45%;
+        top: 50%;
+        left: 50%;
     } 
 }
 

--- a/galaxyui/src/app/page-loading/page-loading.component.less
+++ b/galaxyui/src/app/page-loading/page-loading.component.less
@@ -4,8 +4,18 @@
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 9999;
+    z-index: +100;
+    opacity: 1;
+    transition: 1s ease;
     background:rgba(255,255,255,0.5);
-    text-align: center;
-    padding-top: 15%;
+    .page-loading-inner {
+        position: absolute;
+        top: 45%;
+        left: 45%;
+    } 
+}
+
+.page-loader.hide-content {
+	opacity: 0;
+	z-index: -100;
 }

--- a/galaxyui/src/app/resources/imports/imports.service.ts
+++ b/galaxyui/src/app/resources/imports/imports.service.ts
@@ -50,10 +50,13 @@ export class ImportsService {
         private notificationService: NotificationService
     ){}
 
-    private url:string  = '/api/v1/imports';
+    private url: string  = '/api/v1/imports';
 
-    latest(): Observable<ImportLatest[]> {
-        return this.http.get<PagedResponse>(`${this.url}/latest/`)
+    latest(query?: string): Observable<ImportLatest[]> {
+        let requestUrl = `${this.url}/latest/`;
+        if (query)
+            requestUrl += `?${query}`;
+        return this.http.get<PagedResponse>(requestUrl)
             .pipe(
                 map(response => response.results),
                 tap(_ => this.log('fetched latest imports')),
@@ -61,21 +64,9 @@ export class ImportsService {
             );
     }
 
-    get(id: number): Observable<Import> {
-         return this.http.get<Import[]>(`${this.url}/`, {params: {'id': id.toString()}})
+    get(id: number): Observable<any> {
+        return this.http.get<any>(`${this.url}/${id.toString()}/`)
             .pipe(
-                map(response => {
-                    if (!response) {
-                        return {};
-                    }
-                    if (response['results']) {
-                        return response['results'];
-                    }
-                    if (response.length) {
-                        return response[0];
-                    }
-                    return {};
-                }),
                 tap(_ => this.log('fetched import')),
                 catchError(this.handleError('Get', []))
             );

--- a/galaxyui/src/app/resources/namespaces/namespace.service.ts
+++ b/galaxyui/src/app/resources/namespaces/namespace.service.ts
@@ -30,7 +30,7 @@ export class NamespaceService {
     encounteredErrors: boolean = false;
 
     query(): Observable<Namespace[]> {
-        return this.http.get<PagedResponse>(this.url)
+        return this.http.get<PagedResponse>(this.url + '/')
             .pipe(
                 map(response => response.results),
                 tap(_ => this.log('fetched namespaces')),
@@ -39,7 +39,7 @@ export class NamespaceService {
     }
 
     get(id: number): Observable<Namespace> {
-        const url = `${this.url}/${id}`;
+        const url = `${this.url}/${id}/`;
         return this.http.get<Namespace>(url).pipe(
             tap(_ => this.log(`fetched namespace id=${id}`)),
             catchError(this.handleError<Namespace>(`Get id=${id}`))
@@ -49,7 +49,7 @@ export class NamespaceService {
     save(namespace: Namespace): Observable<Namespace> {
         let httpResult: Observable<Object>;
         if (namespace.id) {
-            httpResult = this.http.put<Namespace>(`${this.url}/${namespace.id}`, namespace, httpOptions);
+            httpResult = this.http.put<Namespace>(`${this.url}/${namespace.id}/`, namespace, httpOptions);
         } else {
             httpResult = this.http.post<Namespace>(`${this.url}/`, namespace, httpOptions);
         }

--- a/galaxyui/src/app/resources/namespaces/namespace.service.ts
+++ b/galaxyui/src/app/resources/namespaces/namespace.service.ts
@@ -29,7 +29,7 @@ export class NamespaceService {
 
     encounteredErrors: boolean = false;
 
-    query(params?: object): Observable<Namespace[]> {
+    query(params?: any): Observable<Namespace[]> {
         return this.http.get<PagedResponse>(this.url + '/', {params: params})
             .pipe(
                 map(response => response.results),

--- a/galaxyui/src/app/resources/namespaces/namespace.service.ts
+++ b/galaxyui/src/app/resources/namespaces/namespace.service.ts
@@ -29,8 +29,8 @@ export class NamespaceService {
 
     encounteredErrors: boolean = false;
 
-    query(): Observable<Namespace[]> {
-        return this.http.get<PagedResponse>(this.url + '/')
+    query(params?: object): Observable<Namespace[]> {
+        return this.http.get<PagedResponse>(this.url + '/', {params: params})
             .pipe(
                 map(response => response.results),
                 tap(_ => this.log('fetched namespaces')),

--- a/galaxyui/src/app/resources/repository-imports/repository-import.service.ts
+++ b/galaxyui/src/app/resources/repository-imports/repository-import.service.ts
@@ -31,11 +31,9 @@ export class RepositoryImportService {
             );
     }
 
-    save(repositoryImport: RepositoryImport): Observable<RepositoryImport> {
+    save(params: any): Observable<RepositoryImport> {
         let httpResult: Observable<Object>;
-
-        return this.http
-            .post<RepositoryImport>(`${this.url}/`, repositoryImport, httpOptions)
+        return this.http.post<RepositoryImport>(`${this.url}/`, params, httpOptions)
             .pipe(
                 tap((newImport: RepositoryImport) => this.log(`Saved repository import`)),
                 catchError(this.handleError<RepositoryImport>('Save'))

--- a/galaxyui/src/app/resources/respositories/repository.service.ts
+++ b/galaxyui/src/app/resources/respositories/repository.service.ts
@@ -24,7 +24,7 @@ export class RepositoryService {
                 private notificationService: NotificationService) {
     }
 
-    query(params): Observable<Repository[]> {
+    query(params?: any): Observable<Repository[]> {
         return this.http.get<PagedResponse>(this.url + '/', {params: params})
             .pipe(
                 map(response => response.results),

--- a/galaxyui/src/app/resources/respositories/repository.service.ts
+++ b/galaxyui/src/app/resources/respositories/repository.service.ts
@@ -25,7 +25,7 @@ export class RepositoryService {
     }
 
     query(params): Observable<Repository[]> {
-        return this.http.get<PagedResponse>(this.url, {params: params})
+        return this.http.get<PagedResponse>(this.url + '/', {params: params})
             .pipe(
                 map(response => response.results),
                tap(_ => this.log('fetched repositories')),
@@ -36,7 +36,7 @@ export class RepositoryService {
     save(repository: Repository): Observable<Repository> {
         let httpResult: Observable<Object>;
         if (repository.id) {
-            httpResult = this.http.put<Repository>(`${this.url}/${repository.id}`, repository, httpOptions);
+            httpResult = this.http.put<Repository>(`${this.url}/${repository.id}/`, repository, httpOptions);
         } else {
             httpResult = this.http.post<Repository>(`${this.url}/`, repository, httpOptions);
         }
@@ -45,6 +45,14 @@ export class RepositoryService {
             tap((newRepo: Repository) => this.log(`Saved repository w/ id=${newRepo.id}`)),
             catchError(this.handleError<Repository>('Save'))
         );
+    }
+
+    destroy(repository: Repository): Observable<any> {
+        return this.http.delete<any>(`${this.url}/${repository.id}/`)
+            .pipe(
+                tap(_ => this.log(`Deleted repository w/ id=${repository.id}`)),
+                catchError(this.handleError('Save'))
+            );
     }
 
     private handleError<T>(operation = '', result?: T) {

--- a/galaxyui/src/styles.less
+++ b/galaxyui/src/styles.less
@@ -51,7 +51,6 @@ a.failed {
     height: 35px;
 }
 
-
 /* About dialog */
 .about-modal-pf {
     .modal-body {

--- a/galaxyui/src/styles.less
+++ b/galaxyui/src/styles.less
@@ -2,10 +2,16 @@
 
 @import 'variables';
 
-.color-green {
+.color-green,
+.succeeded,
+.running,
+a.running,
+a.succeeded {
     color: @green;
 }
-.color-red {
+.color-red,
+.failed,
+a.failed {
     color: @red;
 }
 .color-orange {
@@ -61,5 +67,12 @@
     .modal-footer img {
         height: 70px;
         width: 240px;
+    }
+}
+
+/* Import list page */
+#import-list-page {
+    .list-column .filter-pf.filter-fields .form-group {
+        width: 100%;
     }
 }


### PR DESCRIPTION
Required to support enable/disable of Namespaces. PR #386 expects this.
- For #388 - Added CSS transitions and `setTimeout` in JS to smoothly fade in and out spinners. Fixed absolute placement so that spinners are properly centered over related elements and content.
- For #389 - Added styling to limit flex box expansion and eliminate horizontal scrolling on My Content
- For #387 - Added proper enable/disable of buttons and menu items. Now it's clear when a Namespace is disabled. When a Namespace is disabled, the `Add Content` buttons is correctly disabled, the `Edit` menu option is disabled, and the `Disable` menu option is replaced by an `Enable` option.