### PR TITLE
Set repository.import_branch when importing repository

### DIFF
--- a/galaxy/main/migrations/0094_import_branch.py
+++ b/galaxy/main/migrations/0094_import_branch.py
@@ -1,0 +1,23 @@
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+UPGRADE_SET_IMPORT_BRANCH_DEFAULT_VALUE = """
+UPDATE main_repository 
+SET import_branch = 'master'
+WHERE import_branch IS NULL
+"""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('main', '0093_link_content_version_w_repo'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=UPGRADE_SET_IMPORT_BRANCH_DEFAULT_VALUE,
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/galaxy/worker/tasks.py
+++ b/galaxy/worker/tasks.py
@@ -78,6 +78,9 @@ def _import_repository(import_task, logger):
                      .format(import_task.repository_alt_name))
         repository.name = import_task.repository_alt_name
 
+    if import_task.import_branch:
+        repository.import_branch = import_task.import_branch
+
     token = _get_social_token(import_task)
     gh_api = github.Github(token)
     gh_repo = gh_api.get_repo(repo_full_name)
@@ -96,6 +99,9 @@ def _import_repository(import_task, logger):
         github_token=token,
         github_client=gh_api,
         github_repo=gh_repo)
+
+    if repository.import_branch is None:
+        repository.import_branch = repo_info.branch
 
     new_content_objs = []
     for content_info in repo_info.contents:


### PR DESCRIPTION
`Repository.import_branch` field represents current branch
to import.
If `ImportTask.import_branch` field is set it overrides repository
import_branch field. If neither `Repository.import_branch`, nor
`ImportTask.import_branch` fields are set, `Repository.import_branch`
is set to default git branch, determined by cloning remote repository.

Issue: #507