### PR TITLE
Fix/tslint rules

### DIFF
--- a/galaxyui/src/app/app-routing.module.ts
+++ b/galaxyui/src/app/app-routing.module.ts
@@ -1,13 +1,13 @@
 import { NgModule }              from '@angular/core';
-import { NotFoundComponent }     from './exception-pages/not-found/not-found.component';
+import { AuthService }           from './auth/auth.service';
 import { AuthorDetailComponent } from './authors/detail/author-detail.component';
 import { ContentDetailComponent } from './content-detail/content-detail.component';
-import { AuthService }           from './auth/auth.service';
+import { NotFoundComponent }     from './exception-pages/not-found/not-found.component';
 
 import {
     ContentResolver,
-    RepositoryResolver as ContentRepositoryResolver,
-    NamespaceResolver
+    NamespaceResolver,
+    RepositoryResolver as ContentRepositoryResolver
 } from './content-detail/content-detail.resolver.service';
 
 import {
@@ -17,9 +17,9 @@ import {
 
 
 import {
+    PreloadAllModules,
     RouterModule,
-    Routes,
-    PreloadAllModules
+    Routes
 }  from '@angular/router';
 
 

--- a/galaxyui/src/app/app.component.spec.ts
+++ b/galaxyui/src/app/app.component.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, async } from '@angular/core/testing';
+import { async, TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 describe('AppComponent', () => {
   beforeEach(async(() => {

--- a/galaxyui/src/app/app.component.ts
+++ b/galaxyui/src/app/app.component.ts
@@ -23,9 +23,9 @@ import {
 } from '@angular/core';
 
 import {
-    Router,
+    NavigationEnd,
     NavigationStart,
-    NavigationEnd
+    Router
 } from '@angular/router';
 
 import { DOCUMENT }             from '@angular/common';
@@ -33,15 +33,15 @@ import { DOCUMENT }             from '@angular/common';
 import { BsModalService }       from 'ngx-bootstrap/modal';
 import { BsModalRef }           from 'ngx-bootstrap/modal/bs-modal-ref.service';
 
-import { NavigationItemConfig } from 'patternfly-ng/navigation/navigation-item-config';
 import { AboutModalConfig }     from 'patternfly-ng/modal/about-modal-config';
 import { AboutModalEvent }      from 'patternfly-ng/modal/about-modal-event';
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
+import { NavigationItemConfig } from 'patternfly-ng/navigation/navigation-item-config';
 import { Notification }         from 'patternfly-ng/notification';
+import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
 
 import { AuthService }          from './auth/auth.service';
-import { ApiRootService }       from './resources/api-root/api-root.service';
 import { ApiRoot }              from './resources/api-root/api-root';
+import { ApiRootService }       from './resources/api-root/api-root.service';
 
 
 @Component({

--- a/galaxyui/src/app/app.module.ts
+++ b/galaxyui/src/app/app.module.ts
@@ -3,8 +3,8 @@ import {
 } from '@angular/platform-browser';
 
 import {
-    NgModule,
-    CUSTOM_ELEMENTS_SCHEMA
+    CUSTOM_ELEMENTS_SCHEMA,
+    NgModule
 } from '@angular/core';
 
 import {
@@ -13,8 +13,8 @@ import {
 } from '@angular/common/http';
 
 import {
-    NavigationModule,
-    ModalModule
+    ModalModule,
+    NavigationModule
 } from 'patternfly-ng';
 
 import {
@@ -23,36 +23,36 @@ import {
     TooltipModule
 } from 'ngx-bootstrap';
 
-import { NotificationModule }         from 'patternfly-ng/notification/notification.module';
 import { NotificationService }        from 'patternfly-ng/notification/notification-service/notification.service';
+import { NotificationModule }         from 'patternfly-ng/notification/notification.module';
 
+import { AppRoutingModule }           from './app-routing.module';
+import { AppComponent }               from './app.component';
+import { AuthService }                from './auth/auth.service';
+import { AuthorsModule }              from './authors/authors.module';
+import { ContentDetailModule }        from './content-detail/content-detail.module';
+import { ExceptionPagesModule }       from './exception-pages/exception-pages.module';
 import { HomeModule }                 from './home/home.module';
 import { LoginModule }                from './login/login.module';
+import { ApiRootService }             from './resources/api-root/api-root.service';
+import { CloudPlatformService }       from './resources/cloud-platforms/cloud-platform.service';
+import { ContentBlocksService }       from './resources/content-blocks/content-blocks.service';
+import { ContentSearchService }       from './resources/content-search/content-search.service';
+import { ContentTypeService }         from './resources/content-types/content-type.service';
+import { ContentService }             from './resources/content/content.service';
+import { ImportsService }             from './resources/imports/imports.service';
+import { NamespaceService }           from './resources/namespaces/namespace.service';
+import { PlatformService }            from './resources/platforms/platform.service';
+import { ProviderSourceService }      from './resources/provider-namespaces/provider-source.service';
+import { RepositoryService }          from './resources/repositories/repository.service';
+import { RepositoryImportService }    from './resources/repository-imports/repository-import.service';
+import { TagsService }                from './resources/tags/tags.service';
+import { UserService }                from './resources/users/user.service';
 // import { MyContentModule }            from './my-content/my-content.module';
 // import { MyImportsModule }            from './my-imports/my-imports.module';
 // import { SearchModule }               from './search/search.module';
 import { UserNotificationsComponent } from './user-notifications/user-notifications.component';
-import { AuthorsModule }              from './authors/authors.module';
 import { VendorsModule }              from './vendors/vendors.module';
-import { ContentDetailModule }        from './content-detail/content-detail.module';
-import { AuthService }                from './auth/auth.service';
-import { NamespaceService }           from './resources/namespaces/namespace.service';
-import { UserService }                from './resources/users/user.service';
-import { RepositoryService }          from './resources/repositories/repository.service';
-import { ProviderSourceService }      from './resources/provider-namespaces/provider-source.service';
-import { RepositoryImportService }    from './resources/repository-imports/repository-import.service';
-import { ImportsService }             from './resources/imports/imports.service';
-import { ContentBlocksService }       from './resources/content-blocks/content-blocks.service';
-import { ContentSearchService }       from './resources/content-search/content-search.service';
-import { PlatformService }            from './resources/platforms/platform.service';
-import { ContentTypeService }         from './resources/content-types/content-type.service';
-import { CloudPlatformService }       from './resources/cloud-platforms/cloud-platform.service';
-import { TagsService }                from './resources/tags/tags.service';
-import { ContentService }             from './resources/content/content.service';
-import { AppRoutingModule }           from './app-routing.module';
-import { AppComponent }               from './app.component';
-import { ApiRootService }             from './resources/api-root/api-root.service';
-import { ExceptionPagesModule }       from './exception-pages/exception-pages.module';
 
 @NgModule({
     declarations: [

--- a/galaxyui/src/app/auth/auth.service.ts
+++ b/galaxyui/src/app/auth/auth.service.ts
@@ -11,11 +11,11 @@ import { Observable } from 'rxjs/Observable';
 import { of }         from 'rxjs/observable/of';
 
 import {
-    CanActivate,
-    Router,
-    RouterStateSnapshot,
     ActivatedRouteSnapshot,
-    Route
+    CanActivate,
+    Route,
+    Router,
+    RouterStateSnapshot
 } from '@angular/router';
 
 

--- a/galaxyui/src/app/authors/authors.component.ts
+++ b/galaxyui/src/app/authors/authors.component.ts
@@ -10,29 +10,29 @@ import {
 
 import { Action }             from 'patternfly-ng/action/action';
 import { ActionConfig }       from 'patternfly-ng/action/action-config';
-import { ListEvent }          from 'patternfly-ng/list/list-event';
-import { ListConfig }         from 'patternfly-ng/list/basic-list/list-config';
-import { FilterConfig }       from 'patternfly-ng/filter/filter-config';
-import { ToolbarConfig }      from 'patternfly-ng/toolbar/toolbar-config';
-import { FilterType }         from 'patternfly-ng/filter/filter-type';
-import { SortConfig }         from 'patternfly-ng/sort/sort-config';
-import { FilterField }        from 'patternfly-ng/filter/filter-field';
-import { SortField }          from 'patternfly-ng/sort/sort-field';
-import { ToolbarView }        from 'patternfly-ng/toolbar/toolbar-view';
-import { SortEvent }          from 'patternfly-ng/sort/sort-event';
-import { Filter }             from 'patternfly-ng/filter/filter';
-import { FilterEvent }        from 'patternfly-ng/filter/filter-event';
 import { EmptyStateConfig }   from 'patternfly-ng/empty-state/empty-state-config';
+import { Filter }             from 'patternfly-ng/filter/filter';
+import { FilterConfig }       from 'patternfly-ng/filter/filter-config';
+import { FilterEvent }        from 'patternfly-ng/filter/filter-event';
+import { FilterField }        from 'patternfly-ng/filter/filter-field';
+import { FilterType }         from 'patternfly-ng/filter/filter-type';
+import { ListConfig }         from 'patternfly-ng/list/basic-list/list-config';
+import { ListEvent }          from 'patternfly-ng/list/list-event';
 import { PaginationConfig }   from 'patternfly-ng/pagination/pagination-config';
 import { PaginationEvent }    from 'patternfly-ng/pagination/pagination-event';
+import { SortConfig }         from 'patternfly-ng/sort/sort-config';
+import { SortEvent }          from 'patternfly-ng/sort/sort-event';
+import { SortField }          from 'patternfly-ng/sort/sort-field';
+import { ToolbarConfig }      from 'patternfly-ng/toolbar/toolbar-config';
+import { ToolbarView }        from 'patternfly-ng/toolbar/toolbar-view';
 
-import { NamespaceService }   from '../resources/namespaces/namespace.service';
 import { Namespace }          from '../resources/namespaces/namespace';
+import { NamespaceService }   from '../resources/namespaces/namespace.service';
 
 import {
     ContentTypes,
-    ContentTypesPluralChoices,
-    ContentTypesIconClasses
+    ContentTypesIconClasses,
+    ContentTypesPluralChoices
 } from '../enums/content-types.enum';
 
 @Component({

--- a/galaxyui/src/app/authors/authors.module.ts
+++ b/galaxyui/src/app/authors/authors.module.ts
@@ -1,20 +1,20 @@
-import { NgModule }        from '@angular/core';
 import { CommonModule }    from '@angular/common';
+import { NgModule }        from '@angular/core';
 
+import { TooltipModule }           from 'ngx-bootstrap/tooltip';
 import { ActionModule }            from 'patternfly-ng/action/action.module';
 import { EmptyStateModule }        from 'patternfly-ng/empty-state/empty-state.module';
+import { FilterModule }            from 'patternfly-ng/filter/filter.module';
 import { ListModule }              from 'patternfly-ng/list/basic-list/list.module';
 import { PaginationModule }        from 'patternfly-ng/pagination/pagination.module';
-import { FilterModule }            from 'patternfly-ng/filter/filter.module';
 import { ToolbarModule }           from 'patternfly-ng/toolbar/toolbar.module';
-import { TooltipModule }           from 'ngx-bootstrap/tooltip';
 
-import { AuthorsRoutingModule }      from './authors.routing.module';
-import { AuthorsComponent }          from './authors.component';
-import { AuthorDetailComponent }     from './detail/author-detail.component';
-import { DetailActionsComponent }    from './detail/detail-actions/detail-actions.component';
 import { PageHeaderModule }          from '../page-header/page-header.module';
 import { PageLoadingModule }         from '../page-loading/page-loading.module';
+import { AuthorsComponent }          from './authors.component';
+import { AuthorsRoutingModule }      from './authors.routing.module';
+import { AuthorDetailComponent }     from './detail/author-detail.component';
+import { DetailActionsComponent }    from './detail/detail-actions/detail-actions.component';
 
 
 @NgModule({

--- a/galaxyui/src/app/authors/authors.resolver.service.ts
+++ b/galaxyui/src/app/authors/authors.resolver.service.ts
@@ -12,12 +12,12 @@ import {
 import { Observable }            from 'rxjs/Observable';
 import { forkJoin }              from 'rxjs/observable/forkJoin';
 
-import { ContentService }        from '../resources/content/content.service';
 import { Content }               from '../resources/content/content';
-import { NamespaceService }      from '../resources/namespaces/namespace.service';
+import { ContentService }        from '../resources/content/content.service';
 import { Namespace }             from '../resources/namespaces/namespace';
-import { RepositoryService }     from '../resources/repositories/repository.service';
+import { NamespaceService }      from '../resources/namespaces/namespace.service';
 import { PagedResponse }         from '../resources/paged-response';
+import { RepositoryService }     from '../resources/repositories/repository.service';
 
 @Injectable()
 export class NamespaceListResolver implements Resolve<PagedResponse> {

--- a/galaxyui/src/app/authors/authors.routing.module.ts
+++ b/galaxyui/src/app/authors/authors.routing.module.ts
@@ -4,8 +4,8 @@ import {
 } from '@angular/core';
 
 import {
-    Routes,
-    RouterModule
+    RouterModule,
+    Routes
 } from '@angular/router';
 
 import {

--- a/galaxyui/src/app/authors/detail/author-detail.component.ts
+++ b/galaxyui/src/app/authors/detail/author-detail.component.ts
@@ -12,37 +12,37 @@ import * as moment            from 'moment';
 
 import { Action }             from 'patternfly-ng/action/action';
 import { ActionConfig }       from 'patternfly-ng/action/action-config';
-import { ListEvent }          from 'patternfly-ng/list/list-event';
-import { ListConfig }         from 'patternfly-ng/list/basic-list/list-config';
-import { FilterConfig }       from 'patternfly-ng/filter/filter-config';
-import { ToolbarConfig }      from 'patternfly-ng/toolbar/toolbar-config';
-import { FilterType }         from 'patternfly-ng/filter/filter-type';
-import { SortConfig }         from 'patternfly-ng/sort/sort-config';
-import { FilterField }        from 'patternfly-ng/filter/filter-field';
-import { SortField }          from 'patternfly-ng/sort/sort-field';
-import { ToolbarView }        from 'patternfly-ng/toolbar/toolbar-view';
-import { SortEvent }          from 'patternfly-ng/sort/sort-event';
-import { Filter }             from 'patternfly-ng/filter/filter';
-import { FilterEvent }        from 'patternfly-ng/filter/filter-event';
 import { EmptyStateConfig }   from 'patternfly-ng/empty-state/empty-state-config';
+import { Filter }             from 'patternfly-ng/filter/filter';
+import { FilterConfig }       from 'patternfly-ng/filter/filter-config';
+import { FilterEvent }        from 'patternfly-ng/filter/filter-event';
+import { FilterField }        from 'patternfly-ng/filter/filter-field';
+import { FilterType }         from 'patternfly-ng/filter/filter-type';
+import { ListConfig }         from 'patternfly-ng/list/basic-list/list-config';
+import { ListEvent }          from 'patternfly-ng/list/list-event';
 import { PaginationConfig }   from 'patternfly-ng/pagination/pagination-config';
 import { PaginationEvent }    from 'patternfly-ng/pagination/pagination-event';
+import { SortConfig }         from 'patternfly-ng/sort/sort-config';
+import { SortEvent }          from 'patternfly-ng/sort/sort-event';
+import { SortField }          from 'patternfly-ng/sort/sort-field';
+import { ToolbarConfig }      from 'patternfly-ng/toolbar/toolbar-config';
+import { ToolbarView }        from 'patternfly-ng/toolbar/toolbar-view';
 
 import { Namespace }          from '../../resources/namespaces/namespace';
 
-import { RepositoryService }  from '../../resources/repositories/repository.service';
 import { Repository }         from '../../resources/repositories/repository';
+import { RepositoryService }  from '../../resources/repositories/repository.service';
 
 import {
     ContentTypes,
-    ContentTypesPluralChoices,
-    ContentTypesIconClasses
+    ContentTypesIconClasses,
+    ContentTypesPluralChoices
 } from '../../enums/content-types.enum';
 
 import {
     RepoFormats,
-    RepoFormatsTooltips,
-    RepoFormatsIconClasses
+    RepoFormatsIconClasses,
+    RepoFormatsTooltips
 } from '../../enums/repo-types.enum';
 
 

--- a/galaxyui/src/app/authors/detail/detail-actions/detail-actions.component.ts
+++ b/galaxyui/src/app/authors/detail/detail-actions/detail-actions.component.ts
@@ -1,7 +1,7 @@
 import {
     Component,
-    OnInit,
-    Input
+    Input,
+    OnInit
 } from '@angular/core';
 
 import { Router }           from '@angular/router';
@@ -13,8 +13,8 @@ import { Repository }       from '../../../resources/repositories/repository';
 
 import {
     RepoFormats,
-    RepoFormatsTooltips,
-    RepoFormatsIconClasses
+    RepoFormatsIconClasses,
+    RepoFormatsTooltips
 } from '../../../enums/repo-types.enum';
 
 

--- a/galaxyui/src/app/content-detail/cards/info/card-info.component.ts
+++ b/galaxyui/src/app/content-detail/cards/info/card-info.component.ts
@@ -5,10 +5,10 @@ import {
 } from '@angular/core';
 
 import { CardConfig }     from 'patternfly-ng/card/basic-card/card-config';
+import { RepoFormats }    from '../../../enums/repo-types.enum';
+import { ViewTypes }      from '../../../enums/view-types.enum';
 import { Content }        from '../../../resources/content/content';
 import { Repository }     from '../../../resources/repositories/repository';
-import { ViewTypes }      from '../../../enums/view-types.enum';
-import { RepoFormats }    from '../../../enums/repo-types.enum';
 
 import { ContentTypesPlural }   from '../../../enums/content-types.enum';
 

--- a/galaxyui/src/app/content-detail/cards/platforms/platforms.component.ts
+++ b/galaxyui/src/app/content-detail/cards/platforms/platforms.component.ts
@@ -6,8 +6,8 @@ import {
 
 import { CardConfig }     from 'patternfly-ng/card/basic-card/card-config';
 import { Content }        from '../../../resources/content/content';
-import { Repository }     from '../../../resources/repositories/repository';
 import { Platform }       from '../../../resources/platforms/platform';
+import { Repository }     from '../../../resources/repositories/repository';
 
 @Component({
     selector: 'card-platforms',

--- a/galaxyui/src/app/content-detail/content-detail.component.ts
+++ b/galaxyui/src/app/content-detail/content-detail.component.ts
@@ -16,18 +16,18 @@ import { forkJoin }         from 'rxjs/observable/forkJoin';
 import { EmptyStateConfig } from 'patternfly-ng/empty-state/empty-state-config';
 
 import {
-    ActionConfig,
-    Action
+    Action,
+    ActionConfig
 } from 'patternfly-ng/action';
 
-import { Repository }       from '../resources/repositories/repository';
+import { ContentTypes }     from '../enums/content-types.enum';
+import { RepoFormats }      from '../enums/repo-types.enum';
+import { ViewTypes }        from '../enums/view-types.enum';
 import { Content }          from '../resources/content/content';
 import { Namespace }        from '../resources/namespaces/namespace';
 import { PagedResponse }    from '../resources/paged-response';
+import { Repository }       from '../resources/repositories/repository';
 import { RepoChangeEvent }  from './repository/repository.component';
-import { ViewTypes }        from '../enums/view-types.enum';
-import { RepoFormats }      from '../enums/repo-types.enum';
-import { ContentTypes }     from '../enums/content-types.enum';
 
 import { ContentService }   from '../resources/content/content.service';
 

--- a/galaxyui/src/app/content-detail/content-detail.module.ts
+++ b/galaxyui/src/app/content-detail/content-detail.module.ts
@@ -1,30 +1,30 @@
-import { NgModule }     from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule }     from '@angular/core';
 
-import { EmptyStateModule }            from 'patternfly-ng/empty-state/empty-state.module';
 import { CardModule }                  from 'patternfly-ng/card/basic-card/card.module';
+import { EmptyStateModule }            from 'patternfly-ng/empty-state/empty-state.module';
+import { FilterModule }                from 'patternfly-ng/filter/filter.module';
 import { ListModule }                  from 'patternfly-ng/list/basic-list/list.module';
 import { PaginationModule }            from 'patternfly-ng/pagination/pagination.module';
-import { FilterModule }                from 'patternfly-ng/filter/filter.module';
 
 import { TooltipModule }               from 'ngx-bootstrap/tooltip';
 
 import { UtilitiesModule }             from '../utilities/utilities.module';
 
-import { ContentDetailRoutingModule }  from './content-detail.routing.module';
-import { ContentDetailComponent }      from './content-detail.component';
-import { RepositoryComponent }         from './repository/repository.component';
-import { ModuleUtilsComponent }        from './content/module-utils/module-utils.component';
-import { RolesComponent }              from './content/roles/roles.component';
-import { ModulesComponent }            from './content/modules/modules.component';
-import { PluginsComponent }            from './content/plugins/plugins.component';
+import { PageHeaderModule }            from '../page-header/page-header.module';
+import { PageLoadingModule }           from '../page-loading/page-loading.module';
+import { CardCloudPlatformsComponent } from './cards/cloud-platforms/cloud-platforms.component';
+import { CardDependenciesComponent }   from './cards/dependencies/dependencies.component';
 import { CardInfoComponent }           from './cards/info/card-info.component';
 import { CardPlatformsComponent }      from './cards/platforms/platforms.component';
 import { CardVersionsComponent }       from './cards/versions/versions.component';
-import { CardCloudPlatformsComponent } from './cards/cloud-platforms/cloud-platforms.component';
-import { CardDependenciesComponent }   from './cards/dependencies/dependencies.component';
-import { PageHeaderModule }            from '../page-header/page-header.module';
-import { PageLoadingModule }           from '../page-loading/page-loading.module';
+import { ContentDetailComponent }      from './content-detail.component';
+import { ContentDetailRoutingModule }  from './content-detail.routing.module';
+import { ModuleUtilsComponent }        from './content/module-utils/module-utils.component';
+import { ModulesComponent }            from './content/modules/modules.component';
+import { PluginsComponent }            from './content/plugins/plugins.component';
+import { RolesComponent }              from './content/roles/roles.component';
+import { RepositoryComponent }         from './repository/repository.component';
 
 
 @NgModule({

--- a/galaxyui/src/app/content-detail/content-detail.resolver.service.ts
+++ b/galaxyui/src/app/content-detail/content-detail.resolver.service.ts
@@ -12,12 +12,12 @@ import {
 import { Observable }            from 'rxjs/Observable';
 import { forkJoin }              from 'rxjs/observable/forkJoin';
 
-import { ContentService }        from '../resources/content/content.service';
 import { Content }               from '../resources/content/content';
-import { RepositoryService }     from '../resources/repositories/repository.service';
-import { Repository }            from '../resources/repositories/repository';
-import { NamespaceService }      from '../resources/namespaces/namespace.service';
+import { ContentService }        from '../resources/content/content.service';
 import { Namespace }             from '../resources/namespaces/namespace';
+import { NamespaceService }      from '../resources/namespaces/namespace.service';
+import { Repository }            from '../resources/repositories/repository';
+import { RepositoryService }     from '../resources/repositories/repository.service';
 
 @Injectable()
 export class ContentResolver implements Resolve<Content[]> {

--- a/galaxyui/src/app/content-detail/content-detail.routing.module.ts
+++ b/galaxyui/src/app/content-detail/content-detail.routing.module.ts
@@ -1,15 +1,15 @@
 import { NgModule } from '@angular/core';
 
 import {
-    Routes,
-    RouterModule
+    RouterModule,
+    Routes
 } from '@angular/router';
 
 import { ContentDetailComponent } from './content-detail.component';
 import {
     ContentResolver,
-    RepositoryResolver,
-    NamespaceResolver
+    NamespaceResolver,
+    RepositoryResolver
 } from './content-detail.resolver.service';
 
 const routes: Routes = [

--- a/galaxyui/src/app/content-detail/content/module-utils/module-utils.component.ts
+++ b/galaxyui/src/app/content-detail/content/module-utils/module-utils.component.ts
@@ -6,22 +6,22 @@ import {
 
 import { EmptyStateConfig }  from 'patternfly-ng/empty-state/empty-state-config';
 
-import { ListEvent }         from 'patternfly-ng/list/list-event';
 import { ListConfig }        from 'patternfly-ng/list/basic-list/list-config';
+import { ListEvent }         from 'patternfly-ng/list/list-event';
 
 import { Content }           from '../../../resources/content/content';
 import { ContentService }    from '../../../resources/content/content.service';
-import { Repository }        from '../../../resources/repositories/repository';
 import { PagedResponse }     from '../../../resources/paged-response';
+import { Repository }        from '../../../resources/repositories/repository';
 
 import { ContentTypes }      from '../../../enums/content-types.enum';
 
+import { Filter }            from 'patternfly-ng/filter/filter';
 import { FilterConfig }      from 'patternfly-ng/filter/filter-config';
-import { FilterField }       from 'patternfly-ng/filter/filter-field';
 import { FilterEvent }       from 'patternfly-ng/filter/filter-event';
+import { FilterField }       from 'patternfly-ng/filter/filter-field';
 import { FilterQuery }       from 'patternfly-ng/filter/filter-query';
 import { FilterType }        from 'patternfly-ng/filter/filter-type';
-import { Filter }            from 'patternfly-ng/filter/filter';
 
 import { PaginationConfig }  from 'patternfly-ng/pagination/pagination-config';
 import { PaginationEvent }   from 'patternfly-ng/pagination/pagination-event';

--- a/galaxyui/src/app/content-detail/content/modules/modules.component.ts
+++ b/galaxyui/src/app/content-detail/content/modules/modules.component.ts
@@ -6,22 +6,22 @@ import {
 
 import { EmptyStateConfig }  from 'patternfly-ng/empty-state/empty-state-config';
 
-import { ListEvent }         from 'patternfly-ng/list/list-event';
 import { ListConfig }        from 'patternfly-ng/list/basic-list/list-config';
+import { ListEvent }         from 'patternfly-ng/list/list-event';
 
 import { Content }           from '../../../resources/content/content';
 import { ContentService }    from '../../../resources/content/content.service';
-import { Repository }        from '../../../resources/repositories/repository';
 import { PagedResponse }     from '../../../resources/paged-response';
+import { Repository }        from '../../../resources/repositories/repository';
 
 import { ContentTypes }      from '../../../enums/content-types.enum';
 
+import { Filter }            from 'patternfly-ng/filter/filter';
 import { FilterConfig }      from 'patternfly-ng/filter/filter-config';
-import { FilterField }       from 'patternfly-ng/filter/filter-field';
 import { FilterEvent }       from 'patternfly-ng/filter/filter-event';
+import { FilterField }       from 'patternfly-ng/filter/filter-field';
 import { FilterQuery }       from 'patternfly-ng/filter/filter-query';
 import { FilterType }        from 'patternfly-ng/filter/filter-type';
-import { Filter }            from 'patternfly-ng/filter/filter';
 
 import { PaginationConfig }  from 'patternfly-ng/pagination/pagination-config';
 import { PaginationEvent }   from 'patternfly-ng/pagination/pagination-event';

--- a/galaxyui/src/app/content-detail/content/plugins/plugins.component.ts
+++ b/galaxyui/src/app/content-detail/content/plugins/plugins.component.ts
@@ -6,13 +6,13 @@ import {
 
 import { EmptyStateConfig }  from 'patternfly-ng/empty-state/empty-state-config';
 
-import { ListEvent }         from 'patternfly-ng/list/list-event';
 import { ListConfig }        from 'patternfly-ng/list/basic-list/list-config';
+import { ListEvent }         from 'patternfly-ng/list/list-event';
 
 import { Content }           from '../../../resources/content/content';
 import { ContentService }    from '../../../resources/content/content.service';
-import { Repository }        from '../../../resources/repositories/repository';
 import { PagedResponse }     from '../../../resources/paged-response';
+import { Repository }        from '../../../resources/repositories/repository';
 
 import { ContentTypes }      from '../../../enums/content-types.enum';
 
@@ -21,12 +21,12 @@ import {
     PluginTypes
 } from '../../../enums/plugin-types.enum';
 
+import { Filter }            from 'patternfly-ng/filter/filter';
 import { FilterConfig }      from 'patternfly-ng/filter/filter-config';
-import { FilterField }       from 'patternfly-ng/filter/filter-field';
 import { FilterEvent }       from 'patternfly-ng/filter/filter-event';
+import { FilterField }       from 'patternfly-ng/filter/filter-field';
 import { FilterQuery }       from 'patternfly-ng/filter/filter-query';
 import { FilterType }        from 'patternfly-ng/filter/filter-type';
-import { Filter }            from 'patternfly-ng/filter/filter';
 
 import { PaginationConfig }  from 'patternfly-ng/pagination/pagination-config';
 import { PaginationEvent }   from 'patternfly-ng/pagination/pagination-event';

--- a/galaxyui/src/app/content-detail/content/roles/roles.component.ts
+++ b/galaxyui/src/app/content-detail/content/roles/roles.component.ts
@@ -4,22 +4,22 @@ import {
     OnInit
 } from '@angular/core';
 
-import { ListEvent }         from 'patternfly-ng/list/list-event';
 import { ListConfig }        from 'patternfly-ng/list/basic-list/list-config';
+import { ListEvent }         from 'patternfly-ng/list/list-event';
 
 import { Content }           from '../../../resources/content/content';
 import { ContentService }    from '../../../resources/content/content.service';
-import { Repository }        from '../../../resources/repositories/repository';
 import { PagedResponse }     from '../../../resources/paged-response';
+import { Repository }        from '../../../resources/repositories/repository';
 
 import { ContentTypes }      from '../../../enums/content-types.enum';
 
+import { Filter }            from 'patternfly-ng/filter/filter';
 import { FilterConfig }      from 'patternfly-ng/filter/filter-config';
-import { FilterField }       from 'patternfly-ng/filter/filter-field';
 import { FilterEvent }       from 'patternfly-ng/filter/filter-event';
+import { FilterField }       from 'patternfly-ng/filter/filter-field';
 import { FilterQuery }       from 'patternfly-ng/filter/filter-query';
 import { FilterType }        from 'patternfly-ng/filter/filter-type';
-import { Filter }            from 'patternfly-ng/filter/filter';
 
 import { PaginationConfig }  from 'patternfly-ng/pagination/pagination-config';
 import { PaginationEvent }   from 'patternfly-ng/pagination/pagination-event';

--- a/galaxyui/src/app/content-detail/repository/repository.component.ts
+++ b/galaxyui/src/app/content-detail/repository/repository.component.ts
@@ -2,23 +2,23 @@ import {
     Component,
     EventEmitter,
     Input,
-    Output,
-    OnInit
+    OnInit,
+    Output
 } from '@angular/core';
 
 import {
     Router
 } from '@angular/router';
 
-import { Repository }       from '../../resources/repositories/repository';
 import { Content }          from '../../resources/content/content';
-import { Namespace }        from '../../resources/namespaces/namespace';
 import { ContentService }   from '../../resources/content/content.service';
+import { Namespace }        from '../../resources/namespaces/namespace';
+import { Repository }       from '../../resources/repositories/repository';
 
 import {
     RepoFormats,
-    RepoFormatsTooltips,
-    RepoFormatsIconClasses
+    RepoFormatsIconClasses,
+    RepoFormatsTooltips
 } from '../../enums/repo-types.enum';
 
 import * as moment          from 'moment';

--- a/galaxyui/src/app/exception-pages/access-denied/access-denied.component.ts
+++ b/galaxyui/src/app/exception-pages/access-denied/access-denied.component.ts
@@ -15,8 +15,8 @@ import {
 } from 'patternfly-ng/empty-state';
 
 import {
-    ActionConfig,
-    Action
+    Action,
+    ActionConfig
 } from 'patternfly-ng/action';
 
 @Component({

--- a/galaxyui/src/app/exception-pages/exception-pages.module.ts
+++ b/galaxyui/src/app/exception-pages/exception-pages.module.ts
@@ -1,13 +1,13 @@
-import { NgModule }     from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule }     from '@angular/core';
 
 import { ActionModule }     from 'patternfly-ng/action/action.module';
 import { EmptyStateModule } from 'patternfly-ng/empty-state/empty-state.module';
 
 import { PageHeaderModule }            from '../page-header/page-header.module';
 import { AccessDeniedComponent }       from './access-denied/access-denied.component';
-import { NotFoundComponent }           from './not-found/not-found.component';
 import { ExceptionPagesRoutingModule } from './exception-pages.routing.module';
+import { NotFoundComponent }           from './not-found/not-found.component';
 
 @NgModule({
     declarations: [

--- a/galaxyui/src/app/exception-pages/not-found/not-found.component.ts
+++ b/galaxyui/src/app/exception-pages/not-found/not-found.component.ts
@@ -15,8 +15,8 @@ import {
 } from 'patternfly-ng/empty-state';
 
 import {
-    ActionConfig,
-    Action
+    Action,
+    ActionConfig
 } from 'patternfly-ng/action';
 
 @Component({

--- a/galaxyui/src/app/home/carousel/carousel.component.ts
+++ b/galaxyui/src/app/home/carousel/carousel.component.ts
@@ -1,8 +1,8 @@
 import {
+    AfterViewInit,
     Component,
     Input,
-    OnInit,
-    AfterViewInit
+    OnInit
 } from '@angular/core';
 
 import {

--- a/galaxyui/src/app/home/home.component.ts
+++ b/galaxyui/src/app/home/home.component.ts
@@ -1,7 +1,7 @@
 import {
+    AfterViewInit,
     Component,
-    OnInit,
-    AfterViewInit
+    OnInit
 } from '@angular/core';
 
 import {

--- a/galaxyui/src/app/home/home.module.ts
+++ b/galaxyui/src/app/home/home.module.ts
@@ -1,15 +1,15 @@
 import {
-    NgModule,
-    CUSTOM_ELEMENTS_SCHEMA
+    CUSTOM_ELEMENTS_SCHEMA,
+    NgModule
 } from '@angular/core';
 
 import { CommonModule }         from '@angular/common';
 import { FormsModule }          from '@angular/forms';
 
 import { CarouselComponent }    from './carousel/carousel.component';
-import { PopularComponent }     from './popular/popular.component';
 import { HomeComponent }        from './home.component';
 import { HomeRoutingModule }    from './home.routing.module';
+import { PopularComponent }     from './popular/popular.component';
 
 import { CardModule }           from 'patternfly-ng/card/basic-card/card.module';
 

--- a/galaxyui/src/app/home/home.resolver.service.ts
+++ b/galaxyui/src/app/home/home.resolver.service.ts
@@ -12,10 +12,10 @@ import {
 
 import { Observable }            from 'rxjs/Observable';
 
-import { ContentBlocksService }  from '../resources/content-blocks/content-blocks.service';
 import { ContentBlock }          from '../resources/content-blocks/content-block';
-import { NamespaceService }      from '../resources/namespaces/namespace.service';
+import { ContentBlocksService }  from '../resources/content-blocks/content-blocks.service';
 import { Namespace }             from '../resources/namespaces/namespace';
+import { NamespaceService }      from '../resources/namespaces/namespace.service';
 import { PagedResponse }         from '../resources/paged-response';
 
 @Injectable()

--- a/galaxyui/src/app/home/home.routing.module.ts
+++ b/galaxyui/src/app/home/home.routing.module.ts
@@ -12,8 +12,8 @@ import {
 } from './home.component';
 
 import {
-    VendorListResolver,
-    ContentBlockResolver
+    ContentBlockResolver,
+    VendorListResolver
 } from './home.resolver.service';
 
 const homeRoutes: Routes = [

--- a/galaxyui/src/app/home/popular/popular.component.ts
+++ b/galaxyui/src/app/home/popular/popular.component.ts
@@ -1,8 +1,8 @@
 import {
+    AfterViewInit,
     Component,
-    OnInit,
     Input,
-    AfterViewInit
+    OnInit
 } from '@angular/core';
 
 import {

--- a/galaxyui/src/app/my-content/add-repository-modal/add-repository-modal.component.ts
+++ b/galaxyui/src/app/my-content/add-repository-modal/add-repository-modal.component.ts
@@ -4,20 +4,20 @@ import {
 } from '@angular/core';
 
 import { EmptyStateConfig }        from 'patternfly-ng/empty-state/empty-state-config';
-import { ListEvent }               from 'patternfly-ng/list/list-event';
 import { ListConfig }              from 'patternfly-ng/list/basic-list/list-config';
+import { ListEvent }               from 'patternfly-ng/list/list-event';
 
-import { BsModalRef }              from 'ngx-bootstrap';
 import { cloneDeep }               from 'lodash';
+import { BsModalRef }              from 'ngx-bootstrap';
 
 import { Subject }                 from 'rxjs';
-import { forkJoin }                from 'rxjs/observable/forkJoin';
 import { Observable }              from 'rxjs/Observable';
+import { forkJoin }                from 'rxjs/observable/forkJoin';
 
 import { Namespace }               from '../../resources/namespaces/namespace';
 import { ProviderSourceService }   from '../../resources/provider-namespaces/provider-source.service';
-import { RepositoryService }       from '../../resources/repositories/repository.service';
 import { Repository }              from '../../resources/repositories/repository';
+import { RepositoryService }       from '../../resources/repositories/repository.service';
 import { RepositoryImport }        from '../../resources/repository-imports/repository-import';
 import { RepositoryImportService } from '../../resources/repository-imports/repository-import.service';
 

--- a/galaxyui/src/app/my-content/my-content.module.ts
+++ b/galaxyui/src/app/my-content/my-content.module.ts
@@ -1,5 +1,5 @@
-import { NgModule }     from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule }     from '@angular/core';
 
 import {
     FormsModule,
@@ -14,19 +14,19 @@ import {
 } from 'ngx-bootstrap';
 
 
+import { TooltipModule }    from 'ngx-bootstrap/tooltip';
+import { ModalModule }      from 'patternfly-ng';
 import { ActionModule }     from 'patternfly-ng/action/action.module';
 import { EmptyStateModule } from 'patternfly-ng/empty-state/empty-state.module';
 import { FilterModule }     from 'patternfly-ng/filter/filter.module';
-import { ToolbarModule }    from 'patternfly-ng/toolbar/toolbar.module';
-import { TooltipModule }    from 'ngx-bootstrap/tooltip';
 import { ListModule }       from 'patternfly-ng/list/basic-list/list.module';
-import { ModalModule }      from 'patternfly-ng';
 import { PaginationModule } from 'patternfly-ng/pagination/pagination.module';
+import { ToolbarModule }    from 'patternfly-ng/toolbar/toolbar.module';
 
-import { NamespaceListComponent }             from './namespace-list/namespace-list.component';
 import { NamespaceDetailComponent }           from './namespace-detail/namespace-detail.component';
-import { RepositoriesContentComponent }       from './namespace-list/content/repositories-content/repositories-content.component';
 import { OwnersContentComponent }             from './namespace-list/content/owners-content/owners-content.component';
+import { RepositoriesContentComponent }       from './namespace-list/content/repositories-content/repositories-content.component';
+import { NamespaceListComponent }             from './namespace-list/namespace-list.component';
 
 import {
     ProviderNamespacesContentComponent

--- a/galaxyui/src/app/my-content/my-content.routing.module.ts
+++ b/galaxyui/src/app/my-content/my-content.routing.module.ts
@@ -9,12 +9,12 @@ import { AuthService }              from '../auth/auth.service';
 import { NamespaceDetailComponent } from './namespace-detail/namespace-detail.component';
 
 import {
-    NamespaceDetailResolver,
-    MeResolver
+    MeResolver,
+    NamespaceDetailResolver
 }  from './namespace-detail/namespace-detail.resolver.service';
 
-import { NamespaceListComponent }   from './namespace-list/namespace-list.component';
 import { NamespaceListResolver }    from './namespace-list/namespace-list-resolver.service';
+import { NamespaceListComponent }   from './namespace-list/namespace-list.component';
 
 const myContentRoutes: Routes = [
     {

--- a/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.ts
+++ b/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.ts
@@ -4,7 +4,7 @@ import {
     OnInit
 } from '@angular/core';
 
-import { Router, ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { cloneDeep } from 'lodash';
 
@@ -24,11 +24,11 @@ import { FilterComponent }       from 'patternfly-ng/filter/filter.component';
 import { Me }                    from '../../auth/auth.service';
 import { Namespace }             from '../../resources/namespaces/namespace';
 import { NamespaceService }      from '../../resources/namespaces/namespace.service';
-import { UserService }           from '../../resources/users/user.service';
-import { User }                  from '../../resources/users/user';
 import { ProviderNamespace }     from '../../resources/provider-namespaces/provider-namespace';
 import { ProviderSource }        from '../../resources/provider-namespaces/provider-source';
 import { ProviderSourceService } from '../../resources/provider-namespaces/provider-source.service';
+import { User }                  from '../../resources/users/user';
+import { UserService }           from '../../resources/users/user.service';
 
 class Owner {
     username: string;

--- a/galaxyui/src/app/my-content/namespace-detail/namespace-detail.resolver.service.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-detail/namespace-detail.resolver.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { NamespaceDetailResolver } from './namespace-detail-resolver.service';
 

--- a/galaxyui/src/app/my-content/namespace-detail/namespace-detail.resolver.service.ts
+++ b/galaxyui/src/app/my-content/namespace-detail/namespace-detail.resolver.service.ts
@@ -5,10 +5,10 @@ import { Injectable }        from '@angular/core';
 import { Observable }        from 'rxjs/Observable';
 
 import {
-    Router,
+    ActivatedRouteSnapshot,
     Resolve,
-    RouterStateSnapshot,
-    ActivatedRouteSnapshot
+    Router,
+    RouterStateSnapshot
 } from '@angular/router';
 
 import { Namespace }         from '../../resources/namespaces/namespace';

--- a/galaxyui/src/app/my-content/namespace-list/action/action.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/action/action.component.ts
@@ -2,8 +2,8 @@ import {
     Component,
     EventEmitter,
     Input,
-    Output,
     OnInit,
+    Output,
     TemplateRef,
     ViewChild,
     ViewEncapsulation
@@ -12,8 +12,8 @@ import {
 import { Action }           from 'patternfly-ng/action/action';
 import { ActionConfig }     from 'patternfly-ng/action/action-config';
 
-import { Namespace }        from '../../../resources/namespaces/namespace';
 import { AuthService }      from '../../../auth/auth.service';
+import { Namespace }        from '../../../resources/namespaces/namespace';
 
 
 @Component({

--- a/galaxyui/src/app/my-content/namespace-list/content/owners-content/owners-content.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/owners-content/owners-content.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, ViewEncapsulation } from '@angular/core';
+import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { Namespace }                                   from '../../../../resources/namespaces/namespace';
 
 @Component({

--- a/galaxyui/src/app/my-content/namespace-list/content/provider-namespaces-content/provider-namespaces-content.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/provider-namespaces-content/provider-namespaces-content.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, ViewEncapsulation } from '@angular/core';
+import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 
 import { Namespace }                                   from '../../../../resources/namespaces/namespace';
 

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/action/action.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/action/action.component.ts
@@ -2,8 +2,8 @@ import {
     Component,
     EventEmitter,
     Input,
-    Output,
     OnInit,
+    Output,
     TemplateRef,
     ViewChild,
     ViewEncapsulation
@@ -12,8 +12,8 @@ import {
 import { Action }           from 'patternfly-ng/action/action';
 import { ActionConfig }     from 'patternfly-ng/action/action-config';
 
-import { Repository }        from '../../../../../resources/repositories/repository';
 import { AuthService }      from '../../../../../auth/auth.service';
+import { Repository }        from '../../../../../resources/repositories/repository';
 
 
 @Component({

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.ts
@@ -5,20 +5,20 @@ import {
     } from '@angular/core';
 
 import {
+    AbstractControl,
     FormControl,
-    Validators,
     ValidatorFn,
-    AbstractControl
+    Validators
     } from '@angular/forms';
 
 import { BsModalRef }              from 'ngx-bootstrap';
 
 import { Subject }                 from 'rxjs';
-import { forkJoin }                from 'rxjs/observable/forkJoin';
 import { Observable }              from 'rxjs/Observable';
+import { forkJoin }                from 'rxjs/observable/forkJoin';
 
-import { RepositoryService }       from '../../../../../resources/repositories/repository.service';
 import { Repository }              from '../../../../../resources/repositories/repository';
+import { RepositoryService }       from '../../../../../resources/repositories/repository.service';
 import { RepositoryImportService } from '../../../../../resources/repository-imports/repository-import.service';
 
 

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.ts
@@ -1,38 +1,38 @@
 import {
     Component,
-    OnInit,
+    Input,
     OnDestroy,
+    OnInit,
     TemplateRef,
     ViewEncapsulation,
-    Input,
 } from '@angular/core';
 
 import { flatten }           from 'lodash';
 import { Action }            from 'patternfly-ng/action/action';
 import { ActionConfig }      from 'patternfly-ng/action/action-config';
 import { EmptyStateConfig }  from 'patternfly-ng/empty-state/empty-state-config';
-import { ListEvent }         from 'patternfly-ng/list/list-event';
 import { ListConfig }        from 'patternfly-ng/list/basic-list/list-config';
+import { ListEvent }         from 'patternfly-ng/list/list-event';
 
 import {
-    BsModalService,
-    BsModalRef
+    BsModalRef,
+    BsModalService
 } from 'ngx-bootstrap';
 
 import { Namespace }               from '../../../../resources/namespaces/namespace';
+import { ProviderNamespace }       from '../../../../resources/provider-namespaces/provider-namespace';
 import { Repository }              from '../../../../resources/repositories/repository';
 import { RepositoryService }       from '../../../../resources/repositories/repository.service';
-import { ProviderNamespace }       from '../../../../resources/provider-namespaces/provider-namespace';
-import { RepositoryImportService } from '../../../../resources/repository-imports/repository-import.service';
 import { RepositoryImport }        from '../../../../resources/repository-imports/repository-import';
+import { RepositoryImportService } from '../../../../resources/repository-imports/repository-import.service';
 
 import {
     AlternateNameModalComponent
 } from './alternate-name-modal/alternate-name-modal.component';
 
+import 'rxjs/add/observable/interval';
 import { Observable }              from 'rxjs/Observable';
 import { forkJoin }                from 'rxjs/observable/forkJoin';
-import 'rxjs/add/observable/interval';
 
 import * as moment                 from 'moment';
 

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list-resolver.service.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list-resolver.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { NamespaceListResolver } from './namespace-list-resolver.service';
 

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list-resolver.service.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list-resolver.service.ts
@@ -8,10 +8,10 @@ import {
 } from '@angular/router';
 
 import { Observable }            from 'rxjs/Observable';
-import { NamespaceService }      from '../../resources/namespaces/namespace.service';
-import { Namespace }             from '../../resources/namespaces/namespace';
-import { PagedResponse }         from '../../resources/paged-response';
 import { AuthService }           from '../../auth/auth.service';
+import { Namespace }             from '../../resources/namespaces/namespace';
+import { NamespaceService }      from '../../resources/namespaces/namespace.service';
+import { PagedResponse }         from '../../resources/paged-response';
 
 @Injectable()
 export class NamespaceListResolver implements Resolve<PagedResponse> {

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
@@ -14,29 +14,29 @@ import { cloneDeep }    from 'lodash';
 
 import { Action }       from 'patternfly-ng/action/action';
 import { ActionConfig } from 'patternfly-ng/action/action-config';
-import { ListEvent }    from 'patternfly-ng/list/list-event';
 import { ListConfig }   from 'patternfly-ng/list/basic-list/list-config';
+import { ListEvent }    from 'patternfly-ng/list/list-event';
 
 import { PaginationConfig }   from 'patternfly-ng/pagination/pagination-config';
 import { PaginationEvent }    from 'patternfly-ng/pagination/pagination-event';
 
+import { BsModalRef, BsModalService }  from 'ngx-bootstrap';
+import { Filter }                      from 'patternfly-ng/filter/filter';
+import { FilterConfig }                from 'patternfly-ng/filter/filter-config';
+import { FilterEvent }                 from 'patternfly-ng/filter/filter-event';
+import { FilterField }                 from 'patternfly-ng/filter/filter-field';
+import { FilterType }                  from 'patternfly-ng/filter/filter-type';
+import { SortConfig }                  from 'patternfly-ng/sort/sort-config';
+import { SortEvent }                   from 'patternfly-ng/sort/sort-event';
+import { SortField }                   from 'patternfly-ng/sort/sort-field';
+import { ToolbarConfig }               from 'patternfly-ng/toolbar/toolbar-config';
+import { ToolbarView }                 from 'patternfly-ng/toolbar/toolbar-view';
+import { Me }                          from '../../auth/auth.service';
 import { AuthService }                 from '../../auth/auth.service';
 import { Namespace }                   from '../../resources/namespaces/namespace';
 import { NamespaceService }            from '../../resources/namespaces/namespace.service';
-import { BsModalService, BsModalRef }  from 'ngx-bootstrap';
-import { AddRepositoryModalComponent } from '../add-repository-modal/add-repository-modal.component';
-import { Me }                          from '../../auth/auth.service';
-import { FilterConfig }                from 'patternfly-ng/filter/filter-config';
-import { ToolbarConfig }               from 'patternfly-ng/toolbar/toolbar-config';
-import { FilterType }                  from 'patternfly-ng/filter/filter-type';
-import { SortConfig }                  from 'patternfly-ng/sort/sort-config';
-import { FilterField }                 from 'patternfly-ng/filter/filter-field';
-import { SortField }                   from 'patternfly-ng/sort/sort-field';
-import { ToolbarView }                 from 'patternfly-ng/toolbar/toolbar-view';
-import { SortEvent }                   from 'patternfly-ng/sort/sort-event';
-import { Filter }                      from 'patternfly-ng/filter/filter';
-import { FilterEvent }                 from 'patternfly-ng/filter/filter-event';
 import { PagedResponse }               from '../../resources/paged-response';
+import { AddRepositoryModalComponent } from '../add-repository-modal/add-repository-modal.component';
 
 
 @Component({

--- a/galaxyui/src/app/my-imports/import-detail/import-detail.component.ts
+++ b/galaxyui/src/app/my-imports/import-detail/import-detail.component.ts
@@ -2,9 +2,9 @@ import {
     AfterViewInit,
     Component,
     EventEmitter,
+    Input,
     OnInit,
-    Output,
-    Input
+    Output
 } from '@angular/core';
 
 import {
@@ -12,15 +12,15 @@ import {
     SaveParams
 } from '../../resources/imports/imports.service';
 
+import { ImportState }             from '../../enums/import-state.enum';
 import { Import }                  from '../../resources/imports/import';
 import { ImportLatest }            from '../../resources/imports/import-latest';
-import { ImportState }             from '../../enums/import-state.enum';
 
-import { RepositoryImportService } from '../../resources/repository-imports/repository-import.service';
 import { RepositoryImport }        from '../../resources/repository-imports/repository-import';
+import { RepositoryImportService } from '../../resources/repository-imports/repository-import.service';
 
-import { NamespaceService }        from '../../resources/namespaces/namespace.service';
 import { Namespace }               from '../../resources/namespaces/namespace';
+import { NamespaceService }        from '../../resources/namespaces/namespace.service';
 
 import { AuthService }             from '../../auth/auth.service';
 

--- a/galaxyui/src/app/my-imports/import-list/import-list.component.ts
+++ b/galaxyui/src/app/my-imports/import-list/import-list.component.ts
@@ -1,9 +1,9 @@
 import {
-    Component,
-    OnInit,
-    OnDestroy,
-    ViewChild,
     AfterViewInit,
+    Component,
+    OnDestroy,
+    OnInit,
+    ViewChild,
 } from '@angular/core';
 
 import {
@@ -20,8 +20,8 @@ import {
     SaveParams
 } from '../../resources/imports/imports.service';
 
-import { Observable }    from 'rxjs/Observable';
 import 'rxjs/add/observable/interval';
+import { Observable }    from 'rxjs/Observable';
 
 import { Import }        from '../../resources/imports/import';
 import { ImportLatest }  from '../../resources/imports/import-latest';
@@ -31,23 +31,23 @@ import { PagedResponse } from '../../resources/paged-response';
 
 import { PageHeaderComponent } from '../../page-header/page-header.component';
 
-import { ListConfig }    from 'patternfly-ng/list/basic-list/list-config';
-import { ListEvent }     from 'patternfly-ng/list/list-event';
-import { ListComponent } from 'patternfly-ng/list/basic-list/list.component';
+import { Filter }        from 'patternfly-ng/filter/filter';
 import { FilterConfig }  from 'patternfly-ng/filter/filter-config';
-import { FilterField }   from 'patternfly-ng/filter/filter-field';
 import { FilterEvent }   from 'patternfly-ng/filter/filter-event';
+import { FilterField }   from 'patternfly-ng/filter/filter-field';
 import { FilterQuery }   from 'patternfly-ng/filter/filter-query';
 import { FilterType }    from 'patternfly-ng/filter/filter-type';
-import { Filter }        from 'patternfly-ng/filter/filter';
+import { ListConfig }    from 'patternfly-ng/list/basic-list/list-config';
+import { ListComponent } from 'patternfly-ng/list/basic-list/list.component';
+import { ListEvent }     from 'patternfly-ng/list/list-event';
 
 import { PaginationConfig }  from 'patternfly-ng/pagination/pagination-config';
 import { PaginationEvent }   from 'patternfly-ng/pagination/pagination-event';
 
 import { AuthService }   from '../../auth/auth.service';
 
-import * as moment       from 'moment';
 import * as $            from 'jquery';
+import * as moment       from 'moment';
 
 @Component({
     selector: 'import-list',

--- a/galaxyui/src/app/my-imports/import-list/import-list.resolver.service.ts
+++ b/galaxyui/src/app/my-imports/import-list/import-list.resolver.service.ts
@@ -10,9 +10,9 @@ import {
 } from '@angular/router';
 
 import { Observable }            from 'rxjs/Observable';
-import { ImportsService }        from '../../resources/imports/imports.service';
-import { ImportLatest }          from '../../resources/imports/import-latest';
 import { AuthService }           from '../../auth/auth.service';
+import { ImportLatest }          from '../../resources/imports/import-latest';
+import { ImportsService }        from '../../resources/imports/imports.service';
 import { PagedResponse }         from '../../resources/paged-response';
 
 @Injectable()

--- a/galaxyui/src/app/my-imports/my-imports.module.ts
+++ b/galaxyui/src/app/my-imports/my-imports.module.ts
@@ -1,20 +1,20 @@
-import { NgModule }                  from '@angular/core';
 import { CommonModule }              from '@angular/common';
+import { NgModule }                  from '@angular/core';
 
 import { ActionModule }              from 'patternfly-ng/action/action.module';
 import { EmptyStateModule }          from 'patternfly-ng/empty-state/empty-state.module';
 import { FilterModule }              from 'patternfly-ng/filter/filter.module';
-import { ToolbarModule }             from 'patternfly-ng/toolbar/toolbar.module';
 import { ListModule }                from 'patternfly-ng/list/basic-list/list.module';
 import { PaginationModule }          from 'patternfly-ng/pagination/pagination.module';
+import { ToolbarModule }             from 'patternfly-ng/toolbar/toolbar.module';
 
 import { TooltipModule }             from 'ngx-bootstrap/tooltip';
 
-import { ImportListComponent }       from './import-list/import-list.component';
-import { ImportDetailComponent }     from './import-detail/import-detail.component';
-import { MyImportsRoutingModule }    from './my-imports.routing.module';
 import { PageHeaderModule }          from '../page-header/page-header.module';
 import { PageLoadingModule }         from '../page-loading/page-loading.module';
+import { ImportDetailComponent }     from './import-detail/import-detail.component';
+import { ImportListComponent }       from './import-list/import-list.component';
+import { MyImportsRoutingModule }    from './my-imports.routing.module';
 
 @NgModule({
     imports: [

--- a/galaxyui/src/app/my-imports/my-imports.routing.module.ts
+++ b/galaxyui/src/app/my-imports/my-imports.routing.module.ts
@@ -24,8 +24,8 @@ import {
 } from '@angular/router';
 
 import { AuthService }              from '../auth/auth.service';
-import { ImportListResolver }       from './import-list/import-list.resolver.service';
 import { ImportListComponent }      from './import-list/import-list.component';
+import { ImportListResolver }       from './import-list/import-list.resolver.service';
 
 const myImportRoutes: Routes = [
     {

--- a/galaxyui/src/app/page-header/page-header.component.ts
+++ b/galaxyui/src/app/page-header/page-header.component.ts
@@ -1,7 +1,7 @@
 import {
     Component,
-    OnInit,
-    Input
+    Input,
+    OnInit
 } from '@angular/core';
 
 class Title {

--- a/galaxyui/src/app/page-header/page-header.module.ts
+++ b/galaxyui/src/app/page-header/page-header.module.ts
@@ -1,5 +1,5 @@
-import { NgModule }            from '@angular/core';
 import { CommonModule }        from '@angular/common';
+import { NgModule }            from '@angular/core';
 import { RouterModule }        from '@angular/router';
 
 import { PageHeaderComponent } from './page-header.component';

--- a/galaxyui/src/app/page-loading/page-loading.component.ts
+++ b/galaxyui/src/app/page-loading/page-loading.component.ts
@@ -1,7 +1,7 @@
 import {
     Component,
-    OnInit,
-    Input
+    Input,
+    OnInit
 } from '@angular/core';
 
 @Component({

--- a/galaxyui/src/app/page-loading/page-loading.module.ts
+++ b/galaxyui/src/app/page-loading/page-loading.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { PageLoadingComponent } from './page-loading.component';
 
 @NgModule({

--- a/galaxyui/src/app/resources/api-root/api-root.service.spec.ts
+++ b/galaxyui/src/app/resources/api-root/api-root.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { ApiRootService } from './api-root.service';
 

--- a/galaxyui/src/app/resources/api-root/api-root.service.ts
+++ b/galaxyui/src/app/resources/api-root/api-root.service.ts
@@ -1,10 +1,10 @@
+import { HttpClient }           from '@angular/common/http';
 import { Injectable }           from '@angular/core';
-import { catchError, tap }      from 'rxjs/operators';
 import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
 import { Observable }           from 'rxjs/Observable';
-import { HttpClient }           from '@angular/common/http';
-import { ApiRoot }              from './api-root';
 import { of }                   from 'rxjs/observable/of';
+import { catchError, tap }      from 'rxjs/operators';
+import { ApiRoot }              from './api-root';
 
 
 @Injectable()

--- a/galaxyui/src/app/resources/cloud-platforms/cloud-platform.service.spec.ts
+++ b/galaxyui/src/app/resources/cloud-platforms/cloud-platform.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { CloudPlatformService } from './cloud-platform.service';
 

--- a/galaxyui/src/app/resources/cloud-platforms/cloud-platform.service.ts
+++ b/galaxyui/src/app/resources/cloud-platforms/cloud-platform.service.ts
@@ -9,9 +9,9 @@ import { Observable }           from 'rxjs/Observable';
 import { of }                   from 'rxjs/observable/of';
 import { catchError, map, tap } from 'rxjs/operators';
 
-import { CloudPlatform }          from './cloud-platform';
 import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
 import { PagedResponse }        from '../paged-response';
+import { CloudPlatform }          from './cloud-platform';
 
 const httpOptions = {
     headers: new HttpHeaders({

--- a/galaxyui/src/app/resources/content-blocks/content-blocks.service.spec.ts
+++ b/galaxyui/src/app/resources/content-blocks/content-blocks.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { UserService } from './user.service';
 

--- a/galaxyui/src/app/resources/content-blocks/content-blocks.service.ts
+++ b/galaxyui/src/app/resources/content-blocks/content-blocks.service.ts
@@ -1,11 +1,11 @@
+import { HttpClient }           from '@angular/common/http';
 import { Injectable }           from '@angular/core';
-import { catchError, map, tap } from 'rxjs/operators';
 import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
 import { Observable }           from 'rxjs/Observable';
-import { HttpClient }           from '@angular/common/http';
+import { of }                   from 'rxjs/observable/of';
+import { catchError, map, tap } from 'rxjs/operators';
 import { PagedResponse }        from '../paged-response';
 import { ContentBlock }         from './content-block';
-import { of }                   from 'rxjs/observable/of';
 
 
 @Injectable()

--- a/galaxyui/src/app/resources/content-search/content-search.service.spec.ts
+++ b/galaxyui/src/app/resources/content-search/content-search.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { ContentSearchService } from './content-search.service';
 

--- a/galaxyui/src/app/resources/content-types/content-type.service.spec.ts
+++ b/galaxyui/src/app/resources/content-types/content-type.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { PlatformService } from './platform.service';
 

--- a/galaxyui/src/app/resources/content-types/content-type.service.ts
+++ b/galaxyui/src/app/resources/content-types/content-type.service.ts
@@ -9,9 +9,9 @@ import { Observable }           from 'rxjs/Observable';
 import { of }                   from 'rxjs/observable/of';
 import { catchError, map, tap } from 'rxjs/operators';
 
-import { ContentType }          from './content-type';
 import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
 import { PagedResponse }        from '../paged-response';
+import { ContentType }          from './content-type';
 
 const httpOptions = {
     headers: new HttpHeaders({

--- a/galaxyui/src/app/resources/content/content.service.spec.ts
+++ b/galaxyui/src/app/resources/content/content.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { ContentService } from './content.service';
 

--- a/galaxyui/src/app/resources/imports/imports.service.spec.ts
+++ b/galaxyui/src/app/resources/imports/imports.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { ImportsService } from './imports.service';
 

--- a/galaxyui/src/app/resources/namespaces/namespace.service.spec.ts
+++ b/galaxyui/src/app/resources/namespaces/namespace.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { NamespaceService } from './namespace.service';
 

--- a/galaxyui/src/app/resources/namespaces/namespace.service.ts
+++ b/galaxyui/src/app/resources/namespaces/namespace.service.ts
@@ -81,7 +81,7 @@ export class NamespaceService {
         );
     }
 
-    delete (namespace: Namespace | number): Observable<any> {
+    delete(namespace: Namespace | number): Observable<any> {
         const id = typeof namespace === 'number' ? namespace : namespace.id;
         const url = `${this.url}/${id}`;
 

--- a/galaxyui/src/app/resources/namespaces/namespace.service.ts
+++ b/galaxyui/src/app/resources/namespaces/namespace.service.ts
@@ -1,5 +1,5 @@
-import { Injectable }              from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable }              from '@angular/core';
 
 
 import { Observable }           from 'rxjs/Observable';

--- a/galaxyui/src/app/resources/platforms/platform.service.spec.ts
+++ b/galaxyui/src/app/resources/platforms/platform.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { PlatformService } from './platform.service';
 

--- a/galaxyui/src/app/resources/platforms/platform.service.ts
+++ b/galaxyui/src/app/resources/platforms/platform.service.ts
@@ -1,13 +1,13 @@
-import { Injectable }              from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable }              from '@angular/core';
 
 import { Observable }           from 'rxjs/Observable';
 import { of }                   from 'rxjs/observable/of';
 import { catchError, map, tap } from 'rxjs/operators';
 
-import { Platform }            from './platform';
 import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
 import { PagedResponse }       from '../paged-response';
+import { Platform }            from './platform';
 
 const httpOptions = {
     headers: new HttpHeaders({

--- a/galaxyui/src/app/resources/provider-namespaces/provider-source.service.spec.ts
+++ b/galaxyui/src/app/resources/provider-namespaces/provider-source.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { ProviderSourceService } from './provider-source.service';
 

--- a/galaxyui/src/app/resources/provider-namespaces/provider-source.service.ts
+++ b/galaxyui/src/app/resources/provider-namespaces/provider-source.service.ts
@@ -1,12 +1,12 @@
+import { HttpClient }           from '@angular/common/http';
 import { Injectable }           from '@angular/core';
 import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
-import { catchError, map, tap } from 'rxjs/operators';
-import { HttpClient }           from '@angular/common/http';
 import { Observable }           from 'rxjs/Observable';
 import { of }                   from 'rxjs/observable/of';
+import { catchError, map, tap } from 'rxjs/operators';
+import { RepositorySource }     from '../repositories/repository-source';
 import { ProviderNamespace }    from './provider-namespace';
 import { ProviderSource }       from './provider-source';
-import { RepositorySource }     from '../repositories/repository-source';
 
 @Injectable()
 export class ProviderSourceService {

--- a/galaxyui/src/app/resources/repositories/repository.service.spec.ts
+++ b/galaxyui/src/app/resources/repositories/repository.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { RepositoryService } from './repository.service';
 

--- a/galaxyui/src/app/resources/repositories/repository.service.ts
+++ b/galaxyui/src/app/resources/repositories/repository.service.ts
@@ -1,13 +1,13 @@
-import { Injectable }              from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable }              from '@angular/core';
 
 import { Observable }           from 'rxjs/Observable';
 import { of }                   from 'rxjs/observable/of';
 import { catchError, map, tap } from 'rxjs/operators';
 
-import { Repository }          from './repository';
 import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
 import { PagedResponse }       from '../paged-response';
+import { Repository }          from './repository';
 
 const httpOptions = {
     headers: new HttpHeaders({

--- a/galaxyui/src/app/resources/repository-imports/repository-import.service.spec.ts
+++ b/galaxyui/src/app/resources/repository-imports/repository-import.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { RepositoryImportService } from './repository-import.service';
 

--- a/galaxyui/src/app/resources/repository-imports/repository-import.service.ts
+++ b/galaxyui/src/app/resources/repository-imports/repository-import.service.ts
@@ -1,10 +1,10 @@
-import { Injectable }              from '@angular/core';
-import { catchError, map, tap }    from 'rxjs/operators';
-import { NotificationService }     from 'patternfly-ng/notification/notification-service/notification.service';
-import { PagedResponse }           from '../paged-response';
-import { of }                      from 'rxjs/observable/of';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable }              from '@angular/core';
+import { NotificationService }     from 'patternfly-ng/notification/notification-service/notification.service';
 import { Observable }              from 'rxjs/Observable';
+import { of }                      from 'rxjs/observable/of';
+import { catchError, map, tap }    from 'rxjs/operators';
+import { PagedResponse }           from '../paged-response';
 import { RepositoryImport }        from './repository-import';
 
 const httpOptions = {

--- a/galaxyui/src/app/resources/tags/tags.service.spec.ts
+++ b/galaxyui/src/app/resources/tags/tags.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { TagsService } from './tags.service';
 

--- a/galaxyui/src/app/resources/tags/tags.service.ts
+++ b/galaxyui/src/app/resources/tags/tags.service.ts
@@ -5,13 +5,13 @@ import {
     HttpHeaders
 } from '@angular/common/http';
 
+import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
 import { Observable }           from 'rxjs/Observable';
 import { of }                   from 'rxjs/observable/of';
 import { catchError, map, tap } from 'rxjs/operators';
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
 
-import { Tag }                  from './tag';
 import { PagedResponse }        from '../paged-response';
+import { Tag }                  from './tag';
 
 const httpOptions = {
     headers: new HttpHeaders({

--- a/galaxyui/src/app/resources/users/user.service.spec.ts
+++ b/galaxyui/src/app/resources/users/user.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
 import { UserService } from './user.service';
 

--- a/galaxyui/src/app/resources/users/user.service.ts
+++ b/galaxyui/src/app/resources/users/user.service.ts
@@ -1,11 +1,11 @@
+import { HttpClient }           from '@angular/common/http';
 import { Injectable }           from '@angular/core';
-import { catchError, map, tap } from 'rxjs/operators';
 import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
 import { Observable }           from 'rxjs/Observable';
-import { HttpClient }           from '@angular/common/http';
+import { of }                   from 'rxjs/observable/of';
+import { catchError, map, tap } from 'rxjs/operators';
 import { PagedResponse }        from '../paged-response';
 import { User }                 from './user';
-import { of }                   from 'rxjs/observable/of';
 
 
 @Injectable()

--- a/galaxyui/src/app/search/popular/popular.component.ts
+++ b/galaxyui/src/app/search/popular/popular.component.ts
@@ -2,9 +2,9 @@ import {
     Component,
     EventEmitter,
     Input,
-    ViewChild,
     OnInit,
-    Output
+    Output,
+    ViewChild
 } from '@angular/core';
 
 import {
@@ -17,11 +17,11 @@ import { ListEvent }      from 'patternfly-ng/list/list-event';
 import { Tag }              from '../../resources/tags/tag';
 import { TagsService }      from '../../resources/tags/tags.service';
 
-import { PlatformService }  from '../../resources/platforms/platform.service';
 import { Platform }         from '../../resources/platforms/platform';
+import { PlatformService }  from '../../resources/platforms/platform.service';
 
-import { CloudPlatformService } from '../../resources/cloud-platforms/cloud-platform.service';
 import { CloudPlatform }        from '../../resources/cloud-platforms/cloud-platform';
+import { CloudPlatformService } from '../../resources/cloud-platforms/cloud-platform.service';
 
 class PopularData {
     tags: Tag[];

--- a/galaxyui/src/app/search/search-routing.module.ts
+++ b/galaxyui/src/app/search/search-routing.module.ts
@@ -1,20 +1,20 @@
 import { NgModule } from '@angular/core';
 
 import {
-    Routes,
-    RouterModule
+    RouterModule,
+    Routes
 } from '@angular/router';
 
 import { SearchComponent } from './search.component';
 
 import {
+    PopularCloudPlatformsResolver,
+    PopularPlatformsResolver,
+    PopularTagsResolver,
     SearchCloudPlatformResolver,
     SearchContentResolver,
     SearchContentTypeResolver,
-    SearchPlatformResolver,
-    PopularTagsResolver,
-    PopularPlatformsResolver,
-    PopularCloudPlatformsResolver
+    SearchPlatformResolver
 }  from './search.resolver.service';
 
 const routes: Routes = [

--- a/galaxyui/src/app/search/search.component.ts
+++ b/galaxyui/src/app/search/search.component.ts
@@ -1,8 +1,8 @@
 import {
+    AfterViewInit,
     Component,
     OnInit,
-    ViewChild,
-    AfterViewInit
+    ViewChild
 } from '@angular/core';
 
 import {
@@ -17,26 +17,26 @@ import {
 import { ListConfig }     from 'patternfly-ng/list/basic-list/list-config';
 import { ToolbarConfig }  from 'patternfly-ng/toolbar/toolbar-config';
 
-import { FilterConfig }   from 'patternfly-ng/filter/filter-config';
 import { Filter }         from 'patternfly-ng/filter/filter';
-import { FilterField }    from 'patternfly-ng/filter/filter-field';
+import { FilterConfig }   from 'patternfly-ng/filter/filter-config';
 import { FilterEvent }    from 'patternfly-ng/filter/filter-event';
+import { FilterField }    from 'patternfly-ng/filter/filter-field';
 import { FilterQuery }    from 'patternfly-ng/filter/filter-query';
 import { FilterType }     from 'patternfly-ng/filter/filter-type';
 
 import { SortConfig }     from 'patternfly-ng/sort/sort-config';
-import { SortField }      from 'patternfly-ng/sort/sort-field';
 import { SortEvent }      from 'patternfly-ng/sort/sort-event';
+import { SortField }      from 'patternfly-ng/sort/sort-field';
 
+import { EmptyStateConfig }     from 'patternfly-ng/empty-state/empty-state-config';
 import { PaginationConfig }     from 'patternfly-ng/pagination/pagination-config';
 import { PaginationEvent }      from 'patternfly-ng/pagination/pagination-event';
-import { EmptyStateConfig }     from 'patternfly-ng/empty-state/empty-state-config';
 
-import { ContentSearchService } from '../resources/content-search/content-search.service';
-import { Platform }             from '../resources/platforms/platform';
-import { ContentType }          from '../resources/content-types/content-type';
-import { CloudPlatform }        from '../resources/cloud-platforms/cloud-platform';
 import { ContentTypes }         from '../enums/content-types.enum';
+import { CloudPlatform }        from '../resources/cloud-platforms/cloud-platform';
+import { ContentSearchService } from '../resources/content-search/content-search.service';
+import { ContentType }          from '../resources/content-types/content-type';
+import { Platform }             from '../resources/platforms/platform';
 
 import {
     ContentTypesIconClasses

--- a/galaxyui/src/app/search/search.module.ts
+++ b/galaxyui/src/app/search/search.module.ts
@@ -1,20 +1,20 @@
-import { NgModule }            from '@angular/core';
 import { CommonModule }        from '@angular/common';
+import { NgModule }            from '@angular/core';
 
 import { BsDropdownModule }    from 'ngx-bootstrap';
 
+import { TooltipModule }               from 'ngx-bootstrap/tooltip';
 import { ActionModule }        from 'patternfly-ng/action/action.module';
 import { EmptyStateModule }    from 'patternfly-ng/empty-state/empty-state.module';
 import { FilterModule }        from 'patternfly-ng/filter/filter.module';
-import { ToolbarModule }       from 'patternfly-ng/toolbar/toolbar.module';
 import { ListModule }          from 'patternfly-ng/list/basic-list/list.module';
-import { SortModule }          from 'patternfly-ng/sort/sort.module';
 import { PaginationModule }    from 'patternfly-ng/pagination/pagination.module';
-import { TooltipModule }               from 'ngx-bootstrap/tooltip';
+import { SortModule }          from 'patternfly-ng/sort/sort.module';
+import { ToolbarModule }       from 'patternfly-ng/toolbar/toolbar.module';
 
+import { PopularComponent }    from './popular/popular.component';
 import { SearchRoutingModule } from './search-routing.module';
 import { SearchComponent }     from './search.component';
-import { PopularComponent }    from './popular/popular.component';
 
 import { PageHeaderModule }    from '../page-header/page-header.module';
 import { PageLoadingModule }   from '../page-loading/page-loading.module';

--- a/galaxyui/src/app/search/search.resolver.service.ts
+++ b/galaxyui/src/app/search/search.resolver.service.ts
@@ -14,20 +14,20 @@ import {
 } from '@angular/common';
 
 import { Observable }            from 'rxjs/Observable';
-import { ContentSearchService }  from '../resources/content-search/content-search.service';
 import { ContentResponse }       from '../resources/content-search/content';
+import { ContentSearchService }  from '../resources/content-search/content-search.service';
 
-import { PlatformService }       from '../resources/platforms/platform.service';
 import { Platform }              from '../resources/platforms/platform';
+import { PlatformService }       from '../resources/platforms/platform.service';
 
-import { ContentTypeService }    from '../resources/content-types/content-type.service';
 import { ContentType }           from '../resources/content-types/content-type';
+import { ContentTypeService }    from '../resources/content-types/content-type.service';
 
-import { CloudPlatformService }  from '../resources/cloud-platforms/cloud-platform.service';
 import { CloudPlatform }         from '../resources/cloud-platforms/cloud-platform';
+import { CloudPlatformService }  from '../resources/cloud-platforms/cloud-platform.service';
 
-import { TagsService }           from '../resources/tags/tags.service';
 import { Tag }                   from '../resources/tags/tag';
+import { TagsService }           from '../resources/tags/tags.service';
 
 import { ContributorTypes }      from '../enums/contributor-types.enum';
 

--- a/galaxyui/src/app/user-notifications/user-notifications.component.ts
+++ b/galaxyui/src/app/user-notifications/user-notifications.component.ts
@@ -4,10 +4,10 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 
-import { Notification }         from 'patternfly-ng/notification/notification';
-import { NotificationType }     from 'patternfly-ng/notification/notification-type';
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
 import { NotificationEvent }    from 'patternfly-ng';
+import { Notification }         from 'patternfly-ng/notification/notification';
+import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
+import { NotificationType }     from 'patternfly-ng/notification/notification-type';
 
 @Component({
     encapsulation: ViewEncapsulation.None,

--- a/galaxyui/src/app/utilities/utilities.module.ts
+++ b/galaxyui/src/app/utilities/utilities.module.ts
@@ -1,5 +1,5 @@
-import { NgModule }        from '@angular/core';
 import { CommonModule }    from '@angular/common';
+import { NgModule }        from '@angular/core';
 
 import { TooltipModule }       from 'ngx-bootstrap/tooltip';
 

--- a/galaxyui/src/app/vendors/card/vendor-card.component.ts
+++ b/galaxyui/src/app/vendors/card/vendor-card.component.ts
@@ -13,8 +13,8 @@ import { Namespace }     from '../../resources/namespaces/namespace';
 
 import {
     ContentTypes,
-    ContentTypesPluralChoices,
-    ContentTypesIconClasses
+    ContentTypesIconClasses,
+    ContentTypesPluralChoices
 } from '../../enums/content-types.enum';
 
 @Component({

--- a/galaxyui/src/app/vendors/vendors.component.ts
+++ b/galaxyui/src/app/vendors/vendors.component.ts
@@ -10,28 +10,28 @@ import {
 
 import { Action }             from 'patternfly-ng/action/action';
 import { ActionConfig }       from 'patternfly-ng/action/action-config';
-import { ListEvent }          from 'patternfly-ng/list/list-event';
-import { FilterConfig }       from 'patternfly-ng/filter/filter-config';
-import { ToolbarConfig }      from 'patternfly-ng/toolbar/toolbar-config';
-import { FilterType }         from 'patternfly-ng/filter/filter-type';
-import { SortConfig }         from 'patternfly-ng/sort/sort-config';
-import { FilterField }        from 'patternfly-ng/filter/filter-field';
-import { SortField }          from 'patternfly-ng/sort/sort-field';
-import { ToolbarView }        from 'patternfly-ng/toolbar/toolbar-view';
-import { SortEvent }          from 'patternfly-ng/sort/sort-event';
-import { Filter }             from 'patternfly-ng/filter/filter';
-import { FilterEvent }        from 'patternfly-ng/filter/filter-event';
 import { EmptyStateConfig }   from 'patternfly-ng/empty-state/empty-state-config';
+import { Filter }             from 'patternfly-ng/filter/filter';
+import { FilterConfig }       from 'patternfly-ng/filter/filter-config';
+import { FilterEvent }        from 'patternfly-ng/filter/filter-event';
+import { FilterField }        from 'patternfly-ng/filter/filter-field';
+import { FilterType }         from 'patternfly-ng/filter/filter-type';
+import { ListEvent }          from 'patternfly-ng/list/list-event';
 import { PaginationConfig }   from 'patternfly-ng/pagination/pagination-config';
 import { PaginationEvent }    from 'patternfly-ng/pagination/pagination-event';
+import { SortConfig }         from 'patternfly-ng/sort/sort-config';
+import { SortEvent }          from 'patternfly-ng/sort/sort-event';
+import { SortField }          from 'patternfly-ng/sort/sort-field';
+import { ToolbarConfig }      from 'patternfly-ng/toolbar/toolbar-config';
+import { ToolbarView }        from 'patternfly-ng/toolbar/toolbar-view';
 
-import { NamespaceService }   from '../resources/namespaces/namespace.service';
 import { Namespace }          from '../resources/namespaces/namespace';
+import { NamespaceService }   from '../resources/namespaces/namespace.service';
 
 import {
     ContentTypes,
-    ContentTypesPluralChoices,
-    ContentTypesIconClasses
+    ContentTypesIconClasses,
+    ContentTypesPluralChoices
 } from '../enums/content-types.enum';
 
 @Component({

--- a/galaxyui/src/app/vendors/vendors.module.ts
+++ b/galaxyui/src/app/vendors/vendors.module.ts
@@ -1,19 +1,19 @@
-import { NgModule }        from '@angular/core';
 import { CommonModule }    from '@angular/common';
+import { NgModule }        from '@angular/core';
 
+import { TooltipModule }           from 'ngx-bootstrap/tooltip';
 import { ActionModule }            from 'patternfly-ng/action/action.module';
 import { EmptyStateModule }        from 'patternfly-ng/empty-state/empty-state.module';
+import { FilterModule }            from 'patternfly-ng/filter/filter.module';
 import { ListModule }              from 'patternfly-ng/list/basic-list/list.module';
 import { PaginationModule }        from 'patternfly-ng/pagination/pagination.module';
-import { FilterModule }            from 'patternfly-ng/filter/filter.module';
 import { ToolbarModule }           from 'patternfly-ng/toolbar/toolbar.module';
-import { TooltipModule }           from 'ngx-bootstrap/tooltip';
 
-import { VendorsRoutingModule }    from './vendors.routing.module';
-import { VendorsComponent }        from './vendors.component';
-import { VendorCardComponent }     from './card/vendor-card.component';
 import { PageHeaderModule }        from '../page-header/page-header.module';
 import { PageLoadingModule }       from '../page-loading/page-loading.module';
+import { VendorCardComponent }     from './card/vendor-card.component';
+import { VendorsComponent }        from './vendors.component';
+import { VendorsRoutingModule }    from './vendors.routing.module';
 
 
 @NgModule({

--- a/galaxyui/src/app/vendors/vendors.resolver.service.ts
+++ b/galaxyui/src/app/vendors/vendors.resolver.service.ts
@@ -11,8 +11,8 @@ import {
 
 import { Observable }            from 'rxjs/Observable';
 
-import { NamespaceService }      from '../resources/namespaces/namespace.service';
 import { Namespace }             from '../resources/namespaces/namespace';
+import { NamespaceService }      from '../resources/namespaces/namespace.service';
 import { PagedResponse }         from '../resources/paged-response';
 
 @Injectable()

--- a/galaxyui/src/app/vendors/vendors.routing.module.ts
+++ b/galaxyui/src/app/vendors/vendors.routing.module.ts
@@ -4,8 +4,8 @@ import {
 } from '@angular/core';
 
 import {
-    Routes,
-    RouterModule
+    RouterModule,
+    Routes
 } from '@angular/router';
 
 import {

--- a/galaxyui/src/test.ts
+++ b/galaxyui/src/test.ts
@@ -1,11 +1,11 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/zone-testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
+import 'zone.js/dist/zone-testing';
 
 declare const require: any;
 

--- a/galaxyui/tslint.json
+++ b/galaxyui/tslint.json
@@ -18,7 +18,6 @@
     "object-literal-shorthand": false,
     "ordered-imports": false,
     "prefer-for-of": false,
-    "space-before-function-paren": false,
     "trailing-comma": false,
     "arrow-return-shorthand": true,
     "callable-types": true,

--- a/galaxyui/tslint.json
+++ b/galaxyui/tslint.json
@@ -1,8 +1,25 @@
 {
+  "extends": [
+    "tslint:recommended"
+  ],
   "rulesDirectory": [
     "node_modules/codelyzer"
   ],
   "rules": {
+    "align": false,
+    "array-type": false,
+    "arrow-parens": false,
+    "ban-types": false,
+    "interface-name": false,
+    "jsdoc-format": false,
+    "max-classes-per-file": false,
+    "no-consecutive-blank-lines": false,
+    "object-literal-key-quotes": false,
+    "object-literal-shorthand": false,
+    "ordered-imports": false,
+    "prefer-for-of": false,
+    "space-before-function-paren": false,
+    "trailing-comma": false,
     "arrow-return-shorthand": true,
     "callable-types": true,
     "class-name": true,

--- a/galaxyui/tslint.json
+++ b/galaxyui/tslint.json
@@ -16,7 +16,6 @@
     "no-consecutive-blank-lines": false,
     "object-literal-key-quotes": false,
     "object-literal-shorthand": false,
-    "ordered-imports": false,
     "prefer-for-of": false,
     "trailing-comma": false,
     "class-name": true,

--- a/galaxyui/tslint.json
+++ b/galaxyui/tslint.json
@@ -19,19 +19,14 @@
     "ordered-imports": false,
     "prefer-for-of": false,
     "trailing-comma": false,
-    "arrow-return-shorthand": true,
-    "callable-types": true,
     "class-name": true,
     "comment-format": [
       true,
       "check-space"
     ],
-    "curly": true,
     "deprecation": {
       "severity": "warn"
     },
-    "eofline": true,
-    "forin": true,
     "import-blacklist": [
       true,
       "rxjs/Rx"
@@ -42,8 +37,6 @@
       "spaces",
       4
     ],
-    "interface-over-type-literal": true,
-    "label-position": true,
     "max-line-length": [
       true,
       140
@@ -60,8 +53,6 @@
         ]
       }
     ],
-    "no-arg": true,
-    "no-bitwise": true,
     "no-console": [
       true,
       "debug",
@@ -70,27 +61,15 @@
       "timeEnd",
       "trace"
     ],
-    "no-construct": true,
-    "no-debugger": true,
-    "no-duplicate-super": true,
     "no-empty": false,
-    "no-empty-interface": true,
-    "no-eval": true,
     "no-inferrable-types": [
       true,
       "ignore-params"
     ],
-    "no-misused-new": true,
     "no-non-null-assertion": true,
-    "no-shadowed-variable": true,
     "no-string-literal": false,
-    "no-string-throw": true,
     "no-switch-case-fall-through": true,
-    "no-trailing-whitespace": true,
-    "no-unnecessary-initializer": true,
-    "no-unused-expression": true,
     "no-use-before-declare": true,
-    "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "one-line": [
       true,
@@ -99,12 +78,10 @@
       "check-else",
       "check-whitespace"
     ],
-    "prefer-const": true,
     "quotemark": [
       true,
       "single"
     ],
-    "radix": true,
     "semicolon": [
       true,
       "always"
@@ -123,7 +100,6 @@
         "variable-declaration": "nospace"
       }
     ],
-    "unified-signatures": true,
     "variable-name": false,
     "whitespace": [
       true,


### PR DESCRIPTION
This PR adds "extends tslint:recommended" in tslint config for 
galaxyui according to https://github.com/ansible/galaxy/issues/860 and 
removes custom rules that duplicate provided config.

Recommended rules included in bundle that produce errors on 
`npm run lint` are mostly disabled, but a couple of fixes are already 
included.

This is initial PR with partially done work.
Work is done partially for easier review process and rebases when
required.