### PR TITLE
Preserve search history

### DIFF
--- a/galaxy/api/serializers/roles.py
+++ b/galaxy/api/serializers/roles.py
@@ -132,7 +132,8 @@ class RoleListSerializer(BaseRoleSerializer):
             forks_count=obj.repository.forks_count,
             open_issues_count=obj.repository.open_issues_count,
             travis_status_url=obj.repository.travis_status_url,
-            travis_build_url=obj.repository.travis_build_url)
+            travis_build_url=obj.repository.travis_build_url,
+            format=obj.repository.format)
         d['tags'] = [g.name for g in obj.tags.all()]
         d['versions'] = [
             dict(id=g.id, name=g.name, release_date=g.release_date)

--- a/galaxyui/src/app/search/search.component.html
+++ b/galaxyui/src/app/search/search.component.html
@@ -17,17 +17,11 @@
 			            <div class="list-pf-content-wrapper">
 				          	<div class="list-pf-main-content">
 			            		<div class="list-pf-title">
-			            			<div class="content-name cursor-pointer"
-			            					(click)="itemClicked(item)"
-			            					tooltip="View item details">
+			            			<div class="content-name cursor-pointer">
 			        					<div class="icon">
-			        						<i class="fa fa-cog fa-2x" *ngIf="item.summary_fields.content_type.name == 'role'"></i>
-			        						<i class="fa fa-microchip fa-2x" *ngIf="item.summary_fields.content_type.name == 'module'"></i>
-			        						<i class="fa fa-plug fa-2x"
-			        						*ngIf="item.summary_fields.content_type.name.includes('plugin' )"></i>
-			        						<i class="fa fa-book fa-2x" *ngIf="item.summary_fields.content_type.name == 'apb'"></i>
+			        						<i class="{{ item['iconClass'] }}"></i>
 			        					</div>
-			        					<div class="name">{{ item.name }}</div>
+			        					<div class="name"><a [href]="" (click)="itemClicked(item)" tooltip="View content details">{{ item.name }}</a></div>
 			        					<div class="type">{{ item.summary_fields.content_type.name }}</div>
 			            				<div class="description">
 			            					{{item.description}}
@@ -36,7 +30,7 @@
 			            			<div class="content-namespace">
 			            				<a [routerLink]="['/', item.summary_fields.namespace.name]"
 			            				   tooltip="View the Author's page">
-			            					<img [src]="item.summary_fields.content_type.name.avatar_url || '/assets/avatar.png'" class="avatar">
+			            					<img [src]="item.avatar_url" class="avatar">
 			            					{{ item.summary_fields.namespace.name }}
 			            				</a>
 			            			</div>
@@ -56,9 +50,7 @@
                                     			class="travis-status-img" title="Travis Build Status" />
                                     	</a>
                                     </div>
-			            			<div class="counts cursor-pointer"
-			            					(click)="itemClicked(item)"
-			            		    		tooltip="View item details">
+			            			<div class="counts">
 			            				<div class="count-icon"><i class="fa fa-download fa-2x"></i></div>
 			            				<div class="count-count">{{ item.download_count }}</div>
 			            				<div class="count-text">Downloads</div>
@@ -73,15 +65,11 @@
 			            				{{ item.summary_fields.repository.stargazers_count }}</div>
 			            				<div class="count-text">Star Gazers</div>
 			            			</div>
-			            			<div class="import cursor-pointer"
-			            			     	(click)="itemClicked(item)"
-			            		    	 	tooltip="View item details">
+			            			<div class="import">
 			            				<div class="import-text">Last Imported</div>
 			            				<div class="import-date">{{ item.imported }}</div>
 			            			</div>
-			            			<div class="relevance cursor-pointer" *ngIf="showRelevance"
-			            			        (click)="itemClicked(item)"
-			            		    		tooltip="View item details">
+			            			<div class="relevance" *ngIf="showRelevance">
 			            				<span class="relevance-text">Best Match</span>
 			            				<span class="relevance-score">{{ item.relevance | number:'1.4-4' }}</span>
 			            			</div>

--- a/galaxyui/src/app/search/search.component.less
+++ b/galaxyui/src/app/search/search.component.less
@@ -17,9 +17,9 @@
 			vertical-align: middle;
 		}
 		.icon {
-			width: 32px;
 			text-align: center;
 			margin-right: 5px;
+			font-size: 20px;
 		}
 		.name {
 			font-size: 16px;
@@ -55,14 +55,11 @@
 		}
 		.avatar {
 			margin-right: 5px;
-			width: 32px;
 			text-align: center;
-			img {
-				width: 22px;
-				height: 22px;
-				border-radius: 50%;
-				border: 1px solid @ansible-dark-grey;
-			}
+			width: 22px;
+			height: 22px;
+			border-radius: 50%;
+			border: 1px solid @ansible-dark-grey;
 		}
 	}
 

--- a/galaxyui/src/app/search/search.resolver.service.ts
+++ b/galaxyui/src/app/search/search.resolver.service.ts
@@ -9,6 +9,10 @@ import {
     RouterStateSnapshot
 } from '@angular/router';
 
+import {
+    Location
+} from '@angular/common';
+
 import { Observable }            from 'rxjs/Observable';
 import { ContentSearchService }  from '../resources/content-search/content-search.service';
 import { ContentResponse }       from '../resources/content-search/content';
@@ -29,10 +33,33 @@ import { Tag }                   from '../resources/tags/tag';
 export class SearchContentResolver implements Resolve<ContentResponse> {
     constructor(
         private contentService: ContentSearchService,
-        private router: Router
+        private router: Router,
+        private location: Location
     ){}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<ContentResponse> {
-        return this.contentService.query();
+        let params = '';
+        for (var key in route.queryParams) {
+            if (params != '')
+                params += '&';
+            params += key + '=' + encodeURIComponent(route.queryParams[key]);
+        }
+        // Add default params
+        if (!route.queryParams['order_by']) {
+            if (params != '')
+                params += '&';
+            params += 'order_by=-relevance';
+        }
+        if (!route.queryParams['page_size']) {
+            if (params != '')
+                params += '&';
+            params += 'page_size=10';
+        }
+        if (!route.queryParams['page']) {
+            if (params != '')
+                params += '&';
+            params += 'page=1';
+        }
+        return this.contentService.query(params);
     }
 }
 


### PR DESCRIPTION
- Content is now always displayed on the search page, even when there is no active filter.
- Search history is now preserved. Search for content, click on a content item (which takes you to the Content Detail page), then click the browser back button, and you will now be returned to your search with the previous search results displayed.
- Fixed item links and tooltips, such that only item name and namespace name can be clicked
- Clicking on item name now links to the correct URL based on repository format
- Fixed content author avatar
- Set content icon class via enum
- Added repository format to summary_field.repository on /api/v1/search/content

Closes #562