### PR TITLE
Multi-role repos require mazer

### DIFF
--- a/galaxyui/src/app/content-detail/cards/info/card-info.component.html
+++ b/galaxyui/src/app/content-detail/cards/info/card-info.component.html
@@ -14,7 +14,7 @@
                 <tr>
                     <td>Installation</td>
                     <td class="install-instructions">
-                        <copy-to-clipboard [copyText]="'ansible-galaxy install ' + repoContent.summary_fields['namespace']['name'] + '.' + repoContent.summary_fields['repository']['name']"></copy-to-clipboard>
+                        <copy-to-clipboard [copyText]="repoContent['install_cmd']"></copy-to-clipboard>
                     </td>
                 </tr>
                 <tr>
@@ -76,7 +76,7 @@
                     <tr>
                         <td>Installation</td>
                         <td class="install-instructions">
-                            <copy-to-clipboard [copyText]="'ansible-galaxy install ' +  repoContent.summary_fields['namespace']['name'] + '.' + repoContent.summary_fields['repository']['name']"></copy-to-clipboard>
+                            <copy-to-clipboard [copyText]="repoContent['install_cmd']"></copy-to-clipboard>
                         </td>
                     </tr>
                     <tr>

--- a/galaxyui/src/app/content-detail/cards/info/card-info.component.ts
+++ b/galaxyui/src/app/content-detail/cards/info/card-info.component.ts
@@ -8,7 +8,7 @@ import { CardConfig }     from 'patternfly-ng/card/basic-card/card-config';
 import { Content }        from '../../../resources/content/content';
 import { Repository }     from '../../../resources/repositories/repository';
 import { ViewTypes }      from '../../../enums/view-types.enum';
-import { RepoFormats }      from '../../../enums/repo-types.enum';
+import { RepoFormats }    from '../../../enums/repo-types.enum';
 
 import { ContentTypesPlural }   from '../../../enums/content-types.enum';
 
@@ -59,9 +59,18 @@ export class CardInfoComponent implements OnInit {
     set repoContent(data: Content) {
         this._repoContent = data;
         if (this._repoContent) {
-            this.repoContent['tags'] = this.repoContent.summary_fields['tags'];
-            this.repoContent['hasTags'] =
-                (this.repoContent.summary_fields['tags'] && this.repoContent.summary_fields['tags'].length) ? true : false;
+            if (this._repoType === 'multi') {
+                this._repoContent['install_cmd'] =
+                    `mazer install ${this._repoContent.summary_fields['namespace']['name']}.` +
+                    `${this._repoContent.summary_fields['repository']['name']}`;
+            } else {
+                this._repoContent['install_cmd'] =
+                    `ansible-galaxy install ${this._repoContent.summary_fields['namespace']['name']}.` +
+                    `${this._repoContent.name}`;
+            }
+            this._repoContent['tags'] = this._repoContent.summary_fields['tags'];
+            this._repoContent['hasTags'] =
+                (this.repoContent.summary_fields['tags'] && this._repoContent.summary_fields['tags'].length) ? true : false;
             this.example_name = this._repoContent.name;
             this.example_type = this._repoContent.content_type;
             this.example_type_plural = ContentTypesPlural[this._repoContent.content_type];

--- a/galaxyui/src/app/content-detail/content/roles/roles.component.html
+++ b/galaxyui/src/app/content-detail/content/roles/roles.component.html
@@ -39,7 +39,7 @@
                             <tr>
                                 <td>Installation</td>
                                 <td>
-                                    <copy-to-clipboard [copyText]="'ansible-galaxy install ' + item.summary_fields['namespace']['name'] + '.' + item.summary_fields['repository']['name']"></copy-to-clipboard>
+                                    <copy-to-clipboard [copyText]="item['install_cmd']"></copy-to-clipboard>
                                 </td>
                             </tr>
                             <tr *ngIf="item['hasTags']">

--- a/galaxyui/src/app/content-detail/content/roles/roles.component.ts
+++ b/galaxyui/src/app/content-detail/content/roles/roles.component.ts
@@ -194,6 +194,8 @@ export class RolesComponent implements OnInit {
         forkJoin(queries).subscribe((results: Content[]) => {
             this.items = JSON.parse(JSON.stringify(results));
             this.items.forEach(item => {
+                item['install_cmd'] =
+                    `mazer install ${item.summary_fields['namespace']['name']}.${item.summary_fields['repository']['name']}`;
                 item['hasTags'] = false;
                 if (item.summary_fields['tags'] && item.summary_fields['tags'].length) {
                     item['tags'] = item.summary_fields['tags'];


### PR DESCRIPTION
The install command at the repo level and at the content level for multi-role repositories should show the `mazer install` command, rather than `ansible-galaxy install`.