### PR TITLE
Fix psycopg2 warning message

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ PyYAML
 python-memcached
 ansible
 pyOpenSSL
-psycopg2
+psycopg2-binary
 gevent>=0.13
 
 # Linting


### PR DESCRIPTION
This patch fixes warning raised by psycopg2 lib:

> The psycopg2 wheel package will be renamed from release 2.8;
> in order to keep installing from binary please use
> "pip install psycopg2-binary" instead.
> For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.