### PR TITLE
Adds content_counts to Namespace

### DIFF
--- a/galaxy/api/serializers/namespace.py
+++ b/galaxy/api/serializers/namespace.py
@@ -16,7 +16,7 @@
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
 from django.core.urlresolvers import reverse
-from galaxy.main.models import Namespace
+from galaxy.main import models
 from . import serializers
 
 
@@ -26,9 +26,8 @@ __all__ = [
 
 
 class NamespaceSerializer(serializers.BaseSerializer):
-
     class Meta:
-        model = Namespace
+        model = models.Namespace
         fields = serializers.BASE_FIELDS + (
             'id',
             'description',
@@ -45,6 +44,7 @@ class NamespaceSerializer(serializers.BaseSerializer):
             'avatar_url': u.avatar_url,
             'username': u.username
         } for u in instance.owners.all()]
+
         provider_namespaces = [{
             'id': pn.id,
             'name': pn.name,
@@ -58,9 +58,13 @@ class NamespaceSerializer(serializers.BaseSerializer):
             'provider': pn.provider.id,
             'provider_name': pn.provider.name.lower()
         } for pn in instance.provider_namespaces.all()]
+
+        content_counts = {c['content_type__name']: c['count'] for c in instance.content_counts()}
+
         return {
             'owners': owners,
-            'provider_namespaces': provider_namespaces
+            'provider_namespaces': provider_namespaces,
+            'content_counts': content_counts
         }
 
     def get_related(self, instance):
@@ -73,6 +77,6 @@ class NamespaceSerializer(serializers.BaseSerializer):
                 args=(instance.pk,)),
             'owners': reverse(
                 'api:namespace_owners_list',
-                args=(instance.pk,)),
+                args=(instance.pk,))
         }
         return related

--- a/galaxy/main/models.py
+++ b/galaxy/main/models.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
+import logging
+
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db import models
@@ -27,6 +29,8 @@ from django.utils import timezone
 from galaxy import constants
 from galaxy.main import fields
 from galaxy.main.mixins import DirtyMixin
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     'PrimordialModel', 'Platform', 'CloudPlatform', 'Category', 'Tag',
@@ -538,6 +542,13 @@ class Namespace(CommonModel):
 
     def get_absolute_url(self):
         return reverse('api:namespace_detail', args=(self.pk,))
+
+    def content_counts(self):
+        return Content.objects \
+            .filter(namespace=self.pk) \
+            .values('content_type__name') \
+            .annotate(count=models.Count('content_type__name')) \
+            .order_by('content_type__name')
 
 
 class Provider(CommonModel):


### PR DESCRIPTION
For each namespace, show a count of the related content items by type.

```
"content_counts": {
    "action_plugin": 1,
    "module_utils": 6,
    "lookup_plugin": 3,
    "module": 8,
    "role": 6,
    "filter_plugin": 2,
    "strategy_plugin": 3
},
```