### PR TITLE
Prevent rename of existing repos

### DIFF
--- a/galaxy/importer/loaders/apb.py
+++ b/galaxy/importer/loaders/apb.py
@@ -26,6 +26,7 @@ from galaxy.importer import exceptions as exc
 from galaxy.importer import linters
 from galaxy.importer import models
 from galaxy.importer.loaders import base
+from galaxy.common import sanitize_content_name
 
 
 class APBMetaParser(object):
@@ -150,10 +151,10 @@ class APBMetaParser(object):
     def parse_name(self):
         fieldname = 'name'
         name = self._get_key(fieldname)
-        if not re.match('^[a-z0-9_.-]+$', name):
+        if not re.match('^[a-z0-9_]+$', name):
             raise exc.APBContentLoadError(
                 'Invalid "{0}" value in metadata. Must contain only lowercase '
-                'letters, digits, underscore, period and dash'.format(fieldname))
+                'letters, digits, and underscore'.format(fieldname))
         return name
 
     def parse_description(self):
@@ -189,7 +190,7 @@ class APBLoader(base.BaseLoader):
         self.log.info('Loading metadata file: {0}'.format(self.metadata_file))
         metadata = self._load_metadata()
         meta_parser = APBMetaParser(metadata, logger=self.log)
-        name = meta_parser.parse_name()
+        name = sanitize_content_name(meta_parser.parse_name())
         description = meta_parser.parse_description()
         meta_parser.check_data()
         data = {'tags': meta_parser.parse_tags()}

--- a/galaxy/importer/loaders/role.py
+++ b/galaxy/importer/loaders/role.py
@@ -28,6 +28,7 @@ from galaxy import constants
 from galaxy.importer import models, linters
 from galaxy.importer.loaders import base
 from galaxy.importer import exceptions as exc
+from galaxy.common import sanitize_content_name
 
 
 ROLE_META_FILES = [
@@ -254,7 +255,10 @@ class RoleLoader(base.BaseLoader):
         data['video_links'] = meta_parser.parse_videos()
         readme = self._get_readme()
 
-        name = galaxy_info.get('role_name', self.name)
+        name = self.name
+        if galaxy_info.get('role_name'):
+            name = sanitize_content_name(galaxy_info['role_name'])
+
         return models.Content(
             name=name,
             original_name=self.name,

--- a/galaxy/worker/tasks.py
+++ b/galaxy/worker/tasks.py
@@ -28,7 +28,6 @@ from django.db import transaction
 from allauth.socialaccount import models as auth_models
 
 from galaxy import constants
-from galaxy import common
 from galaxy.common import logutils
 from galaxy.importer import repository as i_repo
 from galaxy.importer import exceptions as i_exc
@@ -99,8 +98,7 @@ def _import_repository(import_task, logger):
 
     if repo_info.name:
         old_name = repository.name
-        new_name = common.sanitize_content_name(repo_info.name)
-
+        new_name = repo_info.name
         if old_name != new_name:
             logger.info(
                 u'Updating repository name "{old_name}" -> "{new_name}"'


### PR DESCRIPTION
This should prevent existing repos from being renamed 

Fixes #776 
Fixes #775 
