### PR TITLE
Fix module_utils migration

### DIFF
--- a/galaxy/main/migrations/0092_content_module_utils.py
+++ b/galaxy/main/migrations/0092_content_module_utils.py
@@ -47,4 +47,6 @@ class Migration(migrations.Migration):
                     ('test_plugin', 'Test Plugin')
                 ], db_index=True, max_length=512, unique=True),
         ),
+        migrations.RunSQL(sql=INSERT_MODULE_UTILS_CONTENT_TYPE,
+                          reverse_sql=DELETE_MODULE_UTILS_CONTENT_TYPE)
     ]


### PR DESCRIPTION
For some reason we never exec the SQL to insert *module_utils* into *main_contenttypes*.