### PR TITLE
Refactor search items

### DIFF
--- a/galaxyui/src/app/search/search.component.html
+++ b/galaxyui/src/app/search/search.component.html
@@ -14,7 +14,16 @@
 			        [items]="contentItems"
 			        [itemTemplate]="itemTemplate">
 			        <ng-template #itemTemplate let-item="item" let-index="index">
-			            <div class="list-pf-content-wrapper">
+		            	<div class="list-pf-left">
+          					<a [routerLink]="['/', item.summary_fields.namespace.name]"
+            				   [tooltip]="'View more content from ' + item['displayNamespace']"
+            				   container="body">
+            					<img [src]="item.avatar_url"
+            					     class="namespace-avatar">
+            					<div class="namespace-name">{{ item['namespace_name'] }}</div>
+            				</a>
+        				</div>
+				        <div class="list-pf-content-wrapper">
 				          	<div class="list-pf-main-content">
 			            		<div class="list-pf-title">
 			            			<div class="content-name cursor-pointer">
@@ -27,13 +36,13 @@
 			            					{{item.description}}
 			            				</div>
 		            				</div>
-			            			<div class="content-namespace">
+			            			<!--div class="content-namespace">
 			            				<a [routerLink]="['/', item.summary_fields.namespace.name]"
 			            				   tooltip="View the Author's page">
 			            					<img [src]="item.avatar_url" class="avatar">
 			            					{{ item.summary_fields.namespace.name }}
 			            				</a>
-			            			</div>
+			            			</div-->
 			            			<div class="content-tags">
 			            				<div class="icon"><i class="fa fa-tag fa-2x"></i></div>
 			            				<div class="tags">

--- a/galaxyui/src/app/search/search.component.less
+++ b/galaxyui/src/app/search/search.component.less
@@ -11,6 +11,11 @@
 	margin-top: 20px;
 	color: @ansible-dark-grey;
 
+	.list-pf-left {
+		border-right: 1px solid #ccc;
+		padding-right: 20px;
+	}
+
 	.content-name {
 		.icon, .name, .type {
 			display: inline-block;
@@ -35,8 +40,6 @@
 			border-color: @ansible-dark-grey;
 		}
 		.description {
-			margin: 15px 0;
-			padding-left: 5px;
 			font-weight: normal;
 		}
 	}
@@ -45,23 +48,23 @@
 		cursor: pointer;
 	}
 
-	.content-namespace {
-		.name {
-			color: @blue;
-		}
-		.avatar, .name {
-			display: inline-block;
-			vertical-align: middle;
-		}
-		.avatar {
-			margin-right: 5px;
-			text-align: center;
-			width: 22px;
-			height: 22px;
-			border-radius: 50%;
-			border: 1px solid @ansible-dark-grey;
-		}
+	.namespace-avatar {
+		margin-top: 15px;
+		width: 90px;
+		height: 90px;
 	}
+
+	.namespace-name {
+		font-size: 12px;
+		padding-top: 10px;
+		width: 90px;
+		text-align: center;
+  		white-space: nowrap;
+  		overflow: hidden;
+  		text-overflow: ellipsis;
+  		min-height: 15px;
+	}
+
 
 	.content-tags {
 		margin-top: 15px;

--- a/galaxyui/src/app/search/search.component.ts
+++ b/galaxyui/src/app/search/search.component.ts
@@ -474,6 +474,8 @@ export class SearchComponent implements OnInit, AfterViewInit {
 			item.imported = moment(item.imported).fromNow();
 			item['repository_format'] = item.summary_fields['repository']['format'];
 			item['avatar_url'] = item.summary_fields['namespace']['avatar_url'] || '/assets/avatar.png';
+			item['namespace_name'] = (item.summary_fields['namespace']['avatar_url']) ? '' : item.summary_fields['namespace']['name'];
+			item['displayNamespace'] = item.summary_fields['namespace']['name'];
 			if (item.summary_fields['content_type']['name'].indexOf('plugin') > -1) {
 				item['iconClass'] = ContentTypesIconClasses.plugin;
 			} else {


### PR DESCRIPTION
Start each content item with its Namespace avatar. Attempting to make search results look more like https://tower-mockups.testing.ansible.com/galaxy/search/search/