### PR TITLE
Fix Travis CI integration

### DIFF
--- a/galaxy/api/serializers/__init__.py
+++ b/galaxy/api/serializers/__init__.py
@@ -19,6 +19,7 @@ from .content import *             # noqa
 from .content_block import *       # noqa
 from .content_type import *        # noqa
 from .namespace import *           # noqa
+from .notification import *        # noqa
 from .provider import *            # noqa
 from .provider_source import *     # noqa
 from .repository_source import *   # noqa

--- a/galaxy/api/serializers/notification.py
+++ b/galaxy/api/serializers/notification.py
@@ -1,0 +1,94 @@
+from collections import OrderedDict
+
+from django.urls import reverse
+from rest_framework import serializers
+
+from galaxy.main.models import NotificationSecret, Notification
+
+from .serializers import BaseSerializer
+
+__all__ = [
+    'NotificationSecretSerializer',
+    'NotificationSerializer',
+
+]
+
+
+class NotificationSecretSerializer(BaseSerializer):
+    secret = serializers.SerializerMethodField()
+
+    class Meta:
+        model = NotificationSecret
+        fields = (
+            'id',
+            'owner',
+            'github_user',
+            'github_repo',
+            'source',
+            'secret',
+            'created',
+            'modified',
+            'active'
+        )
+
+    def get_url(self, obj):
+        if obj is None:
+            return ''
+        elif isinstance(obj, NotificationSecret):
+            return reverse('api:notification_secret_detail', args=(obj.pk,))
+        else:
+            return obj.get_absolute_url()
+
+    def get_secret(self, obj):
+        # show only last 4 digits of secret
+        last = ''
+        try:
+            last = obj.secret[-4:]
+        except Exception:
+            pass
+        return '******' + last
+
+
+class NotificationSerializer(BaseSerializer):
+    class Meta:
+        model = Notification
+        fields = (
+            'id',
+            'owner',
+            'source',
+            'github_branch',
+            'travis_build_url',
+            'travis_status',
+            'commit_message',
+            'committed_at',
+            'commit',
+            'created',
+            'modified'
+        )
+
+    def get_url(self, obj):
+        if obj is None:
+            return ''
+        elif isinstance(obj, Notification):
+            return reverse('api:notification_detail', args=(obj.pk,))
+        else:
+            return obj.get_absolute_url()
+
+    def get_summary_fields(self, obj):
+        if obj is None:
+            return {}
+        d = super(NotificationSerializer, self).get_summary_fields(obj)
+        d['owner'] = OrderedDict([
+            ('id', obj.owner.id),
+            ('username', obj.owner.username)
+        ])
+        return d
+
+    def get_related(self, obj):
+        if obj is None:
+            return {}
+        res = super(NotificationSerializer, self).get_related(obj)
+        res.update(dict(
+            owner=reverse('api:user_detail', args=(obj.owner.id,)),
+        ))
+        return res

--- a/galaxy/api/serializers/serializers.py
+++ b/galaxy/api/serializers/serializers.py
@@ -33,8 +33,6 @@ from galaxy.main.models import (Platform,
                                 Content,
                                 ImportTask,
                                 RepositoryVersion,
-                                NotificationSecret,
-                                Notification,
                                 Subscription,
                                 Stargazer
                                 )
@@ -55,8 +53,6 @@ __all__ = [
     'PlatformSearchSerializer',
     'RepositoryVersionSerializer',
     'TopContributorsSerializer',
-    'NotificationSecretSerializer',
-    'NotificationSerializer',
     'ImportTaskSerializer',
     'ImportTaskLatestSerializer',
     'RoleTopSerializer',
@@ -460,97 +456,6 @@ class TopContributorsSerializer(serializers.BaseSerializer):
             'namespace': obj['namespace'],
             'role_count': obj['count']
         }
-
-
-class NotificationSecretSerializer(BaseSerializer):
-    secret = serializers.SerializerMethodField()
-
-    class Meta:
-        model = NotificationSecret
-        fields = (
-            'id',
-            'owner',
-            'github_user',
-            'github_repo',
-            'source',
-            'secret',
-            'created',
-            'modified',
-            'active'
-        )
-
-    def get_url(self, obj):
-        if obj is None:
-            return ''
-        elif isinstance(obj, NotificationSecret):
-            return reverse('api:notification_secret_detail', args=(obj.pk,))
-        else:
-            return obj.get_absolute_url()
-
-    def get_secret(self, obj):
-        # show only last 4 digits of secret
-        last = ''
-        try:
-            last = obj.secret[-4:]
-        except Exception:
-            pass
-        return '******' + last
-
-
-class NotificationSerializer(BaseSerializer):
-    class Meta:
-        model = Notification
-        fields = (
-            'id',
-            'owner',
-            'source',
-            'github_branch',
-            'travis_build_url',
-            'travis_status',
-            'commit_message',
-            'committed_at',
-            'commit',
-            'messages',
-            'created',
-            'modified'
-        )
-
-    def get_url(self, obj):
-        if obj is None:
-            return ''
-        elif isinstance(obj, Notification):
-            return reverse('api:notification_detail', args=(obj.pk,))
-        else:
-            return obj.get_absolute_url()
-
-    def get_summary_fields(self, obj):
-        if obj is None:
-            return {}
-        d = super(NotificationSerializer, self).get_summary_fields(obj)
-        d['owner'] = OrderedDict([
-            ('id', obj.owner.id),
-            ('username', obj.owner.username)
-        ])
-        d['roles'] = [OrderedDict([
-            ('id', r.id),
-            ('namespace', r.namespace),
-            ('name', r.name)
-        ]) for r in obj.roles.all()]
-        d['imports'] = [OrderedDict([
-            ('id', t.id)
-        ]) for t in obj.imports.all()]
-        return d
-
-    def get_related(self, obj):
-        if obj is None:
-            return {}
-        res = super(NotificationSerializer, self).get_related(obj)
-        res.update(dict(
-            roles=reverse('api:notification_roles_list', args=(obj.pk,)),
-            imports=reverse('api:notification_imports_list', args=(obj.pk,)),
-            owner=reverse('api:user_detail', args=(obj.owner.id,)),
-        ))
-        return res
 
 
 class ImportTaskSerializer(BaseSerializer):

--- a/galaxy/api/urls.py
+++ b/galaxy/api/urls.py
@@ -43,8 +43,6 @@ role_urls = [
         views.RoleDependenciesList.as_view(), name='role_dependencies_list'),
     url(r'^(?P<pk>[0-9]+)/imports/$',
         views.RoleImportTaskList.as_view(), name='role_import_task_list'),
-    url(r'^(?P<pk>[0-9]+)/notifications/$',
-        views.RoleNotificationList.as_view(), name='role_notification_list'),
     url(r'^(?P<pk>[0-9]+)/downloads/$', views.RoleDownloads.as_view(),
         name='role_downloads')
 ]
@@ -110,10 +108,6 @@ notification_urls = [
     url(r'^$', views.NotificationList.as_view(), name='notification_list'),
     url(r'^(?P<pk>[0-9]+)/$', views.NotificationDetail.as_view(),
         name='notification_detail'),
-    url(r'^(?P<pk>[0-9]+)/roles/$', views.NotificationRolesList.as_view(),
-        name='notification_roles_list'),
-    url(r'^(?P<pk>[0-9]+)/imports/$', views.NotificationImportsList.as_view(),
-        name='notification_imports_list'),
 ]
 
 namespace_urls = [

--- a/galaxy/api/views/__init__.py
+++ b/galaxy/api/views/__init__.py
@@ -20,6 +20,7 @@ from .content import *              # noqa
 from .content_block import *        # noqa
 from .content_type import *         # noqa
 from .namespace import *            # noqa
+from .notification import *         # noqa
 from .repository import *           # noqa
 from .provider_source import *      # noqa
 from .repository_source import *    # noqa

--- a/galaxy/api/views/notification.py
+++ b/galaxy/api/views/notification.py
@@ -1,0 +1,267 @@
+import base64
+import json
+from hashlib import sha256
+
+import requests
+from OpenSSL import crypto
+from django.conf import settings
+from django.db import IntegrityError
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+from rest_framework import status
+from rest_framework.authentication import TokenAuthentication, \
+    SessionAuthentication
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from galaxy import constants
+from galaxy.accounts.models import CustomUser as User
+from galaxy.api import serializers, tasks
+from galaxy.api.permissions import ModelAccessPermission
+from galaxy.api.views import base_views
+from galaxy.main import models
+
+
+TRAVIS_STATUS_URL = "https://travis-ci.org/{user}/{repo}.svg?branch={branch}"
+
+__all__ = [
+    'NotificationSecretList',
+    'NotificationSecretDetail',
+    'NotificationList',
+    'NotificationDetail',
+]
+
+
+class NotificationSecretList(base_views.ListCreateAPIView):
+    '''
+    Integration tokens.
+    '''
+    model = models.NotificationSecret
+    serializer_class = serializers.NotificationSecretSerializer
+    authentication_classes = (TokenAuthentication, SessionAuthentication)
+    permission_classes = (IsAuthenticated, ModelAccessPermission,)
+
+    def list(self, request, *args, **kwargs):
+        # only list secrets belonging to the authenticated user
+        queryset = self.filter_queryset(self.get_queryset())
+        queryset = queryset.filter(owner=request.user)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
+
+    def post(self, request, *args, **kwargs):
+        secret = request.data.get('secret', None)
+        source = request.data.get('source', None)
+        github_user = request.data.get('github_user', None)
+        github_repo = request.data.get('github_repo', None)
+
+        if not secret or not source or not github_user or not github_repo:
+            raise ValidationError(dict(detail="Invalid request. Missing one or more required values."))
+
+        if source not in ['github', 'travis']:
+            raise ValidationError(dict(detail="Invalid source value. Expecting one of: [github, travis]"))
+
+        if source == 'travis':
+            secret = sha256(github_user + '/' + github_repo + secret).hexdigest()
+
+        secret, create = models.NotificationSecret.objects.get_or_create(
+            source=source,
+            github_user=github_user,
+            github_repo=github_repo,
+            defaults={
+                'owner': request.user,
+                'source': source,
+                'secret': secret,
+                'github_user': github_user,
+                'github_repo': github_repo
+            }
+        )
+
+        if not create:
+            msg = "Duplicate key. An integration for {0} {1} {2} already exists.".format(source,
+                                                                                         github_user,
+                                                                                         github_repo)
+            raise ValidationError(dict(detail=msg))
+
+        serializer = self.get_serializer(instance=secret)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+
+class NotificationSecretDetail(base_views.RetrieveUpdateDestroyAPIView):
+    model = models.NotificationSecret
+    serializer_class = serializers.NotificationSecretSerializer
+    authentication_classes = (TokenAuthentication, SessionAuthentication)
+    permission_classes = (IsAuthenticated, ModelAccessPermission,)
+
+    def put(self, request, *args, **kwargs):
+        source = request.data.get('source', None)
+        secret = request.data.get('secret', None)
+        github_user = request.data.get('github_user', None)
+        github_repo = request.data.get('github_repo', None)
+
+        if not secret or not source or not github_user or not github_repo:
+            raise ValidationError(dict(detail="Invalid request. Missing one or more required values."))
+
+        if source not in ['github', 'travis']:
+            raise ValidationError(dict(detail="Invalid source value. Expecting one of: [github, travis]"))
+
+        instance = self.get_object()
+
+        if source == 'travis':
+            secret = sha256(github_user + '/' + github_repo + secret).hexdigest()
+
+        try:
+            instance.source = source
+            instance.secret = secret
+            instance.github_user = github_user
+            instance.github_repo = github_repo
+            instance.save()
+        except IntegrityError:
+            msg = "An integration for {0} {1} {2} already exists.".format(source, github_user, github_repo)
+            raise ValidationError(dict(detail=msg))
+
+        serializer = self.get_serializer(instance=instance)
+        return Response(serializer.data, status=status.HTTP_202_ACCEPTED)
+
+    def destroy(self, request, *args, **kwargs):
+        obj = super(NotificationSecretDetail, self).get_object()
+        obj.delete()
+        return Response(dict(detail="Requested secret deleted."),
+                        status=status.HTTP_202_ACCEPTED)
+
+
+class NotificationList(base_views.ListCreateAPIView):
+    model = models.Notification
+    serializer_class = serializers.NotificationSerializer
+
+    def post(self, request, *args, **kwargs):
+        self._verify_request(request)
+
+        github_user, github_repo = self._get_repo_info(request)
+        owner = self._get_owner(github_user)
+        payload = json.loads(request.POST['payload'])
+        request_branch = payload['branch']
+        travis_status_url = TRAVIS_STATUS_URL.format(
+            user=github_user, repo=github_repo, branch=request_branch)
+        committed_at = payload.get('committed_at')
+        if committed_at:
+            committed_at = parse_datetime(committed_at)
+        else:
+            committed_at = timezone.now()
+
+        try:
+            provider_ns = models.ProviderNamespace.objects.get(
+                provider__name=constants.PROVIDER_GITHUB,
+                name=github_user,
+            )
+        except models.ProviderNamespace.DoesNotExist:
+            return ValidationError('Prodiver namespace "{}" not found'
+                                   .format(github_user))
+
+        notification = models.Notification(
+            owner=owner,
+            source='travis',
+            github_branch=request_branch,
+            travis_build_url=payload.get('build_url'),
+            travis_status=payload.get('status_message'),
+            commit_message=payload.get('message'),
+            committed_at=committed_at,
+            commit=payload['commit']
+        )
+
+        repository, _ = models.Repository.objects.get_or_create(
+            provider_namespace=provider_ns,
+            original_name=github_repo,
+            defaults={
+                'name': github_repo,
+                'is_enabled': False,
+                'travis_status_url': travis_status_url,
+                'travis_build_url': payload.get('build_url'),
+            })
+        notification.repository = repository
+
+        task = tasks.create_import_task(
+            repository, owner,
+            travis_status_url=travis_status_url,
+            travis_build_url=payload.get('build_url'))
+        notification.import_task = task
+
+        notification.save()
+
+        serializer = self.get_serializer(instance=notification)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED,
+                        headers=headers)
+
+    def _verify_signature(self, signature, public_key, payload):
+        """
+        Convert the PEM encoded public key to a format palatable for pyOpenSSL,
+        then verify the signature
+        """
+        pkey_public_key = crypto.load_publickey(
+            crypto.FILETYPE_PEM, public_key)
+        certificate = crypto.X509()
+        certificate.set_pubkey(pkey_public_key)
+        crypto.verify(certificate, signature, payload, 'sha1')
+
+    def _get_repo_info(self, request):
+        """Return github username and repository from request headers."""
+
+        slug = request.META.get('HTTP_TRAVIS_REPO_SLUG')
+        if not slug:
+            raise ValidationError('Expected "TRAVIS_REPO_SLUG" header')
+        return slug.split('/', 1)
+
+    def _get_signature(self, request):
+        """
+        Extract the raw bytes of the request signature provided by travis
+        """
+        signature = request.META['HTTP_SIGNATURE']
+        return base64.b64decode(signature)
+
+    def _get_travis_public_key(self):
+        """
+        Returns the PEM encoded public key from the Travis CI /config endpoint
+        """
+        response = requests.get(settings.TRAVIS_CONFIG_URL, timeout=10.0)
+        response.raise_for_status()
+        travis_config = response.json()['config']
+        return travis_config['notifications']['webhook']['public_key']
+
+    def _get_owner(self, github_user):
+        try:
+            return User.objects.get(username=github_user)
+        except User.DoesNotExist:
+            pass
+
+        try:
+            return User.objects.get(
+                username=settings.GITHUB_TASK_USERS[0])
+        except User.DoesNotExist:
+            raise ValidationError('Galaxy task user not found')
+
+    def _verify_request(self, request):
+        signature = self._get_signature(request)
+        payload = request.POST['payload']
+        try:
+            public_key = self._get_travis_public_key()
+        except requests.Timeout:
+            # TODO(cutwater): Probably it shouldn't be "Bad request"
+            raise ValidationError(
+                "Timeout attempting to retrieve Travis CI public key")
+        except requests.RequestException as e:
+            raise ValidationError(
+                "Failed to retrieve Travis CI public key. {}"
+                .format(e.message)
+            )
+        try:
+            self._verify_signature(signature, public_key, payload)
+        except crypto.Error:
+            # FIXME(cutwater): Raise permission denied
+            raise ValidationError("Authorization failed")
+
+
+class NotificationDetail(base_views.RetrieveAPIView):
+    model = models.Notification
+    serializer_class = serializers.NotificationSerializer

--- a/galaxy/main/migrations/0100_notifications.py
+++ b/galaxy/main/migrations/0100_notifications.py
@@ -1,0 +1,88 @@
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def upgrade_data(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
+    Notification = apps.get_model("main", "Notification")
+    for notification in Notification.objects.using(db_alias).all():
+        import_task = notification.imports.order_by('-id').first()
+        content = notification.roles.first()
+
+        if import_task and content:
+            notification.import_task = import_task
+            notification.repository = content.repository
+            notification.save()
+        else:
+            notification.delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('main', '0099_namespace_vendor'),
+    ]
+
+    operations = [
+        migrations.RunSQL('SET CONSTRAINTS ALL IMMEDIATE',
+                          reverse_sql=migrations.RunSQL.noop),
+        migrations.AddField(
+            model_name='notification',
+            name='import_task',
+            field=models.ForeignKey(
+                null=True,
+                editable=False,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='notifications',
+                to='main.ImportTask',
+                verbose_name=b'Tasks'),
+        ),
+        migrations.AddField(
+            model_name='notification',
+            name='repository',
+            field=models.ForeignKey(
+                null=True,
+                editable=False,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='notifications',
+                to='main.Repository'),
+        ),
+        migrations.RunPython(code=upgrade_data),
+        migrations.AlterField(
+            model_name='notification',
+            name='import_task',
+            field=models.ForeignKey(
+                editable=False,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='notifications',
+                to='main.ImportTask',
+                verbose_name=b'Tasks'),
+        ),
+        migrations.AlterField(
+            model_name='notification',
+            name='repository',
+            field=models.ForeignKey(
+                editable=False,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='notifications',
+                to='main.Repository'),
+        ),
+        migrations.RemoveField(
+            model_name='notification',
+            name='imports',
+        ),
+        migrations.RemoveField(
+            model_name='notification',
+            name='messages',
+        ),
+        migrations.RemoveField(
+            model_name='notification',
+            name='roles',
+        ),
+        migrations.AlterUniqueTogether(
+            name='repository',
+            unique_together={('provider_namespace', 'original_name'),
+                             ('provider_namespace', 'name')},
+        ),
+    ]

--- a/galaxy/main/models.py
+++ b/galaxy/main/models.py
@@ -23,7 +23,6 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.forms.models import model_to_dict
-from django.contrib.postgres import fields as psql_fields
 from django.contrib.postgres import search as psql_search
 from django.contrib.postgres import indexes as psql_indexes
 from django.utils import timezone
@@ -901,28 +900,25 @@ class Notification(PrimordialModel):
         max_length=256,
         blank=True
     )
-    roles = models.ManyToManyField(
-        Content,
+    repository = models.ForeignKey(
+        'Repository',
         related_name='notifications',
-        verbose_name='Roles',
-        editable=False
+        editable=False,
     )
-    imports = models.ManyToManyField(
+    import_task = models.ForeignKey(
         ImportTask,
         related_name='notifications',
         verbose_name='Tasks',
-        editable=False
-    )
-    messages = psql_fields.ArrayField(
-        models.CharField(max_length=256),
-        default=list,
         editable=False
     )
 
 
 class Repository(BaseModel):
     class Meta:
-        unique_together = ('provider_namespace', 'name')
+        unique_together = [
+            ('provider_namespace', 'name'),
+            ('provider_namespace', 'original_name'),
+        ]
         ordering = ('provider_namespace', 'name')
 
     # Foreign keys


### PR DESCRIPTION
* General:
  - Fix integration with Travis CI. Handle Travis CI webhook correctly.
* Models:
  - Delete many to many relationships between `Notification` and `Content`.
  - Delete many to many relationships between `Notification` and
    `ImportTask`.
  - Drop `Notification.messages` fields as not used.
  - New relations `Notification.last_import`, `Notification.repository`.
* Views:
  - Extract notification views to standalone module
    `galaxy/serializers/notification.py`.
* Serializers:
  - Extract notification serializers to standalone module
    `galaxy/views/notification.py`

Fixes: #291 