### PR TITLE
Fix APB name parse

### DIFF
--- a/galaxy/importer/loaders/apb.py
+++ b/galaxy/importer/loaders/apb.py
@@ -150,7 +150,7 @@ class APBMetaParser(object):
 
     def parse_name(self):
         fieldname = 'name'
-        name = self._get_key(fieldname)
+        name = sanitize_content_name(self._get_key(fieldname))
         if not re.match('^[a-z0-9_]+$', name):
             raise exc.APBContentLoadError(
                 'Invalid "{0}" value in metadata. Must contain only lowercase '
@@ -190,7 +190,7 @@ class APBLoader(base.BaseLoader):
         self.log.info('Loading metadata file: {0}'.format(self.metadata_file))
         metadata = self._load_metadata()
         meta_parser = APBMetaParser(metadata, logger=self.log)
-        name = sanitize_content_name(meta_parser.parse_name())
+        name = meta_parser.parse_name()
         description = meta_parser.parse_description()
         meta_parser.check_data()
         data = {'tags': meta_parser.parse_tags()}

--- a/galaxy/importer/tests/test_apb_loader.py
+++ b/galaxy/importer/tests/test_apb_loader.py
@@ -248,7 +248,7 @@ class TestAPBMetaParser(unittest.TestCase):
     def test_parse_name(self):
         parser = apb_loader.APBMetaParser(self.data, self.log)
         name = parser.parse_name()
-        assert name == 'mssql-apb'
+        assert name == 'mssql_apb'
 
     def test_parse_description(self):
         parser = apb_loader.APBMetaParser(self.data, self.log)
@@ -354,7 +354,7 @@ class TestRoleLoader(unittest.TestCase):
         role_meta = apb.role_meta
         metadata = apb.metadata['apb_metadata']
 
-        assert apb.name == 'mssql-apb'
+        assert apb.name == 'mssql_apb'
         assert len(metadata['metadata']['dependencies']) == 1
         assert apb.description == 'Deployment of Microsoft SQL Server on Linux'
         assert role_meta['tags'] == ['database', 'mssql']


### PR DESCRIPTION
- Sanitize first, then check for invalid chars.
- Fix name test assertions