### PR TITLE
Add 'z' mount option to bind mounts for selinux

### DIFF
--- a/scripts/compose-dev.yml
+++ b/scripts/compose-dev.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: ./docker-dev
     volumes:
-      - ${PWD}:/galaxy:rw
+      - ${PWD}:/galaxy:z
     environment:
       - TMUX
       - TEST


### PR DESCRIPTION
otherwise 'galaxy_galaxy_1' container entrypoint
script fails with perm errors like:

 "/entrypoint.sh: line 6: /galaxy/scripts/docker-dev/start-develop.sh: Permission denied"