### PR TITLE
Import Fixes

### DIFF
--- a/galaxy/constants.py
+++ b/galaxy/constants.py
@@ -19,10 +19,12 @@ from __future__ import unicode_literals
 
 import enum
 import logging
+import re
 
 
 MAX_TAGS_COUNT = 20
 PROVIDER_GITHUB = 'GitHub'
+TAG_REGEXP = re.compile('^[a-z0-9]+$')
 
 
 class Enum(enum.Enum):

--- a/galaxy/importer/tests/test_role_loader.py
+++ b/galaxy/importer/tests/test_role_loader.py
@@ -52,7 +52,8 @@ class TestRoleMetaParser(unittest.TestCase):
 
         assert tags == ['database']
         self.log.warning.assert_called_once_with(
-            '"s q l" is not a valid tag. Skipping.')
+            "'s q l' is not a valid tag. Tags must container lowercase letters "
+            "and digits only. Skipping.")
 
     def test_parse_categories(self):
         parser = role_loader.RoleMetaParser({
@@ -151,6 +152,7 @@ class TestRoleLoader(unittest.TestCase):
             'galaxy_info': {
                 'description': 'A test role',
                 'author': 'John Smith',
+                'license': 'foo',
                 'min_ansible_version': '2.4.0',
             },
             'dependencies': [{'role': 'testing.test-role-b'}]


### PR DESCRIPTION
- Only allow lowercase letters and digits in tags. Taking a firm stand.
- Catch syntax errors in Python
- Validate role string values. Issues a warning if the strings contain the default values from the Ansible template.