### PR TITLE
workaround 'make dev/tmux_noattach' failing in some cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ dev/tmux_noattach:
 .PHONY: dev/tmux
 dev/tmux:
 	# Connect to the galaxy container, start processes, and pipe stdout/stderr through a tmux session
-	$(DOCKER_COMPOSE) exec galaxy bash -c 'make dev/tmux_noattach; tmux -2 attach-session -t galaxy'
+	$(DOCKER_COMPOSE) exec galaxy script /dev/null -q -c 'make dev/tmux_noattach; tmux -2 attach-session -t galaxy'
 
 .PHONY: dev/tmuxcc
 dev/tmuxcc: dev/tmux_noattach


### PR DESCRIPTION
For some cases, 'make dev/tmux' and specifically 'make
dev/tmux_noattach' will fail:

        make: *** [dev/tmux_noattach] Error 1

If 'tmux -v -v -v' is used, the error in the logfile is:

        fatal: tty_init: ttyname failed

This seems to be dependant on the version of docker
amongst other things.

https://github.com/moby/moby/issues/8755 is a similar
issue with more detail and background.

But a workaround found there
(https://github.com/moby/moby/issues/8755#issuecomment-83403289)
is to use the 'script' command to avoid the ttyname problems.

This commit uses that workaround for 'make dev/tmux'.