### PR TITLE
Change session engine to db

### DIFF
--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -125,7 +125,7 @@ LOGIN_REDIRECT_URL = '/home'
 # Sessions
 # ---------------------------------------------------------
 
-SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
+SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 
 SESSION_SAVE_EVERY_REQUEST = True
 


### PR DESCRIPTION
Since we dropped memcache support, we need to store user sessions
in the database.