### PR TITLE
Add python coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+# pytest-cov config
+[run]
+omit = */migrations/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ __pycache__/
 # Python: Distribution \ packaging
 *.egg-info/
 
+# Python: coverage reports
+.coverage
+htmlcov/
+coverage.xml
+
 # Project directories
 /build/
 /dist/

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,16 @@ dev/test:
 # TODO:  Revert to $(DOCKER_COMPOSE)
 # Currently `docker exec` offers -e option for setting Env variables, and `docker-compose exec` does not.
 # Setting the postgres connetion string to use postgres user, to have authority to create and destroy the test database.
-	@docker exec -e GALAXY_DB_URL=postgres://postgres:postgres@postgres:5432/galaxy galaxy_galaxy_1 bash -c 'source $(VENV_BIN)/activate; pytest galaxy'
+# TODO: Add note about testing and configuring coverage.xml to be used with  pyCharm (pro only),
+# VSCode f.ex. coverage-gutters + config "coverage-gutters.xmlname": "coverage.xml
+	@docker exec -e GALAXY_DB_URL=postgres://postgres:postgres@postgres:5432/galaxy galaxy_galaxy_1 \
+    bash -c '\
+      source $(VENV_BIN)/activate; \
+      pytest galaxy \
+        --cov galaxy \
+        --cov-report xml \
+        --cov-report term \
+        --cov-report html '
 
 .PHONY: dev/waitenv
 dev/waitenv:

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ six
 mock
 pytest
 pytest-django
+pytest-cov==2.5.1
 
 # Docs
 Sphinx


### PR DESCRIPTION
Currently there are no way to monitor test coverage for python code.

This patch introduces pytest py-cov extension that generates following
reports and files:

* `.coverage` - py-cov internal report data.
* `htmlcov/` with `htmlcov/index.html` as entry point - complete report
  on galaxy database with nice UI/UX.
* `coverage.xml` - reusable report that could be imported in most
  editors/IDEs.

All coverage reports are excluded from git repo.
All reports are created during make `dev/test` command

Readme sections should be added separately.