### PR TITLE
Generate source maps during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build/yarn:
 
 .PHONY: build/static
 build/static:
-	cd galaxyui; ng build --prod
+	cd galaxyui; ng build --prod --source-map
 
 .PHONY: build/dist
 build/dist: build/static


### PR DESCRIPTION
Think we need to make source maps available for debugging in QA and Prod.