### PR TITLE
Use Django builtin JSONField class

### DIFF
--- a/galaxy/main/migrations/0081_content_metadata.py
+++ b/galaxy/main/migrations/0081_content_metadata.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
-import galaxy.main.fields
+from django.db import migrations
+from django.contrib.postgres import fields as psql_fields
 
 
 class Migration(migrations.Migration):
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='content',
             name='metadata',
-            field=galaxy.main.fields.JSONField(default={}),
+            field=psql_fields.JSONField(default={}),
         ),
     ]

--- a/galaxy/main/models.py
+++ b/galaxy/main/models.py
@@ -23,6 +23,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.forms.models import model_to_dict
+from django.contrib.postgres import fields as psql_fields
 from django.contrib.postgres import search as psql_search
 from django.contrib.postgres import indexes as psql_indexes
 from django.utils import timezone
@@ -337,7 +338,7 @@ class Content(CommonModelNameNotUnique):
         max_length=256,
         null=False
     )
-    metadata = fields.JSONField(
+    metadata = psql_fields.JSONField(
         null=False,
         default={}
     )


### PR DESCRIPTION
We used backported JSONField as it was not implemented before
Django 1.9. As current version of Django is 1.11, it can be removed.
This patch replaced usage of backported JSONField class with
Django builtin class and removes it implementation.