### PR TITLE
UI Bug Fixes

### DIFF
--- a/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.html
+++ b/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.html
@@ -1,6 +1,6 @@
 <app-page-header [headerTitle]="pageTitle"></app-page-header>
 <div class="padding-15">
-    <form [formGroup]="namespaceForm" (ngSubmit)="saveNamespace()" novalidate>
+    <form [formGroup]="namespaceForm" novalidate>
         <div class="form-group">
             <label for="nameInput">Name <span class="required">*</span></label>
             <input type="text"
@@ -147,9 +147,10 @@
 
         <div class="row form-buttons">
             <div class="col-sm-12">
-                <button type="submit" class="btn btn-primary btn-lg"
+                <button type="button" class="btn btn-primary btn-lg"
                         tooltip-placement="top"
                         uib-tooltip="Save the new namespace"
+                        (click)="saveNamespace($event)"
                         [disabled]="!namespaceForm.valid || !selectedNamespaces.length"><i class="fa fa-check"></i> Save</button>
                 <a [routerLink]="['/my-content']" class="btn btn-default btn-lg"
                    tooltip-placement="top"

--- a/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.ts
+++ b/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.ts
@@ -123,7 +123,7 @@ export class NamespaceDetailComponent implements OnInit {
         } as FilterConfig;
     }
 
-    saveNamespace() {
+    saveNamespace($event) {
         let namespace: Namespace = this.prepareSaveNamespace();
         this.namespaceService.save(namespace)
             .subscribe(

--- a/galaxyui/src/app/resources/provider-namespaces/provider-source.service.ts
+++ b/galaxyui/src/app/resources/provider-namespaces/provider-source.service.ts
@@ -18,7 +18,7 @@ export class ProviderSourceService {
         private notificationService: NotificationService) {}
 
     query(): Observable<ProviderSource[]> {
-        return this.http.get<ProviderSource[]>(this.url)
+        return this.http.get<ProviderSource[]>(this.url + '/')
             .pipe(
                 tap(providerNamespaces => this.log('fetched provider sources')),
                 catchError(this.handleError('Query', []))
@@ -26,7 +26,7 @@ export class ProviderSourceService {
     }
 
     getRepoSources(params):  Observable<RepositorySource[]>{
-        return this.http.get<RepositorySource[]>(`${this.url}/${params.providerName}/${params.name}`)
+        return this.http.get<RepositorySource[]>(`${this.url}/${params.providerName}/${params.name}/`)
         .pipe(
             tap(providerNamespaces => this.log('fetched source repositories')),
         catchError(this.handleError('Query', []))

--- a/galaxyui/src/styles.less
+++ b/galaxyui/src/styles.less
@@ -40,6 +40,9 @@ a.failed {
 .toolbar-pf-results {
     border-top-color: @white;
 }
+.toolbar-pf-results .list-inline {
+    margin-left: 0;
+}
 
 /* Vertical Nav - set menu width*/
 


### PR DESCRIPTION
- On the Namespace edit form, clicking the enter key on a search filter caused the form to be submitted, making it impossible to search for users or provider namespaces. 
- Added the missing '/' to the provider source API request
- Added margin to toolbar filter results. Now there's some space between the label and the search terms.