### PR TITLE
Adds repository, provider_namespace, namespace to content

### DIFF
--- a/galaxy/api/access.py
+++ b/galaxy/api/access.py
@@ -25,7 +25,8 @@ from galaxy.main.models import (Content, ImportTask,
                                 Namespace, NotificationSecret, Notification,
                                 ProviderNamespace,
                                 Repository,
-                                Subscription, Stargazer)
+                                Subscription, Stargazer,
+                                ContentBlock, ContentType)
 
 logger = logging.getLogger('galaxy.api.access')
 
@@ -307,6 +308,16 @@ class RepositoryAccess(BaseAccess):
         return self.user.is_authenticated()
 
 
+class ContentBlockAccess(BaseAccess):
+    def can_read(self, obj):
+        return True
+
+
+class ContentTypeAccess(BaseAccess):
+    def can_read(self, obj):
+        return True
+
+
 register_access(User, UserAccess)
 register_access(Content, RoleAccess)
 register_access(ContentVersion, RoleVersionAccess)
@@ -319,3 +330,5 @@ register_access(Stargazer, StargazerAccess)
 register_access(Namespace, NamespaceAccess)
 register_access(ProviderNamespace, ProviderNamespaceAccess)
 register_access(Repository, RepositoryAccess)
+register_access(ContentBlock, ContentBlockAccess)
+register_access(ContentType, ContentTypeAccess)

--- a/galaxy/api/serializers/content.py
+++ b/galaxy/api/serializers/content.py
@@ -65,6 +65,12 @@ class _RepositorySerializer(serializers.ModelSerializer):
         fields = ('id', 'name')
 
 
+class _ContentTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.ContentType
+        fields = ('id', 'name', 'description')
+
+
 class ContentSerializer(BaseModelSerializer):
     content_type = serializers.StringRelatedField(read_only=True)
 
@@ -88,6 +94,12 @@ class ContentSerializer(BaseModelSerializer):
                 'api:content_dependencies_list', args=(instance.pk,)),
             'versions': urls.reverse(
                 'api:content_versions_list', args=(instance.pk,)),
+            'content_type': urls.reverse(
+                'api:content_type_detail', args=(instance.content_type.pk,)),
+            'imports': urls.reverse(
+                'api:role_import_task_list', args=(instance.pk,)),
+            'notifications': urls.reverse(
+                'api:role_notification_list', args=(instance.pk,)),
         }
 
     def get_summary_fields(self, instance):
@@ -98,6 +110,7 @@ class ContentSerializer(BaseModelSerializer):
             'cloud_platforms': [
                 p.name for p in instance.cloud_platforms.all()],
             'tags': [t.name for t in instance.tags.all()],
+            'content_type': _ContentTypeSerializer().to_representation(instance),
         }
 
 

--- a/galaxy/api/serializers/content_block.py
+++ b/galaxy/api/serializers/content_block.py
@@ -1,0 +1,34 @@
+# (c) 2012-2018, Ansible by Red Hat
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+from .serializers import BaseSerializer
+
+from galaxy.main import models
+
+
+__all__ = (
+    'ContentBlockSerializer',
+)
+
+
+class ContentBlockSerializer(BaseSerializer):
+    class Meta:
+        model = models.ContentBlock
+        fields = (
+            'content',
+            'name',
+        )

--- a/galaxy/api/serializers/content_type.py
+++ b/galaxy/api/serializers/content_type.py
@@ -15,14 +15,21 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-from .content import *             # noqa
-from .content_block import *       # noqa
-from .content_type import *        # noqa
-from .namespace import *           # noqa
-from .provider import *            # noqa
-from .provider_source import *     # noqa
-from .repository_source import *   # noqa
-from .repository import *          # noqa
-from .provider_namespace import *  # noqa
-from .roles import *               # noqa
-from .serializers import *         # noqa
+from .serializers import BaseSerializer
+
+from galaxy.main import models
+
+
+__all__ = (
+    'ContentTypeSerializer',
+)
+
+
+class ContentTypeSerializer(BaseSerializer):
+    class Meta:
+        model = models.ContentType
+        fields = (
+            'id',
+            'name',
+            'description'
+        )

--- a/galaxy/api/serializers/roles.py
+++ b/galaxy/api/serializers/roles.py
@@ -81,6 +81,7 @@ class RoleListSerializer(BaseRoleSerializer):
             return {}
         res = super(RoleListSerializer, self).get_related(obj)
         res.update(dict(
+            content_type=reverse('api:content_type_detail', args=(obj.content_type.pk,)),
             dependencies=reverse('api:role_dependencies_list', args=(obj.pk,)),
             imports=reverse('api:role_import_task_list', args=(obj.pk,)),
             versions=reverse('api:role_versions_list', args=(obj.pk,)),
@@ -100,6 +101,10 @@ class RoleListSerializer(BaseRoleSerializer):
         if obj is None:
             return {}
         d = super(RoleListSerializer, self).get_summary_fields(obj)
+        d['content_type'] = dict(
+            id=obj.content_type.id,
+            name=obj.content_type.name,
+            description=obj.content_type.description)
         d['dependencies'] = [str(g) for g in obj.dependencies.all()]
         d['namespace'] = dict(
             id=obj.repository.provider_namespace.namespace.pk,

--- a/galaxy/api/serializers/roles.py
+++ b/galaxy/api/serializers/roles.py
@@ -66,7 +66,7 @@ class RoleListSerializer(BaseRoleSerializer):
     class Meta:
         model = Content
         fields = BASE_FIELDS + (
-            'role_type', 'namespace', 'is_valid',
+            'role_type', 'is_valid',
             'min_ansible_version', 'issue_tracker_url',
             'license', 'company', 'description',
             'travis_status_url', 'download_count', 'imported'
@@ -101,10 +101,16 @@ class RoleListSerializer(BaseRoleSerializer):
             return {}
         d = super(RoleListSerializer, self).get_summary_fields(obj)
         d['dependencies'] = [str(g) for g in obj.dependencies.all()]
+        d['namespace'] = dict(
+            id=obj.repository.provider_namespace.namespace.pk,
+            name=obj.repository.provider_namespace.namespace.name)
         d['platforms'] = [
             dict(name=g.name, release=g.release) for g in obj.platforms.all()]
-        d['tags'] = [
-            dict(name=g.name) for g in obj.tags.all()]
+        d['provider_namespace'] = dict(
+            id=obj.repository.provider_namespace.pk,
+            name=obj.repository.provider_namespace.name)
+        d['repository'] = dict(id=obj.repository.pk, name=obj.repository.name)
+        d['tags'] = [g.name for g in obj.tags.all()]
         d['versions'] = [
             dict(id=g.id, name=g.name, release_date=g.release_date)
             for g in obj.versions.all()]
@@ -114,15 +120,13 @@ class RoleListSerializer(BaseRoleSerializer):
 
 
 class RoleDetailSerializer(BaseRoleSerializer):
-    tags = drf_serializers.SerializerMethodField()
 
     class Meta:
         model = Content
         fields = BASE_FIELDS + (
             'role_type', 'namespace', 'is_valid',
             'min_ansible_version', 'issue_tracker_url', 'license', 'company',
-            'description',
-            'readme', 'readme_html', 'tags', 'travis_status_url',
+            'description', 'readme', 'readme_html', 'travis_status_url',
             'created', 'modified', 'download_count', 'imported')
 
     def to_native(self, obj):
@@ -148,18 +152,22 @@ class RoleDetailSerializer(BaseRoleSerializer):
         else:
             return obj.get_absolute_url()
 
-    def get_tags(self, obj):
-        return [t for t in obj.get_tags()]
-
     def get_summary_fields(self, obj):
         if obj is None:
             return {}
         d = super(RoleDetailSerializer, self).get_summary_fields(obj)
         d['dependencies'] = [dict(id=g.id, name=str(g))
                              for g in obj.dependencies.all()]
+        d['namespace'] = dict(
+            id=obj.repository.provider_namespace.namespace.pk,
+            name=obj.repository.provider_namespace.namespace.name)
         d['platforms'] = [dict(name=g.name, release=g.release)
                           for g in obj.platforms.all()]
-        d['tags'] = [dict(name=g.name) for g in obj.tags.all()]
+        d['provider_namespace'] = dict(
+            id=obj.repository.provider_namespace.pk,
+            name=obj.repository.provider_namespace.name)
+        d['repository'] = dict(id=obj.repository.pk, name=obj.repository.name)
+        d['tags'] = [g.name for g in obj.tags.all()]
         d['versions'] = [dict(id=g.id, name=g.name,
                               release_date=g.release_date)
                          for g in obj.versions.all()]

--- a/galaxy/api/urls.py
+++ b/galaxy/api/urls.py
@@ -178,6 +178,26 @@ account_urls = [
         name='account_logout_view'),
 ]
 
+content_block_urls = [
+    url(r'^$',
+        views.ContentBlockList.as_view(),
+        name='content_block_list'),
+
+    url(r'^(?P<name>[a-zA-Z0-9-_]+)/$',
+        views.ContentBlockDetail.as_view(),
+        name='content_block_detail'),
+]
+
+content_type_urls = [
+    url(r'^$',
+        views.ContentTypeList.as_view(),
+        name='content_type_list'),
+
+    url(r'^(?P<pk>[0-9]+)/$',
+        views.ContentTypeDetail.as_view(),
+        name='content_type_detail'),
+]
+
 v1_urls = [
     url(r'^$', views.ApiV1RootView.as_view(), name='api_v1_root_view'),
     url(r'^account/', include(account_urls)),
@@ -200,6 +220,8 @@ v1_urls = [
     url(r'^provider_namespaces/', include(provider_namespace_urls)),
     url(r'^repositories/', include(repo_urls)),
     url(r'^search/', include(search_urls)),
+    url(r'^content_blocks/', include(content_block_urls)),
+    url(r'^content_types/', include(content_type_urls)),
 ]
 
 urlpatterns = [

--- a/galaxy/api/views/__init__.py
+++ b/galaxy/api/views/__init__.py
@@ -17,6 +17,8 @@
 
 from .account import *              # noqa
 from .content import *              # noqa
+from .content_block import *        # noqa
+from .content_type import *         # noqa
 from .namespace import *            # noqa
 from .repository import *           # noqa
 from .provider_source import *      # noqa

--- a/galaxy/api/views/content.py
+++ b/galaxy/api/views/content.py
@@ -47,6 +47,10 @@ class ContentList(base.ListAPIView):
     def get_queryset(self):
         return (
             super(ContentList, self).get_queryset()
+            .filter(
+                repository__provider_namespace__namespace__isnull=False,
+                repository__provider_namespace__namespace__active=True
+            )
             .only(*self.QUERY_FIELDS)
             .select_related(
                 'namespace',

--- a/galaxy/api/views/content_block.py
+++ b/galaxy/api/views/content_block.py
@@ -1,0 +1,40 @@
+# (c) 2012-2018, Ansible by Red Hat
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+from galaxy.main import models
+from galaxy.api import serializers
+
+from . import base_views as base
+
+
+__all__ = (
+    'ContentBlockList',
+    'ContentBlockDetail',
+)
+
+
+class ContentBlockList(base.ListAPIView):
+
+    model = models.ContentBlock
+    serializer_class = serializers.ContentBlockSerializer
+
+
+class ContentBlockDetail(base.RetrieveAPIView):
+
+    model = models.ContentBlock
+    serializer_class = serializers.ContentBlockSerializer
+    lookup_field = 'name'

--- a/galaxy/api/views/content_type.py
+++ b/galaxy/api/views/content_type.py
@@ -15,14 +15,25 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-from .content import *             # noqa
-from .content_block import *       # noqa
-from .content_type import *        # noqa
-from .namespace import *           # noqa
-from .provider import *            # noqa
-from .provider_source import *     # noqa
-from .repository_source import *   # noqa
-from .repository import *          # noqa
-from .provider_namespace import *  # noqa
-from .roles import *               # noqa
-from .serializers import *         # noqa
+from galaxy.main import models
+from galaxy.api import serializers
+
+from . import base_views as base
+
+
+__all__ = (
+    'ContentTypeList',
+    'ContentTypeDetail',
+)
+
+
+class ContentTypeList(base.ListAPIView):
+
+    model = models.ContentType
+    serializer_class = serializers.ContentTypeSerializer
+
+
+class ContentTypeDetail(base.RetrieveAPIView):
+
+    model = models.ContentType
+    serializer_class = serializers.ContentTypeSerializer

--- a/galaxy/api/views/search.py
+++ b/galaxy/api/views/search.py
@@ -75,7 +75,10 @@ class ContentSearchView(base.ListAPIView):
     def get_queryset(self):
         role_type = models.ContentType.get(constants.ContentType.ROLE)
         return (models.Content.objects.distinct()
-                .filter(content_type=role_type))
+                .filter(
+                    repository__provider_namespace__namespace__isnull=False,
+                    repository__provider_namespace__namespace__active=True,
+                    content_type=role_type))
 
     # TODO(cutwater): Use serializer to parse request arguments
     def list(self, request, *args, **kwargs):

--- a/galaxy/api/views/views.py
+++ b/galaxy/api/views/views.py
@@ -230,6 +230,8 @@ class ApiV1RootView(APIView):
         data['categories'] = reverse('api:category_list')
         data['cloud_platforms'] = reverse('api:cloud_platform_list')
         data['content'] = reverse('api:content_list')
+        data['content_blocks'] = reverse('api:content_block_list')
+        data['content_types'] = reverse('api:content_type_list')
         data['imports'] = reverse('api:import_task_list')
         data['latest_imports'] = reverse('api:import_task_latest_list')
         data['me'] = reverse('api:user_me_list')

--- a/galaxy/main/migrations/0084_content_block_update.py
+++ b/galaxy/main/migrations/0084_content_block_update.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import galaxy.main.mixins
+
+MAIN_TITLE_BLOCK = ""
+
+MAIN_SHARE_BLOCK = """
+<p>Help other Ansible users by sharing the awesome roles you create.</p>
+<p>Maybe you have a role for installing and configuring a popular
+   software package, or a role for deploying software built by your
+   company. Whatever it is, use Galaxy to share it with the community.</p>
+<p>Top content authors will be featured on the Explore page, achieving
+   worldwide fame! Or at least fame on the internet among other developers
+   and sysadmins.</p>
+"""
+
+MAIN_DOWNLOADS_BLOCK = """
+<p>Jump-start your automation project with great content from the Ansible
+   community. Galaxy provides pre-packaged units of work known to Ansible
+   as roles.</p>
+<p>Roles can be dropped into Ansible PlayBooks and immediately put to work.
+   You'll find roles for provisioning infrastructure, deploying applications,
+   and all of the tasks you do everyday.</p>
+<p>Use Search to find roles for your project, then download them onto your
+   Ansible host using the ansible-galaxy command that comes bundled with
+   Ansible.</p>
+<p>For example:</p>
+<code>$ ansible-galaxy install username.rolename</code>
+"""
+
+MAIN_FEATURED_BLOG_BLOCK = ""
+
+
+def upgrade_contentblocks_data(apps, schema_editor):
+    ContentBlock = apps.get_model("main", "ContentBlock")
+    db_alias = schema_editor.connection.alias
+    ContentBlock.objects.using(db_alias).filter(
+        name='main-title').update(content=MAIN_TITLE_BLOCK)
+    ContentBlock.objects.using(db_alias).filter(
+        name='main-share').update(content=MAIN_SHARE_BLOCK)
+    ContentBlock.objects.using(db_alias).filter(
+        name='main-downloads').update(content=MAIN_DOWNLOADS_BLOCK)
+    ContentBlock.objects.using(db_alias).filter(
+        name='main-featured-blog').update(content=MAIN_FEATURED_BLOG_BLOCK)
+
+
+def downgrade_contentblocks_data(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0083_content_search_vector'),
+    ]
+
+    operations = [
+        migrations.RunPython(upgrade_contentblocks_data,
+                             downgrade_contentblocks_data)
+    ]

--- a/galaxy/main/models.py
+++ b/galaxy/main/models.py
@@ -220,6 +220,9 @@ class ContentType(BaseModel):
     def __unicode__(self):
         return self.name
 
+    def get_absolute_url(self):
+        return reverse('api:content_type_detail', args=(self.pk,))
+
 
 class Content(CommonModelNameNotUnique):
     """A class representing a user role."""

--- a/galaxy/main/models.py
+++ b/galaxy/main/models.py
@@ -1045,3 +1045,6 @@ class ContentBlock(BaseModel):
 
     def __unicode__(self):
         return self.name
+
+    def get_absolute_url(self):
+        return reverse('api:content_block_detail', args=(self.name,))


### PR DESCRIPTION
- Adds repository, provider_namespace, and namespace to `summary_fields`
- Removes tags from the main response body, adds to `summary_fields`, and includes only the tag value in the list.

Here's an example of what's now returned in `summary_fields`: 

```
        "summary_fields": {
                "provider_namespace": {
                    "name": "00willo",
                    "id": 687
                },
                "repository": {
                    "name": "sublimetext-3",
                    "id": 56683
                },
                "tags": [
                    "development",
                    "editor",
                    "ide",
                    "workstation"
                ],
                "versions": [],
                "namespace": {
                    "name": "00willo",
                    "id": 693
                },
                "platforms": [
                    {
                        "release": "27",
                        "name": "Fedora"
                    }
                ],
                "dependencies": [],
                "videos": []
            },
```