### PR TITLE
Show version tag

### DIFF
--- a/galaxyui/src/app/content-detail/cards/versions/versions.component.html
+++ b/galaxyui/src/app/content-detail/cards/versions/versions.component.html
@@ -10,7 +10,7 @@
         <div class="card-list-body">
             <table>
                 <tr *ngFor="let version of versions">
-                    <td class="name">{{ version['version'] }}</td>
+                    <td class="name">{{ version['tag'] }}</td>
                     <td class="date">{{ version['date'] }}</td>
                 </tr>
             </table>


### PR DESCRIPTION
On content details, show the version 'tag', rather than the 'version'. The 'tag' is the actual git tag that maps to the version, which may include a leading 'v'. Using `ansible-galaxy`, the only way to install the version is to include the 'v', so users need to know there is a 'v'.
