### PR TITLE
Version no longer associated with Content

### DIFF
--- a/galaxy/api/serializers/content.py
+++ b/galaxy/api/serializers/content.py
@@ -106,8 +106,6 @@ class ContentSerializer(BaseModelSerializer):
         return {
             'dependencies': urls.reverse(
                 'api:content_dependencies_list', args=(instance.pk,)),
-            'versions': urls.reverse(
-                'api:content_versions_list', args=(instance.pk,)),
             'content_type': urls.reverse(
                 'api:content_type_detail', args=(instance.content_type.pk,)),
             'imports': urls.reverse(

--- a/galaxy/api/views/content.py
+++ b/galaxy/api/views/content.py
@@ -60,8 +60,7 @@ class ContentList(base.ListAPIView):
             .prefetch_related(
                 'platforms',
                 'cloud_platforms',
-                'tags',
-                'versions',
+                'tags'
             )
         )
 


### PR DESCRIPTION
This fixes the 500 error received when executing the following API request:

```
http://localhost:8000/api/v1/content/?repository__name__iexact=testing-content&repository__provider_namespace__namespace__name__iexact=chouseknecht
```