### PR TITLE
Match Ansible flake8 config

### DIFF
--- a/galaxy/importer/linters/__init__.py
+++ b/galaxy/importer/linters/__init__.py
@@ -25,7 +25,7 @@ import six
 logger = logging.getLogger(__name__)
 
 LINTERS_DIR = os.path.abspath(os.path.dirname(__file__))
-FLAKE8_MAX_LINE_LENGTH = 160
+FLAKE8_MAX_LINE_LENGTH = 120
 FLAKE8_IGNORE_ERRORS = 'E402'
 
 

--- a/galaxy/importer/linters/__init__.py
+++ b/galaxy/importer/linters/__init__.py
@@ -25,7 +25,8 @@ import six
 logger = logging.getLogger(__name__)
 
 LINTERS_DIR = os.path.abspath(os.path.dirname(__file__))
-FLAKE8_MAX_LINE_LENGTH = 120
+FLAKE8_MAX_LINE_LENGTH = 160
+FLAKE8_IGNORE_ERRORS = 'E402'
 
 
 class BaseLinter(object):
@@ -49,6 +50,7 @@ class Flake8Linter(BaseLinter):
 
     def _check_files(self, paths):
         cmd = [self.cmd, '--exit-zero', '--isolated',
+               '--ignore', FLAKE8_IGNORE_ERRORS,
                '--max-line-length', str(FLAKE8_MAX_LINE_LENGTH),
                '--'] + paths
         logger.debug('CMD: ' + ' '.join(cmd))


### PR DESCRIPTION
Testing [atestuseraccount/galaxy-test-role](https://github.com/atestuseraccount/galaxy-test-role), which includes many database modules copied from ansible/ansible. During the import process flake8 flags the line length and `E402`.

According to the [ansible/ansible/tox.ini](https://github.com/ansible/ansible/blob/devel/tox.ini), the allowed line length is `160`, and `E402` is ignored.

This PR sets Galaxy's allowed line length to `160`, and adds `E402` to the ignore list.