### PR TITLE
Fix search links and icon sizing

### DIFF
--- a/galaxyui/src/app/content-detail/repository/repository.component.html
+++ b/galaxyui/src/app/content-detail/repository/repository.component.html
@@ -18,34 +18,34 @@
     <div class="col-sm-8">
         <div class="repository-details">
             <div class="repo-count">
-                <i class="fa fa-download fa-2x"></i>
+                <i class="fa fa-download"></i>
                 <span class="count">{{ repositoryView.downloadCount }}</span>
-                <span class="count-label">Downloads</span>
+                <div class="count-label">Downloads</div>
             </div>
             <div class="repo-count">
-                <i class="fa fa-eye fa-2x"></i>
+                <i class="fa fa-eye"></i>
                 <span class="count">{{ repositoryView.watchersCount }}</span>
-                <span class="count-label">Watchers</span>
+                <div class="count-label">Watchers</div>
             </div>
             <div class="repo-count">
-                <i class="fa fa-star fa-2x"></i>
+                <i class="fa fa-star"></i>
                 <span class="count">{{ repositoryView.stargazersCount }}</span>
-                <span class="count-label">Stars</span>
+                <div class="count-label">Stars</div>
             </div>
             <div class="repo-count">
-                <i class="fa fa-copy fa-2x"></i>
+                <i class="fa fa-copy"></i>
                 <span class="count">{{ repositoryView.forksCount }}</span>
-                <span class="count-label">Forks</span>
+                <div class="count-label">Forks</div>
             </div>
-            <div>
+            <div class="external-links">
                 <a [href]="repositoryView.issueTrackerUrl" *ngIf="repositoryView.issueTrackerUrl"
                     target="_blank"
                     tooltip="Visit the issue tracker. Opens in a new browser tab."
+                    container="body"
                     class="btn btn-default"><i class="fa fa-bug"></i> Issue Tracker</a>
-            </div>
-            <div>
                 <a [href]="repositoryView.scmUrl" target="_blank"
-                    tooltip="Visit the repository. Opens in a new browser tab." class="btn btn-default">
+                    tooltip="Visit the repository. Opens in a new browser tab."
+                    container="body" class="btn btn-default">
                         <i [ngClass]="repositoryView.scmIconClass"></i> {{ repositoryView.scmName }} Repo</a>
             </div>
         </div>

--- a/galaxyui/src/app/content-detail/repository/repository.component.html
+++ b/galaxyui/src/app/content-detail/repository/repository.component.html
@@ -2,8 +2,12 @@
 
     <div class="col-lg-2">
         <div class="namespace-img">
-            <img class="img-wrapper" tooltip="View Author's Profile" [src]="namespace.avatar_url" (click)="viewAuthor()">
-            <a (click)="viewAuthor()"><span class="fa fa-user"></span> {{ namespace.name }}</a>
+            <a [routerLink]="['/', repositoryView.namespace]"
+                tooltip="View the author's profile." >
+                <img class="img-wrapper" [src]="namespace.avatar_url"></a>
+            <a [routerLink]="['/', repositoryView.namespace]"
+                tooltip="View the author's profile.">
+                <span class="fa fa-user"></span> {{ namespace.name }}</a>
         </div>
     </div>
 

--- a/galaxyui/src/app/content-detail/repository/repository.component.html
+++ b/galaxyui/src/app/content-detail/repository/repository.component.html
@@ -1,53 +1,65 @@
 <div class="row repository-container">
-    <div class="col-sm-4">
-        <div class="title-box">
-            <div class="icon-container">
-                <span class="fa fa-5x" [ngClass]="repositoryView.iconClass" tooltip="{{ repositoryView.tooltip }}"></span>
+
+    <div class="col-lg-2">
+        <div class="namespace-img">
+            <img class="img-wrapper" tooltip="View Author's Profile" [src]="namespace.avatar_url" (click)="viewAuthor()">
+            <a (click)="viewAuthor()"><span class="fa fa-user"></span> {{ namespace.name }}</a>
+        </div>
+    </div>
+
+    <div class="col-lg-6">
+        <div class="text-overflow-pf">
+            <div class="repo-name">
+                <span class="fa" [ngClass]="repositoryView.iconClass" tooltip="{{ repositoryView.tooltip }}"></span> {{ repositoryView.name }}
             </div>
-            <div class="title-container">
-                <div class="title">{{ repositoryView.name }}</div>
-                <div class="description">{{ repositoryView.description }}</div>
-                <a class="namespace"
-                   [href]=""
-                   (click)="viewAuthor()"
-                   tooltip="View the Author's page">
-                   <img [src]="repositoryView.avatarUrl" > {{ repositoryView.displayName }}</a>
+            <div>
+                {{ repositoryView.description }}
             </div>
         </div>
     </div>
-    <div class="col-sm-8">
-        <div class="repository-details">
-            <div class="repo-count">
-                <i class="fa fa-download"></i>
-                <span class="count">{{ repositoryView.downloadCount }}</span>
-                <div class="count-label">Downloads</div>
-            </div>
-            <div class="repo-count">
-                <i class="fa fa-eye"></i>
-                <span class="count">{{ repositoryView.watchersCount }}</span>
-                <div class="count-label">Watchers</div>
-            </div>
-            <div class="repo-count">
-                <i class="fa fa-star"></i>
-                <span class="count">{{ repositoryView.stargazersCount }}</span>
-                <div class="count-label">Stars</div>
-            </div>
-            <div class="repo-count">
-                <i class="fa fa-copy"></i>
-                <span class="count">{{ repositoryView.forksCount }}</span>
-                <div class="count-label">Forks</div>
-            </div>
-            <div class="external-links">
-                <a [href]="repositoryView.issueTrackerUrl" *ngIf="repositoryView.issueTrackerUrl"
-                    target="_blank"
-                    tooltip="Visit the issue tracker. Opens in a new browser tab."
-                    container="body"
-                    class="btn btn-default"><i class="fa fa-bug"></i> Issue Tracker</a>
-                <a [href]="repositoryView.scmUrl" target="_blank"
-                    tooltip="Visit the repository. Opens in a new browser tab."
-                    container="body" class="btn btn-default">
-                        <i [ngClass]="repositoryView.scmIconClass"></i> {{ repositoryView.scmName }} Repo</a>
-            </div>
-        </div>
+
+    <div class="col-lg-4 repository-details">
+
+        <span class="columns">
+            <ul>
+                <li class="repo-count">
+                    <i class="fa fa-download fa"></i>
+                    <span class="count">{{ repositoryView.downloadCount }}</span>
+                    <span class="count-label">Downloads</span>
+                </li>
+                <li class="repo-count">
+                    <i class="fa fa-eye fa"></i>
+                    <span class="count">{{ repositoryView.watchersCount }}</span>
+                    <span class="count-label">Watchers</span>
+                </li>
+            </ul>
+
+            <a [href]="repositoryView.issueTrackerUrl" *ngIf="repositoryView.issueTrackerUrl"
+                target="_blank"
+                tooltip="Visit the issue tracker. Opens in a new browser tab."
+                class="btn btn-default"><i class="fa fa-bug"></i> Issue Tracker</a>
+        </span>
+
+        &nbsp;
+
+        <span class="columns">
+            <ul>
+                <li class="repo-count">
+                    <i class="fa fa-star fa"></i>
+                    <span class="count">{{ repositoryView.stargazersCount }}</span>
+                    <span class="count-label">Stars</span>
+                </li>
+                <li class="repo-count">
+                    <i class="fa fa-copy fa"></i>
+                    <span class="count">{{ repositoryView.forksCount }}</span>
+                    <span class="count-label">Forks</span>
+                </li>
+            </ul>
+
+            <a [href]="repositoryView.scmUrl" target="_blank"
+                tooltip="Visit the repository. Opens in a new browser tab." class="btn btn-default">
+                    <i [ngClass]="repositoryView.scmIconClass"></i> {{ repositoryView.scmName }} Repo</a>
+        </span>
+
     </div>
 </div>

--- a/galaxyui/src/app/content-detail/repository/repository.component.less
+++ b/galaxyui/src/app/content-detail/repository/repository.component.less
@@ -26,6 +26,10 @@
         .title, .description {
             margin-bottom: 5px;
         }
+        .description {
+            font-size: 16px;
+            margin-bottom: 15px;
+        }
         .title {
             font-weight: 700;
             font-size: 22px;
@@ -49,12 +53,24 @@
         align-items: middle;
     }
 
-    .repository-details > div {
-        font-size: 14px;
-        margin-right: 20px;
-        .count {
-            font-weight: 700;
-            padding: 0 5px;
+    .repository-details { 
+        .repo-count {
+            font-size: 16px;
+            margin-right: 20px;
+            .count {
+                font-size: 14px;
+                font-weight: 700;
+                padding: 0 5px;
+            }
+            .count-label {
+                font-size: 14px;
+            }
+        }
+    }
+    
+    .external-links {
+        a:last-child {
+            margin-left: 20px;
         }
     }
 }

--- a/galaxyui/src/app/content-detail/repository/repository.component.less
+++ b/galaxyui/src/app/content-detail/repository/repository.component.less
@@ -12,65 +12,46 @@
     border-bottom: 1px solid #ccc;
     padding-bottom: 15px;
 
-    .title-box {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: nowrap;
-        justify-content: flex-start;
-        align-content: middle;
-    }
-    .icon-container {
-        margin-right: 15px;
-    }
-    .title-container {
-        .title, .description {
-            margin-bottom: 5px;
-        }
-        .description {
-            font-size: 16px;
-            margin-bottom: 15px;
-        }
-        .title {
-            font-weight: 700;
-            font-size: 22px;
-        }
-        .namespace {
-            font-size: 14px;
-            img {
-                max-height: 64px;
-                margin-right: 5px;
-            }
-        }
-        .namespace:hover {
-            cursor: pointer;
-        }
-    }
     .repository-details {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: nowrap;
-        justify-content: flex-start;
-        align-items: middle;
+        height: 120px;
+        min-width: 270px;
+
+        .columns {
+            display: inline-block;
+            vertical-align: top;
+        }
+
+        ul {
+            list-style-type: none;
+            font-size: 14px;
+            padding: 0;
+        }
     }
 
-    .repository-details { 
-        .repo-count {
-            font-size: 16px;
-            margin-right: 20px;
-            .count {
-                font-size: 14px;
-                font-weight: 700;
-                padding: 0 5px;
+    .namespace-img {
+        min-width: 150px;
+        cursor: pointer;
+
+        @media(min-width: 1260px){
+            border-right: 1px solid #ccc;
+            text-align: center;
+        }
+
+        .img-wrapper {
+            height: 120px;
+            @media(min-width: 1200px){
+                margin: auto;
             }
-            .count-label {
-                font-size: 14px;
-            }
+            padding: 0;
+            border: 0;
+            display: block;
         }
     }
-    
-    .external-links {
-        a:last-child {
-            margin-left: 20px;
-        }
+
+    .repo-name {
+        font-size: 14px;
+        color: @black;
+        font-weight: 700;
+        font-size: 18px;
     }
 }

--- a/galaxyui/src/app/content-detail/repository/repository.component.ts
+++ b/galaxyui/src/app/content-detail/repository/repository.component.ts
@@ -71,10 +71,6 @@ export class RepositoryComponent implements OnInit {
         this.setRepositoryView();
     }
 
-    viewAuthor() {
-        this.router.navigate(['/', this.repositoryView.namespace]);
-    }
-
     // private
     private setRepositoryView() {
         // Determine repoType: role, apb, multiconent

--- a/galaxyui/src/app/search/search.component.html
+++ b/galaxyui/src/app/search/search.component.html
@@ -33,11 +33,11 @@
                         <div class="list-pf-content-wrapper">
                               <div class="list-pf-main-content">
                                 <div class="list-pf-title">
-                                    <div class="content-name cursor-pointer">
+                                    <div class="content-name">
                                         <div class="icon">
                                             <i class="{{ item['iconClass'] }}"></i>
                                         </div>
-                                        <div class="name"><a [href]="" (click)="itemClicked(item)" tooltip="View content details">{{ item.name }}</a></div>
+                                        <div class="name cursor-pointer"><a [routerLink]="[item['contentLink']]" tooltip="View content details">{{ item.name }}</a></div>
                                         <div class="type">{{ item.summary_fields.content_type.name }}</div>
                                         <div class="description">
                                             {{item.description}}
@@ -61,25 +61,25 @@
                                     </div>
                                     <div class="counts">
                                         <div class="repo-count">
-                                            <i class="fa fa-download fa-2x"></i>
+                                            <i class="fa fa-download"></i>
                                             <span class="count">{{ item.download_count }}</span>
                                             <span class="count-text">Downloads</span>
                                         </div>
 
                                         <div class="repo-count">
-                                            <i class="fa fa-eye fa-2x"></i>
+                                            <i class="fa fa-eye"></i>
                                             <span class="count">{{ item.summary_fields.repository.watchers_count }}</span>
                                             <span class="count-text">Watchers</span>
                                         </div>
 
                                         <div class="repo-count">
-                                            <i class="fa fa-star fa-2x"></i>
+                                            <i class="fa fa-star"></i>
                                             <span class="count">{{ item.summary_fields.repository.stargazers_count }}</span>
                                             <span class="count-text">Stars</span>
                                         </div>
 
                                         <div class="repo-count">
-                                            <i class="fa fa-copy fa-2x"></i>
+                                            <i class="fa fa-copy"></i>
                                             <span class="count">{{ item.summary_fields.repository.forks_count }}</span>
                                             <span class="count-text">Forks</span>
                                         </div>

--- a/galaxyui/src/app/search/search.component.less
+++ b/galaxyui/src/app/search/search.component.less
@@ -114,11 +114,15 @@
     }
 
     .counts > div {
-        font-size: 12px;
+        font-size: 16px;
         margin-right: 15px;
         .count {
+            font-size: 14px;
             font-weight: 700;
             padding: 0 5px;
+        }
+        .count-text {
+            font-size: 14px;
         }
     }
     .counts div:last-child {

--- a/galaxyui/src/app/search/search.component.ts
+++ b/galaxyui/src/app/search/search.component.ts
@@ -336,17 +336,6 @@ export class SearchComponent implements OnInit, AfterViewInit {
         }
     }
 
-    itemClicked(item: Content) {
-        const namespace = item.summary_fields['namespace']['name'].toLowerCase();
-        const repository = item.summary_fields['repository']['name'].toLowerCase();
-        const name = item.name.toLowerCase();
-        if (item['repository_format'] === RepoFormats.multi) {
-            this.router.navigate(['/', namespace, repository, name]);
-        } else {
-            this.router.navigate(['/', namespace, repository]);
-        }
-    }
-
     // private
 
     private setPageSize(params: any) {
@@ -502,6 +491,14 @@ export class SearchComponent implements OnInit, AfterViewInit {
                 item['iconClass'] = ContentTypesIconClasses.plugin;
             } else {
                 item['iconClass'] = ContentTypesIconClasses[item.summary_fields['content_type']['name']];
+            }
+            // Determine navigation for item click
+            const namespace = item.summary_fields['namespace']['name'].toLowerCase();
+            const repository = item.summary_fields['repository']['name'].toLowerCase();
+            const name = item.name.toLowerCase();
+            item['contentLink'] = `/${namespace}/${repository}`;
+            if (item['repository_format'] === RepoFormats.multi) {
+                item['contentLink'] += `/${name}`;
             }
         });
         this.contentItems = data;

--- a/galaxyui/src/styles.less
+++ b/galaxyui/src/styles.less
@@ -143,6 +143,9 @@ a.failed {
         padding-left: 0;
         padding-right: 0;
     }
+    .list-pf-item:hover {
+        background-color: @white;
+    }
     @media only screen and (max-width : 992px) {
         .list-pf-description {
             padding-top: 15px;


### PR DESCRIPTION
Fixes #744 - It's now clear where to click to get to content detail, links are links (as opposed to JS functions),  and right clicking shows 'Open Link in New Tab' and 'Open Link in New Window' options.

Fixes #720 - Icon size, count number size, and count label size are now consistent between search and content detail views.

Fixes #812 - No longer changes cursor to pointer when hovering over description. Remove background color change when hovering over a list item.