### PR TITLE
Move repository_type to list view

### DIFF
--- a/galaxy/api/serializers/repository.py
+++ b/galaxy/api/serializers/repository.py
@@ -122,7 +122,10 @@ class RepositorySerializer(BaseSerializer):
             instance.original_name)
 
     def get_repository_type(self, instance):
-        content_count = instance.content_objects.count()
+        try:
+            content_count = instance.content_count
+        except AttributeError:
+            content_count = instance.content_objects.count()
 
         if content_count > 1:
             return self.REPOSITORY_TYPE_MULTIPLE

--- a/galaxy/api/serializers/repository.py
+++ b/galaxy/api/serializers/repository.py
@@ -23,13 +23,14 @@ from .serializers import BaseSerializer
 
 
 __all__ = [
-    'RepositorySerializer',
-    'RepositoryDetailSerializer',
+    'RepositorySerializer'
 ]
 
 
 class RepositorySerializer(BaseSerializer):
+    REPOSITORY_TYPE_MULTIPLE = 'multiple'
     external_url = drf_serializers.SerializerMethodField()
+    repository_type = drf_serializers.SerializerMethodField()
 
     class Meta:
         model = Repository
@@ -53,6 +54,7 @@ class RepositorySerializer(BaseSerializer):
             'clone_url',
             'external_url',
             'issue_tracker_url',
+            'repository_type'
         )
 
     def get_related(self, instance):
@@ -119,12 +121,7 @@ class RepositorySerializer(BaseSerializer):
             instance.provider_namespace.name,
             instance.original_name)
 
-
-class RepositoryDetailSerializer(RepositorySerializer):
-
-    REPOSITORY_TYPE_MULTIPLE = 'multiple'
-
-    def _get_repository_type(self, instance):
+    def get_repository_type(self, instance):
         content_count = instance.content_objects.count()
 
         if content_count > 1:
@@ -134,9 +131,3 @@ class RepositoryDetailSerializer(RepositorySerializer):
             return content.content_type.name
         else:
             return None
-
-    def get_summary_fields(self, instance):
-        summary_fields = super(
-            RepositoryDetailSerializer, self).get_summary_fields(instance)
-        summary_fields['repository_type'] = self._get_repository_type(instance)
-        return summary_fields

--- a/galaxy/api/views/repository.py
+++ b/galaxy/api/views/repository.py
@@ -19,6 +19,7 @@ import logging
 import re
 
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Count
 
 from rest_framework.exceptions import ValidationError, APIException
 from rest_framework.filters import SearchFilter
@@ -81,6 +82,10 @@ class RepositoryList(ListCreateAPIView):
     model = Repository
     serializer_class = RepositorySerializer
     filter_backends = (FieldLookupBackend, SearchFilter, OrderByBackend)
+
+    def get_queryset(self):
+        qs = super(RepositoryList, self).get_queryset()
+        return qs.annotate(content_count=Count('content_objects'))
 
     def post(self, request, *args, **kwargs):
         data = request.data

--- a/galaxy/api/views/repository.py
+++ b/galaxy/api/views/repository.py
@@ -28,8 +28,7 @@ from rest_framework import status
 from galaxy.accounts.models import CustomUser as User
 from galaxy.api.githubapi import GithubAPI
 from galaxy.api.filters import FieldLookupBackend, OrderByBackend
-from galaxy.api.serializers import (RepositorySerializer,
-                                    RepositoryDetailSerializer)
+from galaxy.api.serializers import RepositorySerializer
 from galaxy.api.views.base_views import (ListCreateAPIView,
                                          RetrieveUpdateDestroyAPIView)
 from galaxy.main.models import Repository, ProviderNamespace
@@ -139,7 +138,7 @@ class RepositoryList(ListCreateAPIView):
 
 class RepositoryDetail(RetrieveUpdateDestroyAPIView):
     model = Repository
-    serializer_class = RepositoryDetailSerializer
+    serializer_class = RepositorySerializer
     filter_backends = (FieldLookupBackend, SearchFilter, OrderByBackend)
 
     def update(self, request, *args, **kwargs):

--- a/galaxy/importer/loaders/module.py
+++ b/galaxy/importer/loaders/module.py
@@ -34,7 +34,7 @@ class ModuleLoader(base.BaseLoader):
             content_type, path, root, logger=logger)
 
         self.documentation = None
-        self.metdata = None
+        self.metadata = None
 
     def make_name(self):
         return base.make_module_name(self.path)
@@ -52,7 +52,7 @@ class ModuleLoader(base.BaseLoader):
             content_type=self.content_type,
             description=description,
             metadata={
-                'ansible_metadata': self.metdata,
+                'ansible_metadata': self.metadata,
                 'documentation': self.documentation
             }
         )


### PR DESCRIPTION
- Moves repository_type to main repository serializers. Having it available on the repository list view enables the UI to set the repo type icon on My Content. Plus, it can be used to construct the link to the content detail page.

- Fixes missing module meatadata