### PR TITLE
Add content info to Repository summary_fields

### DIFF
--- a/galaxy/api/serializers/namespace.py
+++ b/galaxy/api/serializers/namespace.py
@@ -59,7 +59,7 @@ class NamespaceSerializer(serializers.BaseSerializer):
             'provider_name': pn.provider.name.lower()
         } for pn in instance.provider_namespaces.all()]
 
-        content_counts = {c['content_type__name']: c['count'] for c in instance.content_counts()}
+        content_counts = {c['content_type__name']: c['count'] for c in instance.content_counts}
 
         return {
             'owners': owners,

--- a/galaxy/api/serializers/repository.py
+++ b/galaxy/api/serializers/repository.py
@@ -113,12 +113,19 @@ class RepositorySerializer(serializers.BaseSerializer):
             latest_import['created'] = import_tasks[0].created
             latest_import['modified'] = import_tasks[0].modified
 
+        content_objects = [{'id': c.id, 'name': c.name, 'content_type': c.content_type.name}
+                           for c in instance.content_objects.all()]
+
+        content_counts = {c['content_type__name']: c['count'] for c in instance.content_counts}
+
         return {
             'owners': owners,
             'provider_namespace': provider_namespace,
             'provider': provider,
             'namespace': namespace,
-            'latest_import': latest_import
+            'latest_import': latest_import,
+            'content_objects': content_objects,
+            'content_counts': content_counts
         }
 
     def get_external_url(self, instance):

--- a/galaxy/main/models.py
+++ b/galaxy/main/models.py
@@ -543,6 +543,7 @@ class Namespace(CommonModel):
     def get_absolute_url(self):
         return reverse('api:namespace_detail', args=(self.pk,))
 
+    @property
     def content_counts(self):
         return Content.objects \
             .filter(namespace=self.pk) \
@@ -979,6 +980,14 @@ class Repository(BaseModel):
     @property
     def github_repo(self):
         return self.original_name
+
+    @property
+    def content_counts(self):
+        return Content.objects \
+            .filter(repository=self.pk) \
+            .values('content_type__name') \
+            .annotate(count=models.Count('content_type__name')) \
+            .order_by('content_type__name')
 
     def get_absolute_url(self):
         return reverse('api:repository_detail', args=(self.pk,))


### PR DESCRIPTION
To reduce the number of API calls and processing performed by the UI, added the following Content information to Repository summary_fields:

- content_counts (similar to content_counts added to Namespace)
- content[], with minimal attributes about each child Content_Object