### PR TITLE
[WIP] Importer exc subclass ImporterError

### DIFF
--- a/galaxy/importer/exceptions.py
+++ b/galaxy/importer/exceptions.py
@@ -21,9 +21,9 @@ class ImporterError(Exception):
     pass
 
 
-class ContentNotFound(ImportError):
+class ContentNotFound(ImporterError):
     pass
 
 
-class ContentLoadError(ImportError):
+class ContentLoadError(ImporterError):
     pass


### PR DESCRIPTION
Subclass ImporterError instead of
python stdlib exception ImportError

[WIP] because I haven't tested much and I'm unsure of the original intention.