### PR TITLE
Check Galaxy permissions not GitHub

### DIFF
--- a/galaxy/api/views/repository.py
+++ b/galaxy/api/views/repository.py
@@ -201,11 +201,11 @@ class RepositoryDetail(RetrieveUpdateDestroyAPIView):
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
-        repo = get_repo(instance.provider_namespace, request.user,
-                        instance.original_name)
-        if not repo:
+        try:
+            instance.provider_namespace.namespace.owners.get(pk=request.user.pk)
+        except ObjectDoesNotExist:
             raise APIException(
-                "User does not have access to {0}/{1} in GitHub"
+                "User does not have access to {0}/{1}"
                 .format(instance.provider_namespace.name,
                         instance.original_name))
         self.perform_destroy(instance)


### PR DESCRIPTION
If the user renames a repo in GitHub, and then subsequently attempts to delete the repo in Galaxy, the result is a 500 internal server error. This is happening because we throw an API exception, if we think the user does not have access to the repo in GitHub, and we think the user does not have access because we can no longer match the repo name to something in GitHub. 

This PR fixes the issue by removing the GitHub check. Instead, it checks to see if the requesting user is listed as an owner on the parent Namespace. 