### PR TITLE
Fix flake8 warning E501 - line is too long

### DIFF
--- a/galaxy/accounts/migrations/0001_initial.py
+++ b/galaxy/accounts/migrations/0001_initial.py
@@ -11,36 +11,133 @@ import django.core.validators
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('auth', '0006_require_contenttypes_0002'),
-    ]
+    dependencies = [('auth', '0006_require_contenttypes_0002')]
 
     operations = [
         migrations.CreateModel(
             name='CustomUser',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('password', models.CharField(max_length=128, verbose_name='password')),
-                ('last_login', models.DateTimeField(null=True, verbose_name='last login', blank=True)),
-                ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
-                ('username', models.CharField(help_text='Required. 30 characters or fewer. Letters, numbers and @/./+/-/_ characters', unique=True, max_length=30, verbose_name='username', validators=[django.core.validators.RegexValidator(re.compile('^[\\w.@+-]+$'), 'Enter a valid username.', 'invalid')])),
-                ('full_name', models.CharField(max_length=254, verbose_name='full name', blank=True)),
-                ('short_name', models.CharField(max_length=30, verbose_name='short name', blank=True)),
-                ('email', models.EmailField(unique=True, max_length=254, verbose_name='email address')),
-                ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
-                ('is_active', models.BooleanField(default=True, help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', db_index=True, verbose_name='active')),
-                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'password',
+                    models.CharField(max_length=128, verbose_name='password'),
+                ),
+                (
+                    'last_login',
+                    models.DateTimeField(
+                        null=True, verbose_name='last login', blank=True
+                    ),
+                ),
+                (
+                    'is_superuser',
+                    models.BooleanField(
+                        default=False,
+                        help_text='Designates that this user has all '
+                                  'permissions without explicitly '
+                                  'assigning them.',
+                        verbose_name='superuser status',
+                    ),
+                ),
+                (
+                    'username',
+                    models.CharField(
+                        help_text='Required. 30 characters or fewer. '
+                                  'Letters, numbers and @/./+/-/_ characters',
+                        unique=True,
+                        max_length=30,
+                        verbose_name='username',
+                        validators=[
+                            django.core.validators.RegexValidator(
+                                re.compile('^[\\w.@+-]+$'),
+                                'Enter a valid username.',
+                                'invalid',
+                            )
+                        ],
+                    ),
+                ),
+                (
+                    'full_name',
+                    models.CharField(
+                        max_length=254, verbose_name='full name', blank=True
+                    ),
+                ),
+                (
+                    'short_name',
+                    models.CharField(
+                        max_length=30, verbose_name='short name', blank=True
+                    ),
+                ),
+                (
+                    'email',
+                    models.EmailField(
+                        unique=True,
+                        max_length=254,
+                        verbose_name='email address',
+                    ),
+                ),
+                (
+                    'is_staff',
+                    models.BooleanField(
+                        default=False,
+                        help_text='Designates whether the user can log into '
+                                  'this admin site.',
+                        verbose_name='staff status',
+                    ),
+                ),
+                (
+                    'is_active',
+                    models.BooleanField(
+                        default=True,
+                        help_text='Designates whether this user should be '
+                                  'treated as active. Unselect this instead '
+                                  'of deleting accounts.',
+                        db_index=True,
+                        verbose_name='active',
+                    ),
+                ),
+                (
+                    'date_joined',
+                    models.DateTimeField(
+                        default=django.utils.timezone.now,
+                        verbose_name='date joined',
+                    ),
+                ),
                 ('karma', models.IntegerField(default=0, db_index=True)),
-                ('groups', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', verbose_name='groups')),
-                ('user_permissions', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Permission', blank=True, help_text='Specific permissions for this user.', verbose_name='user permissions')),
+                (
+                    'groups',
+                    models.ManyToManyField(
+                        related_query_name='user',
+                        related_name='user_set',
+                        to='auth.Group',
+                        blank=True,
+                        help_text='The groups this user belongs to. '
+                                  'A user will get all permissions granted '
+                                  'to each of their groups.',
+                        verbose_name='groups',
+                    ),
+                ),
+                (
+                    'user_permissions',
+                    models.ManyToManyField(
+                        related_query_name='user',
+                        related_name='user_set',
+                        to='auth.Permission',
+                        blank=True,
+                        help_text='Specific permissions for this user.',
+                        verbose_name='user permissions',
+                    ),
+                ),
             ],
-            options={
-                'verbose_name': 'user',
-                'verbose_name_plural': 'users',
-            },
+            options={'verbose_name': 'user', 'verbose_name_plural': 'users'},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
-            managers=[
-                ('objects', django.contrib.auth.models.UserManager()),
-            ],
-        ),
+            managers=[('objects', django.contrib.auth.models.UserManager())],
+        )
     ]

--- a/galaxy/accounts/migrations/0002_auto_20150803_1328.py
+++ b/galaxy/accounts/migrations/0002_auto_20150803_1328.py
@@ -11,5 +11,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunSQL("ALTER TABLE accounts_customuser ALTER COLUMN last_login DROP NOT NULL;")
+        migrations.RunSQL(
+            "ALTER TABLE accounts_customuser "
+            "ALTER COLUMN last_login DROP NOT NULL;"
+        )
     ]

--- a/galaxy/accounts/migrations/0003_auto_20151125_0840.py
+++ b/galaxy/accounts/migrations/0003_auto_20151125_0840.py
@@ -6,19 +6,21 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('accounts', '0002_auto_20150803_1328'),
-    ]
+    dependencies = [('accounts', '0002_auto_20150803_1328')]
 
     operations = [
         migrations.AddField(
             model_name='customuser',
             name='github_avatar',
-            field=models.CharField(max_length=254, verbose_name='github avatar', blank=True),
+            field=models.CharField(
+                max_length=254, verbose_name='github avatar', blank=True
+            ),
         ),
         migrations.AddField(
             model_name='customuser',
             name='github_user',
-            field=models.CharField(max_length=254, verbose_name='github user', blank=True),
+            field=models.CharField(
+                max_length=254, verbose_name='github user', blank=True
+            ),
         ),
     ]

--- a/galaxy/accounts/migrations/0004_customuser_cache_refreshed.py
+++ b/galaxy/accounts/migrations/0004_customuser_cache_refreshed.py
@@ -14,6 +14,8 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='customuser',
             name='cache_refreshed',
-            field=models.BooleanField(default=False, verbose_name='cache refreshed'),
+            field=models.BooleanField(
+                default=False, verbose_name='cache refreshed'
+            ),
         ),
     ]

--- a/galaxy/api/serializers/namespace.py
+++ b/galaxy/api/serializers/namespace.py
@@ -60,7 +60,10 @@ class NamespaceSerializer(serializers.BaseSerializer):
             'provider_name': pn.provider.name.lower()
         } for pn in instance.provider_namespaces.all()]
 
-        content_counts = {c['content_type__name']: c['count'] for c in instance.content_counts}
+        content_counts = {
+            c['content_type__name']: c['count']
+            for c in instance.content_counts
+        }
 
         return {
             'owners': owners,

--- a/galaxy/api/serializers/repository.py
+++ b/galaxy/api/serializers/repository.py
@@ -104,12 +104,13 @@ class RepositorySerializer(serializers.BaseSerializer):
             'id': instance.provider_namespace.provider.id,
         }
         namespace = {}
-        if instance.provider_namespace.namespace:
+        namespace_obj = instance.provider_namespace.namespace
+        if namespace_obj:
             namespace = {
-                'id': instance.provider_namespace.namespace.pk,
-                'name': instance.provider_namespace.namespace.name,
-                'description': instance.provider_namespace.namespace.description,
-                'is_vendor': instance.provider_namespace.namespace.is_vendor
+                'id': namespace_obj.pk,
+                'name': namespace_obj.name,
+                'description': namespace_obj.description,
+                'is_vendor': namespace_obj.is_vendor
             }
         latest_import = {}
         import_tasks = instance.import_tasks.order_by('-id')
@@ -121,16 +122,27 @@ class RepositorySerializer(serializers.BaseSerializer):
             latest_import['created'] = import_tasks[0].created
             latest_import['modified'] = import_tasks[0].modified
 
-        content_objects = [{'id': c.id, 'name': c.name, 'content_type': c.content_type.name,
-                           'description': c.description} for c in instance.content_objects.all()]
+        content_objects = [
+            {
+                'id': c.id,
+                'name': c.name,
+                'content_type': c.content_type.name,
+                'description': c.description,
+            }
+            for c in instance.content_objects.all()
+        ]
 
-        content_counts = {c['content_type__name']: c['count'] for c in instance.content_counts}
+        content_counts = {
+            c['content_type__name']: c['count']
+            for c in instance.content_counts
+        }
 
         versions = []
 
         for version in instance.all_versions():
             versions.append({
-                'download_url': version.repository.get_download_url(version.tag),
+                'download_url':
+                    version.repository.get_download_url(version.tag),
                 'version': str(version.version)
             })
 

--- a/galaxy/api/serializers/repository_source.py
+++ b/galaxy/api/serializers/repository_source.py
@@ -19,9 +19,8 @@ from collections import OrderedDict
 from django.core.urlresolvers import reverse
 from rest_framework.serializers import BaseSerializer
 
-__all__ = [
-    'RepositorySourceSerializer',
-]
+
+__all__ = ['RepositorySourceSerializer']
 
 
 class RepositorySourceSerializer(BaseSerializer):
@@ -33,14 +32,14 @@ class RepositorySourceSerializer(BaseSerializer):
         'watchers_count',
         'forks_count',
         'open_issues_count',
-        'default_branch'
+        'default_branch',
     ]
 
     optional_fields = [
         'commit',
         'commit_message',
         'commit_url',
-        'commit_created'
+        'commit_created',
     ]
 
     def to_representation(self, instance):
@@ -54,27 +53,34 @@ class RepositorySourceSerializer(BaseSerializer):
         name = instance['name'].replace('.', '-')
 
         result['related'] = {
-            'provider': reverse('api:active_provider_detail', kwargs={'pk': provider_id}),
-            'source_repository': reverse('api:repository_source_detail', kwargs={
-                'provider_name': provider_name,
-                'provider_namespace': source_namespace,
-                'repo_name': name
-            })
+            'provider': reverse(
+                'api:active_provider_detail', kwargs={'pk': provider_id}
+            ),
+            'source_repository': reverse(
+                'api:repository_source_detail',
+                kwargs={
+                    'provider_name': provider_name,
+                    'provider_namespace': source_namespace,
+                    'repo_name': name,
+                },
+            ),
         }
 
         if instance.get('namespace_url'):
             result['related']['namespace'] = instance['namespace_url']
         if instance.get('provider_namespace_url'):
-            result['related']['provider_namespace'] = instance['provider_namespace_url']
+            result['related']['provider_namespace'] = instance[
+                'provider_namespace_url'
+            ]
         if instance.get('repository_url'):
             result['related']['repository'] = instance['repository_url']
 
-        result['summary_fields'] = {
-            'provider': instance['provider'],
-        }
+        result['summary_fields'] = {'provider': instance['provider']}
 
         if instance.get('provider_namespace'):
-            result['summary_fields']['provider_namespace'] = instance['provider_namespace']
+            result['summary_fields']['provider_namespace'] = instance[
+                'provider_namespace'
+            ]
         if instance.get('namespace'):
             result['summary_fields']['namespace'] = instance['namespace']
         if instance.get('repository'):

--- a/galaxy/api/urls.py
+++ b/galaxy/api/urls.py
@@ -132,7 +132,8 @@ provider_namespace_urls = [
         name='provider_namespace_list'),
     url(r'^(?P<pk>[0-9]+)/$', views.ProviderNamespaceDetail.as_view(),
         name='provider_namespace_detail'),
-    url(r'^(?P<pk>[0-9]+)/repositories/$', views.ProviderNamespaceRepositoriesList.as_view(),
+    url(r'^(?P<pk>[0-9]+)/repositories/$',
+        views.ProviderNamespaceRepositoriesList.as_view(),
         name='provider_namespace_repositories_list'),
 ]
 

--- a/galaxy/api/views/provider_namespace.py
+++ b/galaxy/api/views/provider_namespace.py
@@ -50,7 +50,10 @@ def check_provider_access(provider, user, name):
                 match = True
                 break
         if not match:
-            raise APIException("User does not have access to namespace {0} in GitHub".format(name))
+            raise APIException(
+                "User does not have access to namespace "
+                "{0} in GitHub".format(name)
+            )
 
 
 def check_namespace_access(user, namespace_id):
@@ -64,7 +67,9 @@ def check_namespace_access(user, namespace_id):
 class ProviderNamespaceList(base_views.ListCreateAPIView):
     model = models.ProviderNamespace
     serializer_class = serializers.ProviderNamespaceSerializer
-    filter_backends = (FieldLookupBackend, SearchFilter, OrderByBackend)  # excludes ActiveOnly
+
+    # excludes ActiveOnly
+    filter_backends = (FieldLookupBackend, SearchFilter, OrderByBackend)
 
     def post(self, request, *args, **kwargs):
         data = request.data
@@ -86,14 +91,20 @@ class ProviderNamespaceList(base_views.ListCreateAPIView):
         try:
             provider = models.Provider.objects.get(pk=data['provider'])
         except ObjectDoesNotExist:
-            raise ValidationError(detail={'provider': 'provider does not exist'})
+            raise ValidationError(
+                detail={'provider': 'provider does not exist'}
+            )
 
         try:
-            models.ProviderNamespace.objects.get(name=data['name'], provider=provider)
+            models.ProviderNamespace.objects.get(
+                name=data['name'], provider=provider
+            )
         except ObjectDoesNotExist:
             pass
         else:
-            raise APIException("The requested provider namespace already exists")
+            raise APIException(
+                "The requested provider namespace already exists"
+            )
 
         try:
             check_provider_access(provider, request.user, data['name'])
@@ -107,13 +118,20 @@ class ProviderNamespaceList(base_views.ListCreateAPIView):
         obj = models.ProviderNamespace.objects.create(**data)
         serializer = self.get_serializer(obj)
         headers = self.get_success_headers(serializer.data)
-        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+        return Response(
+            serializer.data,
+            status=status.HTTP_201_CREATED,
+            headers=headers,
+        )
 
 
 class ProviderNamespaceDetail(base_views.RetrieveUpdateDestroyAPIView):
     model = models.ProviderNamespace
     serializer_class = serializers.ProviderNamespaceSerializer
-    filter_backends = (FieldLookupBackend, SearchFilter, OrderByBackend)  # excludes ActiveOnly
+
+    # excludes ActiveOnly
+    filter_backends = (FieldLookupBackend, SearchFilter, OrderByBackend)
 
     def update(self, request, *args, **kwargs):
         data = request.data
@@ -128,20 +146,30 @@ class ProviderNamespaceDetail(base_views.RetrieveUpdateDestroyAPIView):
         if data.get('namespace'):
             # User attempting to change the namespace
             try:
-                namespace = models.Namespace.objects.get(pk=data['namespace'], active=True)
+                namespace = models.Namespace.objects.get(
+                    pk=data['namespace'], active=True
+                )
             except ObjectDoesNotExist:
-                raise ValidationError(detail={'namespace': 'namespace does not exist'})
+                raise ValidationError(
+                    detail={'namespace': 'namespace does not exist'}
+                )
             try:
                 request.user.namespaces.get(pk=namespace.pk, active=True)
             except ObjectDoesNotExist:
-                raise ValidationError(detail={'namespace': 'you do not have access to this namespace'})
+                raise ValidationError(
+                    detail={
+                        'namespace': 'you do not have access to this namespace'
+                    }
+                )
             data['namespace'] = namespace
 
         if data.get('provider'):
             try:
                 provider = models.Provider.objects.get(pk=data['provider'])
             except ObjectDoesNotExist:
-                raise ValidationError(detail={'provider': 'provider does not exist'})
+                raise ValidationError(
+                    detail={'provider': 'provider does not exist'}
+                )
         else:
             provider = instance.provider
 

--- a/galaxy/api/views/provider_source.py
+++ b/galaxy/api/views/provider_source.py
@@ -30,22 +30,24 @@ from ..githubapi import GithubAPI
 from ..serializers import ProviderSourceSerializer
 
 
-__all__ = (
-    'ProviderSourceList',
-)
+__all__ = ['ProviderSourceList']
 
 logger = logging.getLogger(__name__)
 
 
 class ProviderSourceList(ListAPIView):
-    """ User namespaces available within each active provider """
+    """User namespaces available within each active provider."""
+
     model = ProviderNamespace
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
     serializer_class = ProviderSourceSerializer
 
     def get(self, request, *args, **kwargs):
-        # Return a list of namespaces from all providers for the requesting user
+        """
+        Return a list of namespaces from all providers
+        for the requesting user.
+        """
         sources = []
         for provider in Provider.objects.filter(active=True):
             if provider.name.lower() == 'github':
@@ -53,16 +55,19 @@ class ProviderSourceList(ListAPIView):
                 for source in sources:
                     source['provider'] = {
                         'id': provider.pk,
-                        'name': provider.name.lower()
+                        'name': provider.name.lower(),
                     }
                     try:
-                        provider_namespace = ProviderNamespace.objects.get(provider=provider,
-                                                                           name__iexact=source['name'])
+                        provider_namespace = ProviderNamespace.objects.get(
+                            provider=provider, name__iexact=source['name']
+                        )
                         source['provider_namespace'] = {
                             'id': provider_namespace.id,
-                            'name': provider_namespace.name.lower()
+                            'name': provider_namespace.name.lower(),
                         }
-                        source['provider_namespace_url'] = provider_namespace.get_absolute_url()
+                        source[
+                            'provider_namespace_url'
+                        ] = provider_namespace.get_absolute_url()
                     except ObjectDoesNotExist:
                         provider_namespace = None
                         source['provider_namespace'] = None
@@ -71,9 +76,11 @@ class ProviderSourceList(ListAPIView):
                     if provider_namespace and provider_namespace.namespace:
                         source['namespace'] = {
                             'id': provider_namespace.namespace.pk,
-                            'name': provider_namespace.namespace.name
+                            'name': provider_namespace.namespace.name,
                         }
-                        source['namespace_url'] = provider_namespace.namespace.get_absolute_url()
+                        source[
+                            'namespace_url'
+                        ] = provider_namespace.namespace.get_absolute_url()
                     else:
                         source['namespace'] = None
                         source['namespace_url'] = None

--- a/galaxy/api/views/repository_source.py
+++ b/galaxy/api/views/repository_source.py
@@ -30,16 +30,17 @@ from .base_views import ListAPIView
 from ..githubapi import GithubAPI
 from ..serializers import RepositorySourceSerializer
 
-__all__ = (
+
+__all__ = [
     'RepositorySourceList',
     'RepositorySourceDetail',
-)
+]
 
 logger = logging.getLogger(__name__)
 
 
 class RepositorySourceList(ListAPIView):
-    """ Repositories available for a given provider and namespace """
+    """Repositories available for a given provider and namespace."""
     model = Repository
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
@@ -51,17 +52,23 @@ class RepositorySourceList(ListAPIView):
         request_namespace = kwargs.get('provider_namespace')
         repos = []
         try:
-            provider = Provider.objects.get(name__iexact=request_provider.lower(), active=True)
+            provider = Provider.objects.get(
+                name__iexact=request_provider.lower(), active=True
+            )
         except ObjectDoesNotExist:
             raise APIException("Invalid provider {0}".format(request_provider))
 
         try:
-            provider_namespace = ProviderNamespace.objects.get(provider=provider, name__iexact=request_namespace)
+            provider_namespace = ProviderNamespace.objects.get(
+                provider=provider, name__iexact=request_namespace
+            )
         except ObjectDoesNotExist:
             provider_namespace = None
 
         if provider.name.lower() == 'github':
-            repos = GithubAPI(user=request.user).get_namespace_repositories(request_namespace)
+            repos = GithubAPI(user=request.user).get_namespace_repositories(
+                request_namespace
+            )
 
         for repo in repos:
             repo['source_namespace'] = request_namespace
@@ -79,7 +86,10 @@ class RepositorySourceList(ListAPIView):
 
             if provider_namespace:
                 try:
-                    repository_obj = Repository.objects.get(provider_namespace=provider_namespace, original_name=repo['name'])
+                    repository_obj = Repository.objects.get(
+                        provider_namespace=provider_namespace,
+                        original_name=repo['name']
+                    )
                 except ObjectDoesNotExist:
                     repository_obj = None
 
@@ -88,12 +98,16 @@ class RepositorySourceList(ListAPIView):
                         'id': provider_namespace.pk,
                         'name': provider_namespace.name
                     }
-                    repo['provider_namespace_url'] = provider_namespace.get_absolute_url()
+                    repo[
+                        'provider_namespace_url'
+                    ] = provider_namespace.get_absolute_url()
                     repo['namespace'] = {
                         'id': provider_namespace.namespace.pk,
                         'name': provider_namespace.namespace.name
                     }
-                    repo['namespace_url'] = provider_namespace.namespace.get_absolute_url()
+                    repo[
+                        'namespace_url'
+                    ] = provider_namespace.namespace.get_absolute_url()
                     repo['repository'] = {
                         'id': repository_obj.pk,
                         'name': repository_obj.name,
@@ -119,17 +133,23 @@ class RepositorySourceDetail(ListAPIView):
         repo = {}
 
         try:
-            provider = Provider.objects.get(name__iexact=request_provider.lower(), active=True)
+            provider = Provider.objects.get(
+                name__iexact=request_provider.lower(), active=True
+            )
         except ObjectDoesNotExist:
             raise APIException("Invalid provider {0}".format(request_provider))
 
         try:
-            provider_namespace = ProviderNamespace.objects.get(provider=provider, name__iexact=request_namespace)
+            provider_namespace = ProviderNamespace.objects.get(
+                provider=provider, name__iexact=request_namespace
+            )
         except ObjectDoesNotExist:
             provider_namespace = None
 
         if provider.name.lower() == 'github':
-            repos = GithubAPI(user=request.user).get_namespace_repositories(request_namespace, name=request_repo)
+            repos = GithubAPI(user=request.user).get_namespace_repositories(
+                request_namespace, name=request_repo
+            )
             if len(repos):
                 repo = repos[0]
 
@@ -149,8 +169,10 @@ class RepositorySourceDetail(ListAPIView):
 
             if provider_namespace:
                 try:
-                    repository_obj = Repository.objects.get(provider_namespace=provider_namespace,
-                                                            original_name=repo['name'])
+                    repository_obj = Repository.objects.get(
+                        provider_namespace=provider_namespace,
+                        original_name=repo['name']
+                    )
                 except ObjectDoesNotExist:
                     repository_obj = None
 
@@ -159,12 +181,16 @@ class RepositorySourceDetail(ListAPIView):
                         'id': provider_namespace.pk,
                         'name': provider_namespace.name
                     }
-                    repo['provider_namespace_url'] = provider_namespace.get_absolute_url()
+                    repo[
+                        'provider_namespace_url'
+                    ] = provider_namespace.get_absolute_url()
                     repo['namespace'] = {
                         'id': provider_namespace.namespace.pk,
                         'name': provider_namespace.namespace.name
                     }
-                    repo['namespace_url'] = provider_namespace.namespace.get_absolute_url()
+                    repo[
+                        'namespace_url'
+                    ] = provider_namespace.namespace.get_absolute_url()
                     repo['repository'] = {
                         'id': repository_obj.pk,
                         'name': repository_obj.name,

--- a/galaxy/api/views/views.py
+++ b/galaxy/api/views/views.py
@@ -41,7 +41,9 @@ from github.GithubException import GithubException
 
 # rest framework stuff
 from rest_framework import status
-from rest_framework.authentication import TokenAuthentication, SessionAuthentication
+from rest_framework.authentication import (
+    TokenAuthentication, SessionAuthentication
+)
 from rest_framework.authtoken.models import Token
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -105,7 +107,7 @@ __all__ = [
 ]
 
 
-# --------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Helper functions
 
 
@@ -125,7 +127,7 @@ def filter_rating_queryset(qs):
         owner__is_active=True,
     )
 
-# --------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 
 class ApiRootView(base_views.APIView):
@@ -387,22 +389,29 @@ class ImportTaskList(base_views.ListCreateAPIView):
         if not repository_id:
             # request received from old client
             if not github_user or not github_repo:
-                raise ValidationError(
-                    dict(detail="Invalid request. Expecting github_user and github_repo.")
-                )
+                raise ValidationError({
+                    'detail': "Invalid request. "
+                              "Expecting github_user and github_repo."
+                })
 
             namespace = models.ProviderNamespace.objects.get(
                 provider__name=constants.PROVIDER_GITHUB,
                 name=github_user
             )
             if not request.user.is_staff and \
-               not namespace.namespace.owners.filter(username=request.user.get_username()):
+               not namespace.namespace.owners.filter(
+                   username=request.user.get_username()):
                 # User is not an onwer of the Namespace
-                raise PermissionDenied("You are not an owner of {0}".format(namespace.namespace.name))
+                raise PermissionDenied(
+                    "You are not an owner of {0}"
+                    .format(namespace.namespace.name)
+                )
 
             try:
-                repository = models.Repository.objects.get(provider_namespace=namespace,
-                                                           original_name=github_repo)
+                repository = models.Repository.objects.get(
+                    provider_namespace=namespace,
+                    original_name=github_repo
+                )
             except ObjectDoesNotExist:
                 repository, created = models.Repository.objects.get_or_create(
                     provider_namespace=namespace,
@@ -414,14 +423,18 @@ class ImportTaskList(base_views.ListCreateAPIView):
             try:
                 repository = models.Repository.objects.get(pk=repository_id)
             except ObjectDoesNotExist:
-                raise ValidationError(
-                    dict(detail="Repository {0} not found, or you do not have access".format(repository_id))
-                )
+                raise ValidationError({
+                    'detail': "Repository {0} not found, or you do not "
+                              "have access".format(repository_id)
+                })
 
             if not request.user.is_staff and \
-               not repository.provider_namespace.namespace.owners.filter(username=request.user.get_username()):
+               not repository.provider_namespace.namespace.owners.filter(
+                   username=request.user.get_username()):
                 # User is not an onwer of the Namespace
-                raise PermissionDenied("You are not an owner of {0}".format(repository.name))
+                raise PermissionDenied(
+                    "You are not an owner of {0}".format(repository.name)
+                )
 
         task = tasks.create_import_task(
             repository, request.user,
@@ -455,7 +468,7 @@ class ImportTaskNotificationList(base_views.SubListAPIView):
 
 
 class ImportTaskLatestList(base_views.ListAPIView):
-    """ Return the most recent import for each of the user's repositories """
+    """Return the most recent import for each of the user's repositories."""
     authentication_classes = (TokenAuthentication, SessionAuthentication)
     permission_classes = (IsAuthenticated,)
     model = models.ImportTask
@@ -531,47 +544,66 @@ class StargazerList(base_views.ListCreateAPIView):
         github_repo = request.data.get('github_repo', None)
 
         if not github_user or not github_repo:
-            raise ValidationError(dict(detail="Invalid request. Missing one or more required values."))
+            raise ValidationError({
+                'detail': "Invalid request. "
+                          "Missing one or more required values."
+            })
 
         try:
-            token = SocialToken.objects.get(account__user=request.user, account__provider='github')
+            token = SocialToken.objects.get(
+                account__user=request.user, account__provider='github'
+            )
         except Exception:
-            msg = "Failed to get GitHub token for user {0} ".format(request.user.username) + \
-                  "You must first authenticate with GitHub."
-            raise ValidationError(dict(detail=msg))
+            msg = (
+                "Failed to get GitHub token for user {0} "
+                "You must first authenticate with GitHub."
+                .format(request.user.username)
+            )
+            raise ValidationError({'detail': msg})
 
         try:
             gh_api = Github(token.token)
             gh_api.get_api_status()
         except GithubException as e:
-            msg = "Failed to connect to GitHub API. This is most likely a temporary error, " + \
-                  "please try again in a few minutes. {0} - {1}".format(e.data, e.status)
-            raise ValidationError(dict(detail=msg))
+            msg = (
+                "Failed to connect to GitHub API. This is most likely "
+                "a temporary error, please try again in a few minutes. "
+                "{0} - {1}".format(e.data, e.status)
+            )
+            raise ValidationError({'detail': msg})
 
         try:
             gh_repo = gh_api.get_repo(github_user + '/' + github_repo)
         except GithubException as e:
-            msg = "GitHub API failed to return repo for {0}/{1}. {2} - {3}".format(github_user,
-                                                                                   github_repo,
-                                                                                   e.data,
-                                                                                   e.status)
-            raise ValidationError(dict(detail=msg))
+            msg = (
+                "GitHub API failed to return repo for {0}/{1}. {2} - {3}"
+                .format(github_user, github_repo, e.data, e.status)
+            )
+            raise ValidationError({'detail': msg})
 
         try:
             gh_user = gh_api.get_user()
         except GithubException as e:
-            msg = "GitHub API failed to return authorized user. {0} - {1}".format(e.data, e.status)
-            raise ValidationError(dict(detail=msg))
+            msg = (
+                "GitHub API failed to return authorized user. {0} - {1}"
+                .format(e.data, e.status)
+            )
+            raise ValidationError({'detail': msg})
 
         try:
             gh_user.add_to_starred(gh_repo)
         except GithubException as e:
-            msg = "GitHub API failed to add user {0} to stargazers ".format(request.user.username) + \
-                "for {0}/{1}. {2} - {3}".format(github_user, github_repo, e.data, e.status)
-            raise ValidationError(dict(detail=msg))
+            msg = (
+                "GitHub API failed to add user {0} to stargazers "
+                "for {1}/{2}. {3} - {4}"
+                .format(request.user.username, github_user, github_repo,
+                        e.data, e.status)
+            )
+            raise ValidationError({'detail': msg})
 
-        repo = models.Repository.objects.get(github_user=github_user,
-                                             github_repo=github_repo)
+        repo = models.Repository.objects.get(
+            github_user=github_user, github_repo=github_repo
+        )
         star = repo.stars.create(owner=request.user)
         repo.stargazers_count = gh_repo.stargazers_count + 1
         repo.save()
@@ -593,14 +625,16 @@ class StargazerDetail(base_views.RetrieveUpdateDestroyAPIView):
         obj = super(StargazerDetail, self).get_object()
 
         try:
-            token = SocialToken.objects.get(account__user=request.user, account__provider='github')
+            token = SocialToken.objects.get(
+                account__user=request.user, account__provider='github'
+            )
         except Exception:
             msg = (
                 "Failed to connect to GitHub account for Galaxy user {}. "
                 "You must first authenticate with Github."
                 .format(request.user.username)
             )
-            raise ValidationError(dict(detail=msg))
+            raise ValidationError({'detail': msg})
         try:
             gh_api = Github(token.token)
             gh_api.get_api_status()
@@ -610,7 +644,7 @@ class StargazerDetail(base_views.RetrieveUpdateDestroyAPIView):
                 "temporary error, please try again in a few minutes. {} - {}"
                 .format(e.data, e.status)
             )
-            raise ValidationError(dict(detail=msg))
+            raise ValidationError({'detail': msg})
 
         try:
             gh_repo = gh_api.get_repo(
@@ -620,7 +654,7 @@ class StargazerDetail(base_views.RetrieveUpdateDestroyAPIView):
                 "GitHub API failed to return repo for {}/{}. {} - {}"
                 .format(obj.github_user, obj.github_repo, e.data, e.status)
             )
-            raise ValidationError(dict(detail=msg))
+            raise ValidationError({'detail': msg})
 
         try:
             gh_user = gh_api.get_user()
@@ -629,7 +663,7 @@ class StargazerDetail(base_views.RetrieveUpdateDestroyAPIView):
                 "GitHub API failed to return authorized user. {} - {}"
                 .format(e.data, e.status)
             )
-            raise ValidationError(dict(detail=msg))
+            raise ValidationError({'detail': msg})
 
         try:
             gh_user.remove_from_starred(gh_repo)
@@ -640,12 +674,14 @@ class StargazerDetail(base_views.RetrieveUpdateDestroyAPIView):
                 .format(request.user.username, obj.github_user,
                         obj.github_repo, e.data, e.status)
             )
-            raise ValidationError(dict(detail=msg))
+            raise ValidationError({'detail': msg})
 
         obj.delete()
 
-        repo = models.Repository.objects.get(github_user=obj.role.github_user,
-                                             github_repo=obj.role.github_repo)
+        repo = models.Repository.objects.get(
+            github_user=obj.role.github_user,
+            github_repo=obj.role.github_repo,
+        )
         repo.stargazers_count = max(0, gh_repo.stargazers_count - 1)
         repo.save()
 
@@ -661,10 +697,16 @@ class SubscriptionList(base_views.ListCreateAPIView):
         github_repo = request.data.get('github_repo', None)
 
         if not github_user or not github_repo:
-            raise ValidationError(dict(detail="Invalid request. Missing one or more required values."))
+            raise ValidationError({
+                'detail': "Invalid request. "
+                          "Missing one or more required values."
+            })
 
         try:
-            token = SocialToken.objects.get(account__user=request.user, account__provider='github')
+            token = SocialToken.objects.get(
+                account__user=request.user,
+                account__provider='github'
+            )
         except Exception:
             msg = (
                 "Failed to connect to GitHub account for Galaxy user {}. "
@@ -748,7 +790,9 @@ class SubscriptionDetail(base_views.RetrieveUpdateDestroyAPIView):
         obj = super(SubscriptionDetail, self).get_object()
 
         try:
-            token = SocialToken.objects.get(account__user=request.user, account__provider='github')
+            token = SocialToken.objects.get(
+                account__user=request.user, account__provider='github'
+            )
         except Exception:
             msg = (
                 "Failed to access GitHub account for Galaxy user {}. "
@@ -823,10 +867,16 @@ class UserDetail(base_views.RetrieveAPIView):
         # make sure non-read-only fields that can only be edited by admins,
         # are only edited by admins
         obj = User.objects.get(pk=kwargs['pk'])
-        can_change = check_user_access(request.user, User, 'change', obj, request.data)
-        can_admin = check_user_access(request.user, User, 'admin', obj, request.data)
+        can_change = check_user_access(
+            request.user, User, 'change', obj, request.data
+        )
+        can_admin = check_user_access(
+            request.user, User, 'admin', obj, request.data
+        )
         if can_change and not can_admin:
-            admin_only_edit_fields = ('full_name', 'username', 'is_active', 'is_superuser')
+            admin_only_edit_fields = (
+                'full_name', 'username', 'is_active', 'is_superuser'
+            )
             changed = {}
             for field in admin_only_edit_fields:
                 left = getattr(obj, field, None)
@@ -834,7 +884,9 @@ class UserDetail(base_views.RetrieveAPIView):
                 if left is not None and right is not None and left != right:
                     changed[field] = (left, right)
             if changed:
-                raise PermissionDenied('Cannot change %s' % ', '.join(changed.keys()))
+                raise PermissionDenied(
+                    'Cannot change %s' % ', '.join(changed.keys())
+                )
 
     def get_object(self, qs=None):
         obj = super(UserDetail, self).get_object()
@@ -898,14 +950,16 @@ class RemoveRole(base_views.APIView):
         if not request.user.is_staff:
             # Verify via GitHub API that user has access to requested role
             try:
-                token = SocialToken.objects.get(account__user=request.user, account__provider='github')
+                token = SocialToken.objects.get(
+                    account__user=request.user, account__provider='github'
+                )
             except Exception:
                 msg = (
                     "Failed to get Github account for Galaxy user {}. "
                     "You must first authenticate with Github."
                     .format(request.user.username)
                 )
-                raise ValidationError(dict(detail=msg))
+                raise ValidationError({'detail': msg})
 
             try:
                 gh_api = Github(token.token)
@@ -913,15 +967,17 @@ class RemoveRole(base_views.APIView):
             except GithubException as e:
                 msg = (
                     "Failed to connect to GitHub API. This is most likely a "
-                    "temporary error, please try again in a few minutes. {} - {}"
-                    .format(e.data, e.status)
+                    "temporary error, please try again in a few minutes. "
+                    "{} - {}".format(e.data, e.status)
                 )
-                raise ValidationError(dict(detail=msg))
+                raise ValidationError({'detail': msg})
 
             try:
                 ghu = gh_api.get_user()
             except Exception:
-                raise ValidationError(dict(detail="Failed to get Github authorized user."))
+                raise ValidationError(
+                    {'detail': "Failed to get Github authorized user."}
+                )
 
             allowed = False
             repo_full_name = "{}/{}".format(gh_user, gh_repo)
@@ -931,8 +987,10 @@ class RemoveRole(base_views.APIView):
                     continue
 
             if not allowed:
-                msg = "Galaxy user {0} does not have access to repo {1}".format(
-                    request.user.username, repo_full_name)
+                msg = (
+                    "Galaxy user {0} does not have access to repo {1}"
+                    .format(request.user.username, repo_full_name)
+                )
                 raise ValidationError(dict(detail=msg))
 
         # User has access. Delete requested role and associated bits.
@@ -981,16 +1039,19 @@ class RemoveRole(base_views.APIView):
 
 
 class RefreshUserRepos(base_views.APIView):
-    '''
-    Return user GitHub repos directly from GitHub. Use to refresh cache for the authenticated user.
-    '''
+    """
+    Return user GitHub repos directly from GitHub.
+    Use to refresh cache for the authenticated user.
+    """
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, *args, **kwargs):
         # Return a the list of user's repositories directly from GitHub
         try:
-            token = SocialToken.objects.get(account__user=request.user, account__provider='github')
+            token = SocialToken.objects.get(
+                account__user=request.user, account__provider='github'
+            )
         except Exception:
             msg = (
                 "Failed to connect to GitHub account for Galaxy user {} "
@@ -1054,32 +1115,40 @@ class TokenView(base_views.APIView):
         github_token = request.data.get('github_token', None)
 
         if github_token is None:
-            raise ValidationError(dict(detail="Invalid request."))
+            raise ValidationError({'detail': "Invalid request."})
 
         try:
             git_status = requests.get(settings.GITHUB_SERVER)
             git_status.raise_for_status()
         except Exception:
-            raise ValidationError(dict(detail="Error accessing GitHub API. Please try again later."))
+            raise ValidationError({
+                'detail': "Error accessing GitHub API. Please try again later."
+            })
 
         try:
             header = dict(Authorization='token ' + github_token)
-            gh_user = requests.get(settings.GITHUB_SERVER + '/user', headers=header)
+            gh_user = requests.get(
+                settings.GITHUB_SERVER + '/user', headers=header
+            )
             gh_user.raise_for_status()
             gh_user = gh_user.json()
             if hasattr(gh_user, 'message'):
-                raise ValidationError(dict(detail=gh_user['message']))
+                raise ValidationError({'detail': gh_user['message']})
         except Exception:
-            raise ValidationError(dict(detail="Error accessing GitHub with provided token."))
+            raise ValidationError({
+                'detail': "Error accessing GitHub with provided token."
+            })
 
-        if SocialAccount.objects.filter(provider='github', uid=gh_user['id']).count() > 0:
-            user = SocialAccount.objects.get(provider='github', uid=gh_user['id']).user
+        if SocialAccount.objects.filter(
+                provider='github', uid=gh_user['id']).count() > 0:
+            user = SocialAccount.objects.get(
+                provider='github', uid=gh_user['id']).user
         else:
             msg = (
                 "Galaxy user not found. You must first log into Galaxy using "
                 "your GitHub account."
             )
-            raise ValidationError(dict(detail=msg))
+            raise ValidationError({'detail': msg})
 
         if Token.objects.filter(user=user).count() > 0:
             token = Token.objects.filter(user=user)[0]

--- a/galaxy/importer/loaders/apb.py
+++ b/galaxy/importer/loaders/apb.py
@@ -124,8 +124,8 @@ class APBMetaParser(object):
             if plan.get('parameters'):
                 if not isinstance(plan['parameters'], list):
                     raise exc.APBContentLoadError(
-                        'Expecting "parameters" in "plans[{0}]" of metadata to '
-                        'be a list'.format(idx))
+                        'Expecting "parameters" in "plans[{0}]" '
+                        'of metadata to be a list'.format(idx))
                 pidx = 0
                 for params in plan['parameters']:
                     if not isinstance(params, dict):
@@ -183,7 +183,9 @@ class APBLoader(base.BaseLoader):
     linters = (linters.YamlLinter,)
 
     def __init__(self, content_type, path, root, metadata_path, logger=None):
-        super(APBLoader, self).__init__(content_type, path, root, logger=logger)
+        super(APBLoader, self).__init__(
+            content_type, path, root, logger=logger
+        )
         self.metadata_file = metadata_path
 
     def load(self):

--- a/galaxy/importer/loaders/role.py
+++ b/galaxy/importer/loaders/role.py
@@ -247,7 +247,9 @@ class RoleLoader(base.BaseLoader):
 
         description = data.pop('description')
 
-        data['role_type'] = self._get_role_type(galaxy_info, container_yml_type)
+        data['role_type'] = self._get_role_type(
+            galaxy_info, container_yml_type
+        )
         data['tags'] = meta_parser.parse_tags()
         data['platforms'] = meta_parser.parse_platforms()
         data['cloud_platforms'] = meta_parser.parse_cloud_platforms()

--- a/galaxy/importer/tests/test_role_loader.py
+++ b/galaxy/importer/tests/test_role_loader.py
@@ -52,8 +52,8 @@ class TestRoleMetaParser(unittest.TestCase):
 
         assert tags == ['database']
         self.log.warning.assert_called_once_with(
-            "'s q l' is not a valid tag. Tags must container lowercase letters "
-            "and digits only. Skipping.")
+            "'s q l' is not a valid tag. "
+            "Tags must container lowercase letters and digits only. Skipping.")
 
     def test_parse_categories(self):
         parser = role_loader.RoleMetaParser({
@@ -117,13 +117,14 @@ class TestRoleMetaParser(unittest.TestCase):
             'galaxy_info': {
                 'video_links': [{
                     'title': 'Google Drive Video',
-                    'url': 'https://drive.google.com/file/d/gxH17k3EzzJP3g/browse'
+                    'url': 'https://drive.google.com/'
+                           'file/d/gxH17k3EzzJP3g/browse',
                 }, {
                     'title': 'Vimeo Video',
                     'url': 'https://vimeo.com/1733124',
                 }, {
                     'title': 'Youtube Video',
-                    'url': 'https://youtu.be/TxHPpfkGms9eDQ'
+                    'url': 'https://youtu.be/TxHPpfkGms9eDQ',
                 }]
             },
             'dependencies': []
@@ -134,13 +135,16 @@ class TestRoleMetaParser(unittest.TestCase):
         assert videos == [
             models.VideoLink(
                 'https://drive.google.com/file/d/gxH17k3EzzJP3g/preview',
-                'Google Drive Video'),
+                'Google Drive Video'
+            ),
             models.VideoLink(
                 'https://player.vimeo.com/video/1733124',
-                'Vimeo Video'),
+                'Vimeo Video'
+            ),
             models.VideoLink(
                 'https://www.youtube.com/embed/TxHPpfkGms9eDQ',
-                'Youtube Video'),
+                'Youtube Video'
+            ),
         ]
 
 

--- a/galaxy/main/fields.py
+++ b/galaxy/main/fields.py
@@ -74,7 +74,7 @@ class LooseVersionField(models.Field):
         return str(value)
 
 
-# From: http://stackoverflow.com/questions/3459843/auto-truncating-fields-at-max-length-in-django-charfields
+# From: http://stackoverflow.com/questions/3459843/auto-truncating-fields-at-max-length-in-django-charfields # noqa: E501
 class TruncatingCharField(models.CharField):
     def get_prep_value(self, value):
         value = super(TruncatingCharField, self).get_prep_value(value)

--- a/galaxy/main/management/commands/reimport_role.py
+++ b/galaxy/main/management/commands/reimport_role.py
@@ -32,7 +32,11 @@ class Command(BaseCommand):
             raise Exception("Please provide a role ID.")
         role_id = options.get('role_id')[0]
         role = Content.objects.get(id=role_id)
-        last_task = ImportTask.objects.filter(role=role, state='SUCCESS').order_by('-id').first()
+        last_task = (
+            ImportTask.objects
+            .filter(role=role, state='SUCCESS')
+            .order_by('-id').first()
+        )
         task = ImportTask.objects.create(
             github_user=role.github_user,
             github_repo=role.github_repo,

--- a/galaxy/main/management/commands/waitenv.py
+++ b/galaxy/main/management/commands/waitenv.py
@@ -26,15 +26,20 @@ def wait_for_connection(host, port, attempts=10):
             pass
         time.sleep(6)
         attempts -= 1
-    logger.error('manage.py waitenv: Failed to connect to {}:{}'.format(host, port))
+    logger.error('manage.py waitenv: Failed to connect to {}:{}'
+                 .format(host, port))
     raise IOError('Cannot connect to {0}:{1}'.format(host, port))
 
 
 class Command(management.BaseCommand):
 
     def add_arguments(self, parser):
-        parser.add_argument('--wait-for', action='store', dest='services', default=[], nargs='+',
-                            help="Override settings.WAIT_FOR with a list of 'host:port' services to wait on")
+        parser.add_argument(
+            '--wait-for', action='store', dest='services',
+            default=[], nargs='+',
+            help="Override settings.WAIT_FOR with a list "
+                 "of 'host:port' services to wait on",
+        )
 
     def handle(self, *args, **options):
         logger.info('manage.py waitenv...')

--- a/galaxy/main/migrations/0001_initial.py
+++ b/galaxy/main/migrations/0001_initial.py
@@ -9,20 +9,36 @@ import galaxy.main.fields
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-    ]
+    dependencies = [migrations.swappable_dependency(settings.AUTH_USER_MODEL)]
 
     operations = [
         migrations.CreateModel(
             name='Category',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
-                ('name', models.CharField(unique=True, max_length=512, db_index=True)),
+                (
+                    'name',
+                    models.CharField(
+                        unique=True, max_length=512, db_index=True
+                    ),
+                ),
                 ('original_name', models.CharField(max_length=512)),
             ],
             options={
@@ -34,72 +50,240 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Platform',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
                 ('name', models.CharField(max_length=512, db_index=True)),
                 ('original_name', models.CharField(max_length=512)),
-                ('release', models.CharField(max_length=50, verbose_name=b'Distribution Release Version')),
+                (
+                    'release',
+                    models.CharField(
+                        max_length=50,
+                        verbose_name=b'Distribution Release Version',
+                    ),
+                ),
             ],
-            options={
-                'ordering': ['name', 'release'],
-            },
+            options={'ordering': ['name', 'release']},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.CreateModel(
             name='Role',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
                 ('name', models.CharField(max_length=512, db_index=True)),
                 ('original_name', models.CharField(max_length=512)),
-                ('github_user', models.CharField(max_length=256, verbose_name=b'Github Username')),
-                ('github_repo', models.CharField(max_length=256, verbose_name=b'Github Repository')),
+                (
+                    'github_user',
+                    models.CharField(
+                        max_length=256, verbose_name=b'Github Username'
+                    ),
+                ),
+                (
+                    'github_repo',
+                    models.CharField(
+                        max_length=256, verbose_name=b'Github Repository'
+                    ),
+                ),
                 ('readme', models.TextField(default=b'', blank=True)),
-                ('min_ansible_version', models.CharField(max_length=10, null=True, verbose_name=b'Minimum Ansible Version Required', blank=True)),
-                ('issue_tracker_url', models.CharField(max_length=256, null=True, verbose_name=b'Issue Tracker URL', blank=True)),
-                ('license', models.CharField(max_length=30, verbose_name=b'License (optional)', blank=True)),
-                ('company', models.CharField(max_length=50, null=True, verbose_name=b'Company Name (optional)', blank=True)),
-                ('is_valid', models.BooleanField(default=False, db_index=True)),
-                ('featured', models.BooleanField(default=False, editable=False)),
-                ('bayesian_score', models.FloatField(default=0.0, editable=False, db_index=True)),
-                ('authors', models.ManyToManyField(related_name='author_on', editable=False, to=settings.AUTH_USER_MODEL)),
-                ('categories', models.ManyToManyField(related_name='roles', editable=False, to='main.Category', blank=True, help_text=b'', verbose_name=b'Categories')),
-                ('dependencies', models.ManyToManyField(related_name='+', editable=False, to='main.Role', blank=True)),
-                ('owner', models.ForeignKey(related_name='roles', editable=False, to=settings.AUTH_USER_MODEL)),
-                ('platforms', models.ManyToManyField(related_name='roles', editable=False, to='main.Platform', blank=True, help_text=b'', verbose_name=b'Supported Platforms')),
+                (
+                    'min_ansible_version',
+                    models.CharField(
+                        max_length=10,
+                        null=True,
+                        verbose_name=b'Minimum Ansible Version Required',
+                        blank=True,
+                    ),
+                ),
+                (
+                    'issue_tracker_url',
+                    models.CharField(
+                        max_length=256,
+                        null=True,
+                        verbose_name=b'Issue Tracker URL',
+                        blank=True,
+                    ),
+                ),
+                (
+                    'license',
+                    models.CharField(
+                        max_length=30,
+                        verbose_name=b'License (optional)',
+                        blank=True,
+                    ),
+                ),
+                (
+                    'company',
+                    models.CharField(
+                        max_length=50,
+                        null=True,
+                        verbose_name=b'Company Name (optional)',
+                        blank=True,
+                    ),
+                ),
+                (
+                    'is_valid',
+                    models.BooleanField(default=False, db_index=True),
+                ),
+                (
+                    'featured',
+                    models.BooleanField(default=False, editable=False),
+                ),
+                (
+                    'bayesian_score',
+                    models.FloatField(
+                        default=0.0, editable=False, db_index=True
+                    ),
+                ),
+                (
+                    'authors',
+                    models.ManyToManyField(
+                        related_name='author_on',
+                        editable=False,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    'categories',
+                    models.ManyToManyField(
+                        related_name='roles',
+                        editable=False,
+                        to='main.Category',
+                        blank=True,
+                        help_text=b'',
+                        verbose_name=b'Categories',
+                    ),
+                ),
+                (
+                    'dependencies',
+                    models.ManyToManyField(
+                        related_name='+',
+                        editable=False,
+                        to='main.Role',
+                        blank=True,
+                    ),
+                ),
+                (
+                    'owner',
+                    models.ForeignKey(
+                        related_name='roles',
+                        editable=False,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    'platforms',
+                    models.ManyToManyField(
+                        related_name='roles',
+                        editable=False,
+                        to='main.Platform',
+                        blank=True,
+                        help_text=b'',
+                        verbose_name=b'Supported Platforms',
+                    ),
+                ),
             ],
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.CreateModel(
             name='RoleImport',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
-                ('celery_task_id', models.CharField(default=b'', max_length=100, editable=False, db_index=True, blank=True)),
+                (
+                    'celery_task_id',
+                    models.CharField(
+                        default=b'',
+                        max_length=100,
+                        editable=False,
+                        db_index=True,
+                        blank=True,
+                    ),
+                ),
                 ('released', models.DateTimeField(auto_now_add=True)),
-                ('state', models.CharField(default=b'', max_length=20, db_index=True, blank=True)),
-                ('status_message', models.CharField(default=b'', max_length=512, blank=True)),
-                ('role', models.ForeignKey(related_name='imports', to='main.Role')),
+                (
+                    'state',
+                    models.CharField(
+                        default=b'', max_length=20, db_index=True, blank=True
+                    ),
+                ),
+                (
+                    'status_message',
+                    models.CharField(default=b'', max_length=512, blank=True),
+                ),
+                (
+                    'role',
+                    models.ForeignKey(related_name='imports', to='main.Role'),
+                ),
             ],
-            options={
-                'get_latest_by': 'released',
-            },
+            options={'get_latest_by': 'released'},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.CreateModel(
             name='RoleRating',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
@@ -108,50 +292,105 @@ class Migration(migrations.Migration):
                 ('code_quality', models.IntegerField(default=5)),
                 ('wow_factor', models.IntegerField(default=5)),
                 ('comment', models.TextField(null=True, blank=True)),
-                ('score', models.FloatField(default=0.0, editable=False, db_index=True)),
-                ('down_votes', models.ManyToManyField(default=None, related_name='user_down_votes', to=settings.AUTH_USER_MODEL)),
-                ('owner', models.ForeignKey(related_name='ratings', to=settings.AUTH_USER_MODEL)),
-                ('role', models.ForeignKey(related_name='ratings', to='main.Role')),
-                ('up_votes', models.ManyToManyField(default=None, related_name='user_up_votes', to=settings.AUTH_USER_MODEL)),
+                (
+                    'score',
+                    models.FloatField(
+                        default=0.0, editable=False, db_index=True
+                    ),
+                ),
+                (
+                    'down_votes',
+                    models.ManyToManyField(
+                        default=None,
+                        related_name='user_down_votes',
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    'owner',
+                    models.ForeignKey(
+                        related_name='ratings', to=settings.AUTH_USER_MODEL
+                    ),
+                ),
+                (
+                    'role',
+                    models.ForeignKey(related_name='ratings', to='main.Role'),
+                ),
+                (
+                    'up_votes',
+                    models.ManyToManyField(
+                        default=None,
+                        related_name='user_up_votes',
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
             ],
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.CreateModel(
             name='RoleVersion',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
                 ('name', models.CharField(max_length=512, db_index=True)),
                 ('original_name', models.CharField(max_length=512)),
                 ('release_date', models.DateTimeField(null=True, blank=True)),
-                ('loose_version', galaxy.main.fields.LooseVersionField(editable=False, db_index=True)),
-                ('role', models.ForeignKey(related_name='versions', to='main.Role')),
+                (
+                    'loose_version',
+                    galaxy.main.fields.LooseVersionField(
+                        editable=False, db_index=True
+                    ),
+                ),
+                (
+                    'role',
+                    models.ForeignKey(related_name='versions', to='main.Role'),
+                ),
             ],
-            options={
-                'ordering': ('-loose_version',),
-            },
+            options={'ordering': ('-loose_version',)},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.CreateModel(
             name='UserAlias',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
                 ('alias_name', models.CharField(unique=True, max_length=30)),
-                ('alias_of', models.ForeignKey(related_name='aliases', to=settings.AUTH_USER_MODEL)),
+                (
+                    'alias_of',
+                    models.ForeignKey(
+                        related_name='aliases', to=settings.AUTH_USER_MODEL
+                    ),
+                ),
             ],
-            options={
-                'verbose_name_plural': 'UserAliases',
-            },
+            options={'verbose_name_plural': 'UserAliases'},
         ),
         migrations.AlterUniqueTogether(
-            name='rolerating',
-            unique_together=set([('owner', 'role')]),
+            name='rolerating', unique_together=set([('owner', 'role')])
         ),
         migrations.AlterUniqueTogether(
-            name='role',
-            unique_together=set([('owner', 'name')]),
+            name='role', unique_together=set([('owner', 'name')])
         ),
     ]

--- a/galaxy/main/migrations/0005_auto_20150824_1444.py
+++ b/galaxy/main/migrations/0005_auto_20150824_1444.py
@@ -7,19 +7,20 @@ from galaxy.api.aggregators import AvgWithZeroForNull
 
 
 class Migration(migrations.Migration):
-
     def update_roles(apps, schema_editor):
-        # Going forward num_ratings and average_score will be stored on the role
+        # Going forward num_ratings and average_score
+        # will be stored on the role
         Roles = apps.get_model("main", "Role")
         for role in Roles.objects.all():
             role.num_ratings = role.ratings.filter(active=True).count()
-            role.average_score = role.ratings.filter(active=True).aggregate(avg=AvgWithZeroForNull('score'))['avg'] or 0
+            role.average_score = (
+                role.ratings.filter(active=True).aggregate(
+                    avg=AvgWithZeroForNull('score')
+                )['avg']
+                or 0
+            )
             role.save()
 
-    dependencies = [
-        ('main', '0004_auto_20150824_1430'),
-    ]
+    dependencies = [('main', '0004_auto_20150824_1430')]
 
-    operations = [
-        migrations.RunPython(update_roles)
-    ]
+    operations = [migrations.RunPython(update_roles)]

--- a/galaxy/main/migrations/0014_auto_20150917_1211.py
+++ b/galaxy/main/migrations/0014_auto_20150917_1211.py
@@ -9,9 +9,7 @@ import galaxy.main.mixins
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0010_auto_20150826_1017'),
-    ]
+    dependencies = [('main', '0010_auto_20150826_1017')]
 
     @transaction.atomic
     def copy_categories_to_tags(apps, schema_editor):
@@ -22,11 +20,7 @@ class Migration(migrations.Migration):
             for name in category.name.split(':'):
                 try:
                     with transaction.atomic():
-                        tag = Tag(
-                            name=name,
-                            description=name,
-                            active=True
-                        )
+                        tag = Tag(name=name, description=name, active=True)
                         tag.save()
                 except IntegrityError:
                     pass
@@ -47,24 +41,45 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Tag',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
-                ('name', models.CharField(unique=True, max_length=512, db_index=True)),
+                (
+                    'name',
+                    models.CharField(
+                        unique=True, max_length=512, db_index=True
+                    ),
+                ),
                 ('original_name', models.CharField(max_length=512)),
             ],
-            options={
-                'ordering': ['name'],
-                'verbose_name_plural': 'Tags',
-            },
+            options={'ordering': ['name'], 'verbose_name_plural': 'Tags'},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.AddField(
             model_name='role',
             name='tags',
-            field=models.ManyToManyField(related_name='tags', verbose_name=b'Tags', editable=False, to='main.Tag', blank=True),
+            field=models.ManyToManyField(
+                related_name='tags',
+                verbose_name=b'Tags',
+                editable=False,
+                to='main.Tag',
+                blank=True,
+            ),
         ),
         migrations.RunPython(copy_categories_to_tags),
         migrations.RunPython(copy_tags),

--- a/galaxy/main/migrations/0015_auto_20150917_1504.py
+++ b/galaxy/main/migrations/0015_auto_20150917_1504.py
@@ -6,19 +6,31 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0014_auto_20150917_1211'),
-    ]
+    dependencies = [('main', '0014_auto_20150917_1211')]
 
     operations = [
         migrations.AlterField(
             model_name='role',
             name='categories',
-            field=models.ManyToManyField(related_name='categories', editable=False, to='main.Category', blank=True, help_text=b'', verbose_name=b'Categories'),
+            field=models.ManyToManyField(
+                related_name='categories',
+                editable=False,
+                to='main.Category',
+                blank=True,
+                help_text=b'',
+                verbose_name=b'Categories',
+            ),
         ),
         migrations.AlterField(
             model_name='role',
             name='tags',
-            field=models.ManyToManyField(related_name='roles', editable=False, to='main.Tag', blank=True, help_text=b'', verbose_name=b'Tags'),
+            field=models.ManyToManyField(
+                related_name='roles',
+                editable=False,
+                to='main.Tag',
+                blank=True,
+                help_text=b'',
+                verbose_name=b'Tags',
+            ),
         ),
     ]

--- a/galaxy/main/migrations/0016_auto_20150922_1041.py
+++ b/galaxy/main/migrations/0016_auto_20150922_1041.py
@@ -6,14 +6,17 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0015_auto_20150917_1504'),
-    ]
+    dependencies = [('main', '0015_auto_20150917_1504')]
 
     operations = [
         migrations.AddField(
             model_name='platform',
             name='alias',
-            field=models.CharField(max_length=256, null=True, verbose_name=b'Search terms', blank=True),
-        ),
+            field=models.CharField(
+                max_length=256,
+                null=True,
+                verbose_name=b'Search terms',
+                blank=True,
+            ),
+        )
     ]

--- a/galaxy/main/migrations/0017_auto_20151104_1700.py
+++ b/galaxy/main/migrations/0017_auto_20151104_1700.py
@@ -6,22 +6,21 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0016_auto_20150922_1041'),
-    ]
+    dependencies = [('main', '0016_auto_20150922_1041')]
 
     operations = [
-        migrations.RemoveField(
-            model_name='role',
-            name='authors',
-        ),
+        migrations.RemoveField(model_name='role', name='authors'),
         migrations.AddField(
             model_name='role',
             name='namespace',
-            field=models.CharField(max_length=256, null=True, verbose_name=b'Namespace', blank=True),
+            field=models.CharField(
+                max_length=256,
+                null=True,
+                verbose_name=b'Namespace',
+                blank=True,
+            ),
         ),
         migrations.AlterUniqueTogether(
-            name='role',
-            unique_together=set([('namespace', 'name')]),
+            name='role', unique_together={('namespace', 'name')}
         ),
     ]

--- a/galaxy/main/migrations/0018_auto_20151104_1701.py
+++ b/galaxy/main/migrations/0018_auto_20151104_1701.py
@@ -5,11 +5,12 @@ from django.db import migrations, transaction
 
 
 class Migration(migrations.Migration):
-
     @transaction.atomic
     def set_namespace(apps, schema_editor):
         Roles = apps.get_model("main", "Role")
-        for role in Roles.objects.all().order_by('github_user', 'name', '-modified'):
+        for role in Roles.objects.all().order_by(
+            'github_user', 'name', '-modified'
+        ):
             try:
                 with transaction.atomic():
                     role.namespace = role.owner.username
@@ -17,10 +18,6 @@ class Migration(migrations.Migration):
             except Exception:
                 pass
 
-    dependencies = [
-        ('main', '0017_auto_20151104_1700'),
-    ]
+    dependencies = [('main', '0017_auto_20151104_1700')]
 
-    operations = [
-        migrations.RunPython(set_namespace),
-    ]
+    operations = [migrations.RunPython(set_namespace)]

--- a/galaxy/main/migrations/0019_auto_20151113_0936.py
+++ b/galaxy/main/migrations/0019_auto_20151113_0936.py
@@ -19,90 +19,242 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ImportTask',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
-                ('github_user', models.CharField(max_length=256, verbose_name=b'Github Username')),
-                ('github_repo', models.CharField(max_length=256, verbose_name=b'Github Repository')),
-                ('github_reference', models.CharField(max_length=256, verbose_name=b'Github Reference')),
-                ('alternate_role_name', models.CharField(max_length=256, null=True, verbose_name=b'Alternate Role Name', blank=True)),
-                ('celery_task_id', models.CharField(max_length=100, null=True, blank=True)),
+                (
+                    'github_user',
+                    models.CharField(
+                        max_length=256, verbose_name=b'Github Username'
+                    ),
+                ),
+                (
+                    'github_repo',
+                    models.CharField(
+                        max_length=256, verbose_name=b'Github Repository'
+                    ),
+                ),
+                (
+                    'github_reference',
+                    models.CharField(
+                        max_length=256, verbose_name=b'Github Reference'
+                    ),
+                ),
+                (
+                    'alternate_role_name',
+                    models.CharField(
+                        max_length=256,
+                        null=True,
+                        verbose_name=b'Alternate Role Name',
+                        blank=True,
+                    ),
+                ),
+                (
+                    'celery_task_id',
+                    models.CharField(max_length=100, null=True, blank=True),
+                ),
                 ('state', models.CharField(default=b'PENDING', max_length=20)),
                 ('started', models.DateTimeField(null=True, blank=True)),
-                ('owner', models.ForeignKey(related_name='import_tasks', to=settings.AUTH_USER_MODEL)),
-                ('role', models.ForeignKey(related_name='import_tasks', to='main.Role')),
+                (
+                    'owner',
+                    models.ForeignKey(
+                        related_name='import_tasks',
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    'role',
+                    models.ForeignKey(
+                        related_name='import_tasks', to='main.Role'
+                    ),
+                ),
             ],
-            options={
-                'ordering': ('-id',),
-                'get_latest_by': 'created',
-            },
+            options={'ordering': ('-id',), 'get_latest_by': 'created'},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.CreateModel(
             name='ImportTaskMessage',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
                 ('message_type', models.CharField(max_length=10)),
                 ('message_text', models.CharField(max_length=256)),
-                ('task', models.ForeignKey(related_name='messages', to='main.ImportTask')),
+                (
+                    'task',
+                    models.ForeignKey(
+                        related_name='messages', to='main.ImportTask'
+                    ),
+                ),
             ],
-            options={
-                'abstract': False,
-            },
+            options={'abstract': False},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.CreateModel(
             name='Notification',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
-                ('source', models.CharField(max_length=20, verbose_name=b'Source', editable=False)),
-                ('owner', models.ForeignKey(related_name='notifications', to=settings.AUTH_USER_MODEL, editable=False)),
-                ('roles', models.ManyToManyField(related_name='notifications', verbose_name=b'Roles', to='main.Role', editable=False)),
-                ('imports', models.ManyToManyField(related_name='notifications', verbose_name=b'Tasks', to='main.ImportTask', editable=False)),
-                ('github_branch', models.CharField(max_length=256, verbose_name=b'GitHub Branch', blank=True, editable=False)),
-                ('messages', django.contrib.postgres.fields.ArrayField(default=list, base_field=models.CharField(max_length=256), size=None, editable=False))
+                (
+                    'source',
+                    models.CharField(
+                        max_length=20, verbose_name=b'Source', editable=False
+                    ),
+                ),
+                (
+                    'owner',
+                    models.ForeignKey(
+                        related_name='notifications',
+                        to=settings.AUTH_USER_MODEL,
+                        editable=False,
+                    ),
+                ),
+                (
+                    'roles',
+                    models.ManyToManyField(
+                        related_name='notifications',
+                        verbose_name=b'Roles',
+                        to='main.Role',
+                        editable=False,
+                    ),
+                ),
+                (
+                    'imports',
+                    models.ManyToManyField(
+                        related_name='notifications',
+                        verbose_name=b'Tasks',
+                        to='main.ImportTask',
+                        editable=False,
+                    ),
+                ),
+                (
+                    'github_branch',
+                    models.CharField(
+                        max_length=256,
+                        verbose_name=b'GitHub Branch',
+                        blank=True,
+                        editable=False,
+                    ),
+                ),
+                (
+                    'messages',
+                    django.contrib.postgres.fields.ArrayField(
+                        default=list,
+                        base_field=models.CharField(max_length=256),
+                        size=None,
+                        editable=False,
+                    ),
+                ),
             ],
-            options={
-                'ordering': ('-id',),
-            },
+            options={'ordering': ('-id',)},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.CreateModel(
             name='NotificationSecret',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
-                ('source', models.CharField(max_length=20, verbose_name=b'Source')),
-                ('secret', models.CharField(max_length=256, verbose_name=b'Secret', db_index=True)),
-                ('owner', models.ForeignKey(related_name='notification_secrets', to=settings.AUTH_USER_MODEL)),
-                ('github_repo', models.CharField(max_length=256, verbose_name=b'Github Repository')),
-                ('github_user', models.CharField(max_length=256, verbose_name=b'Github Username')),
+                (
+                    'source',
+                    models.CharField(max_length=20, verbose_name=b'Source'),
+                ),
+                (
+                    'secret',
+                    models.CharField(
+                        max_length=256, verbose_name=b'Secret', db_index=True
+                    ),
+                ),
+                (
+                    'owner',
+                    models.ForeignKey(
+                        related_name='notification_secrets',
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    'github_repo',
+                    models.CharField(
+                        max_length=256, verbose_name=b'Github Repository'
+                    ),
+                ),
+                (
+                    'github_user',
+                    models.CharField(
+                        max_length=256, verbose_name=b'Github Username'
+                    ),
+                ),
             ],
-            options={
-                'ordering': ('source', 'github_user', 'github_repo',),
-            },
+            options={'ordering': ('source', 'github_user', 'github_repo')},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.AlterUniqueTogether(
             name='notificationsecret',
-            unique_together=set([('source', 'github_user', 'github_repo')]),
+            unique_together={('source', 'github_user', 'github_repo')},
         ),
         migrations.AlterModelOptions(
-            name='role',
-            options={'ordering': ['namespace', 'name']},
+            name='role', options={'ordering': ['namespace', 'name']}
         ),
         migrations.AlterField(
             model_name='role',
@@ -112,22 +264,21 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='role',
             name='license',
-            field=models.CharField(max_length=50, verbose_name=b'License (optional)', blank=True),
+            field=models.CharField(
+                max_length=50, verbose_name=b'License (optional)', blank=True
+            ),
         ),
-        migrations.RemoveField(
-            model_name='roleimport',
-            name='role',
-        ),
-        migrations.RemoveField(
-            model_name='role',
-            name='owner',
-        ),
+        migrations.RemoveField(model_name='roleimport', name='role'),
+        migrations.RemoveField(model_name='role', name='owner'),
         migrations.AddField(
             model_name='role',
             name='github_branch',
-            field=models.CharField(default=b'', max_length=256, verbose_name=b'Github Branch', blank=True),
+            field=models.CharField(
+                default=b'',
+                max_length=256,
+                verbose_name=b'Github Branch',
+                blank=True,
+            ),
         ),
-        migrations.DeleteModel(
-            name='RoleImport',
-        )
+        migrations.DeleteModel(name='RoleImport'),
     ]

--- a/galaxy/main/migrations/0020_auto_20151118_1350.py
+++ b/galaxy/main/migrations/0020_auto_20151118_1350.py
@@ -6,9 +6,7 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0019_auto_20151113_0936'),
-    ]
+    dependencies = [('main', '0019_auto_20151113_0936')]
 
     operations = [
         migrations.AddField(
@@ -34,6 +32,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='role',
             name='travis_status_url',
-            field=models.CharField(default=b'', max_length=256, verbose_name=b'Travis Build Status', blank=True),
+            field=models.CharField(
+                default=b'',
+                max_length=256,
+                verbose_name=b'Travis Build Status',
+                blank=True,
+            ),
         ),
     ]

--- a/galaxy/main/migrations/0026_auto_20151122_0827.py
+++ b/galaxy/main/migrations/0026_auto_20151122_0827.py
@@ -18,15 +18,45 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Repository',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
-                ('github_user', models.CharField(max_length=256, verbose_name=b'Github Username')),
-                ('github_repo', models.CharField(max_length=256, verbose_name=b'Github Repository')),
+                (
+                    'github_user',
+                    models.CharField(
+                        max_length=256, verbose_name=b'Github Username'
+                    ),
+                ),
+                (
+                    'github_repo',
+                    models.CharField(
+                        max_length=256, verbose_name=b'Github Repository'
+                    ),
+                ),
                 ('is_enabled', models.BooleanField(default=False)),
-                ('owner', models.ForeignKey(related_name='repositories', editable=False, to=settings.AUTH_USER_MODEL)),
+                (
+                    'owner',
+                    models.ForeignKey(
+                        related_name='repositories',
+                        editable=False,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
             ],
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
@@ -37,6 +67,8 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterIndexTogether(
             name='repository',
-            index_together=set([('owner', 'github_user', 'github_repo', 'is_enabled')]),
+            index_together={
+                ('owner', 'github_user', 'github_repo', 'is_enabled')
+            },
         ),
     ]

--- a/galaxy/main/migrations/0027_auto_20151125_0009.py
+++ b/galaxy/main/migrations/0027_auto_20151125_0009.py
@@ -22,6 +22,9 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterIndexTogether(
             name='repository',
-            index_together=set([('github_user', 'github_repo'), ('owner', 'github_user', 'github_repo', 'is_enabled')]),
+            index_together={
+                ('github_user', 'github_repo'),
+                ('owner', 'github_user', 'github_repo', 'is_enabled')
+            },
         )
     ]

--- a/galaxy/main/migrations/0029_importtask_github_branch.py
+++ b/galaxy/main/migrations/0029_importtask_github_branch.py
@@ -6,14 +6,17 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0028_auto_20151125_1231'),
-    ]
+    dependencies = [('main', '0028_auto_20151125_1231')]
 
     operations = [
         migrations.AddField(
             model_name='importtask',
             name='github_branch',
-            field=models.CharField(default=b'', max_length=256, verbose_name=b'Github Branch', blank=True),
-        ),
+            field=models.CharField(
+                default=b'',
+                max_length=256,
+                verbose_name=b'Github Branch',
+                blank=True,
+            ),
+        )
     ]

--- a/galaxy/main/migrations/0030_auto_20151127_0824.py
+++ b/galaxy/main/migrations/0030_auto_20151127_0824.py
@@ -18,43 +18,96 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Stargazer',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
-                ('github_user', models.CharField(max_length=256, verbose_name=b'Github Username')),
-                ('github_repo', models.CharField(max_length=256, verbose_name=b'Github Repository')),
-                ('owner', models.ForeignKey(related_name='starred', to=settings.AUTH_USER_MODEL)),
+                (
+                    'github_user',
+                    models.CharField(
+                        max_length=256, verbose_name=b'Github Username'
+                    ),
+                ),
+                (
+                    'github_repo',
+                    models.CharField(
+                        max_length=256, verbose_name=b'Github Repository'
+                    ),
+                ),
+                (
+                    'owner',
+                    models.ForeignKey(
+                        related_name='starred', to=settings.AUTH_USER_MODEL
+                    ),
+                ),
             ],
-            options={
-                'ordering': ('owner', 'github_user', 'github_repo'),
-            },
+            options={'ordering': ('owner', 'github_user', 'github_repo')},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.CreateModel(
             name='Subscription',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
-                ('github_user', models.CharField(max_length=256, verbose_name=b'Github Username')),
-                ('github_repo', models.CharField(max_length=256, verbose_name=b'Github Repository')),
-                ('owner', models.ForeignKey(related_name='subscriptions', to=settings.AUTH_USER_MODEL)),
+                (
+                    'github_user',
+                    models.CharField(
+                        max_length=256, verbose_name=b'Github Username'
+                    ),
+                ),
+                (
+                    'github_repo',
+                    models.CharField(
+                        max_length=256, verbose_name=b'Github Repository'
+                    ),
+                ),
+                (
+                    'owner',
+                    models.ForeignKey(
+                        related_name='subscriptions',
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
             ],
-            options={
-                'ordering': ('owner', 'github_user', 'github_repo'),
-            },
+            options={'ordering': ('owner', 'github_user', 'github_repo')},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.AlterIndexTogether(
             name='subscription',
-            index_together=set([('owner', 'github_user', 'github_repo')]),
+            index_together={('owner', 'github_user', 'github_repo')},
         ),
         migrations.AlterIndexTogether(
             name='stargazer',
-            index_together=set([('owner', 'github_user', 'github_repo')]),
+            index_together={('owner', 'github_user', 'github_repo')},
         ),
     ]

--- a/galaxy/main/migrations/0031_auto_20151129_1230.py
+++ b/galaxy/main/migrations/0031_auto_20151129_1230.py
@@ -7,15 +7,15 @@ from django.conf import settings
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0030_auto_20151127_0824'),
-    ]
+    dependencies = [('main', '0030_auto_20151127_0824')]
 
     operations = [
         migrations.AlterField(
             model_name='repository',
             name='owner',
-            field=models.ForeignKey(related_name='repositories', to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(
+                related_name='repositories', to=settings.AUTH_USER_MODEL
+            ),
         ),
         migrations.AlterUniqueTogether(
             name='stargazer',
@@ -26,11 +26,9 @@ class Migration(migrations.Migration):
             unique_together=set([('owner', 'github_user', 'github_repo')]),
         ),
         migrations.AlterIndexTogether(
-            name='stargazer',
-            index_together=set([]),
+            name='stargazer', index_together=set([])
         ),
         migrations.AlterIndexTogether(
-            name='subscription',
-            index_together=set([]),
+            name='subscription', index_together=set([])
         ),
     ]

--- a/galaxy/main/migrations/0033_refreshrolecount.py
+++ b/galaxy/main/migrations/0033_refreshrolecount.py
@@ -8,24 +8,33 @@ import galaxy.main.mixins
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0032_role_download_count'),
-    ]
+    dependencies = [('main', '0032_role_download_count')]
 
     operations = [
         migrations.CreateModel(
             name='RefreshRoleCount',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
                 ('state', models.CharField(max_length=20)),
             ],
-            options={
-                'abstract': False,
-            },
+            options={'abstract': False},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
-        ),
+        )
     ]

--- a/galaxy/main/migrations/0036_auto_20151205_2254.py
+++ b/galaxy/main/migrations/0036_auto_20151205_2254.py
@@ -6,20 +6,28 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0035_remove_roleversion_release_date'),
-    ]
+    dependencies = [('main', '0035_remove_roleversion_release_date')]
 
     operations = [
         migrations.AddField(
             model_name='importtask',
             name='travis_build_url',
-            field=models.CharField(default=b'', max_length=256, verbose_name=b'Travis Build URL', blank=True),
+            field=models.CharField(
+                default=b'',
+                max_length=256,
+                verbose_name=b'Travis Build URL',
+                blank=True,
+            ),
         ),
         migrations.AddField(
             model_name='importtask',
             name='travis_status_url',
-            field=models.CharField(default=b'', max_length=256, verbose_name=b'Travis Build Status', blank=True),
+            field=models.CharField(
+                default=b'',
+                max_length=256,
+                verbose_name=b'Travis Build Status',
+                blank=True,
+            ),
         ),
         migrations.AddField(
             model_name='notification',
@@ -29,11 +37,22 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='role',
             name='travis_build_url',
-            field=models.CharField(default=b'', max_length=256, verbose_name=b'Travis Build URL', blank=True),
+            field=models.CharField(
+                default=b'',
+                max_length=256,
+                verbose_name=b'Travis Build URL',
+                blank=True,
+            ),
         ),
         migrations.AlterField(
             model_name='importtask',
             name='github_reference',
-            field=models.CharField(default=b'', max_length=256, null=True, verbose_name=b'Github Reference', blank=True),
+            field=models.CharField(
+                default=b'',
+                max_length=256,
+                null=True,
+                verbose_name=b'Github Reference',
+                blank=True,
+            ),
         ),
     ]

--- a/galaxy/main/migrations/0038_role_github_default_branch.py
+++ b/galaxy/main/migrations/0038_role_github_default_branch.py
@@ -6,14 +6,16 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0037_roleversion_release_date'),
-    ]
+    dependencies = [('main', '0037_roleversion_release_date')]
 
     operations = [
         migrations.AddField(
             model_name='role',
             name='github_default_branch',
-            field=models.CharField(default=b'master', max_length=256, verbose_name=b'Default Branch'),
-        ),
+            field=models.CharField(
+                default=b'master',
+                max_length=256,
+                verbose_name=b'Default Branch',
+            ),
+        )
     ]

--- a/galaxy/main/migrations/0039_namespace.py
+++ b/galaxy/main/migrations/0039_namespace.py
@@ -8,31 +8,99 @@ import galaxy.main.mixins
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0038_role_github_default_branch'),
-    ]
+    dependencies = [('main', '0038_role_github_default_branch')]
 
     operations = [
         migrations.CreateModel(
             name='Namespace',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('active', models.BooleanField(default=True, db_index=True)),
-                ('namespace', models.CharField(unique=True, max_length=256, verbose_name=b'GitHub namespace', db_index=True)),
-                ('name', models.CharField(max_length=256, null=True, verbose_name=b'GitHub name', blank=True)),
-                ('avatar_url', models.CharField(max_length=256, null=True, verbose_name=b'GitHub Avatar URL', blank=True)),
-                ('location', models.CharField(max_length=256, null=True, verbose_name=b'Location', blank=True)),
-                ('company', models.CharField(max_length=256, null=True, verbose_name=b'Location', blank=True)),
-                ('email', models.CharField(max_length=256, null=True, verbose_name=b'Location', blank=True)),
-                ('html_url', models.CharField(max_length=256, null=True, verbose_name=b'URL', blank=True)),
-                ('followers', models.IntegerField(null=True, verbose_name=b'Followers')),
+                (
+                    'namespace',
+                    models.CharField(
+                        unique=True,
+                        max_length=256,
+                        verbose_name=b'GitHub namespace',
+                        db_index=True,
+                    ),
+                ),
+                (
+                    'name',
+                    models.CharField(
+                        max_length=256,
+                        null=True,
+                        verbose_name=b'GitHub name',
+                        blank=True,
+                    ),
+                ),
+                (
+                    'avatar_url',
+                    models.CharField(
+                        max_length=256,
+                        null=True,
+                        verbose_name=b'GitHub Avatar URL',
+                        blank=True,
+                    ),
+                ),
+                (
+                    'location',
+                    models.CharField(
+                        max_length=256,
+                        null=True,
+                        verbose_name=b'Location',
+                        blank=True,
+                    ),
+                ),
+                (
+                    'company',
+                    models.CharField(
+                        max_length=256,
+                        null=True,
+                        verbose_name=b'Location',
+                        blank=True,
+                    ),
+                ),
+                (
+                    'email',
+                    models.CharField(
+                        max_length=256,
+                        null=True,
+                        verbose_name=b'Location',
+                        blank=True,
+                    ),
+                ),
+                (
+                    'html_url',
+                    models.CharField(
+                        max_length=256,
+                        null=True,
+                        verbose_name=b'URL',
+                        blank=True,
+                    ),
+                ),
+                (
+                    'followers',
+                    models.IntegerField(null=True, verbose_name=b'Followers'),
+                ),
             ],
-            options={
-                'ordering': ('namespace',),
-            },
+            options={'ordering': ('namespace',)},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
-        ),
+        )
     ]

--- a/galaxy/main/migrations/0040_auto_20160206_0921.py
+++ b/galaxy/main/migrations/0040_auto_20160206_0921.py
@@ -6,19 +6,21 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0039_namespace'),
-    ]
+    dependencies = [('main', '0039_namespace')]
 
     operations = [
         migrations.AddField(
             model_name='role',
             name='readme_type',
-            field=models.CharField(max_length=5, null=True, verbose_name=b'README type'),
+            field=models.CharField(
+                max_length=5, null=True, verbose_name=b'README type'
+            ),
         ),
         migrations.AlterField(
             model_name='role',
             name='readme',
-            field=models.TextField(default=b'', verbose_name=b'README content', blank=True),
+            field=models.TextField(
+                default=b'', verbose_name=b'README content', blank=True
+            ),
         ),
     ]

--- a/galaxy/main/migrations/0042_auto_20160721_2318.py
+++ b/galaxy/main/migrations/0042_auto_20160721_2318.py
@@ -6,24 +6,28 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0041_auto_20160207_2148'),
-    ]
+    dependencies = [('main', '0041_auto_20160207_2148')]
 
     operations = [
         migrations.AddField(
             model_name='role',
             name='readme_html',
-            field=models.TextField(default=b'', verbose_name=b'README HTML', blank=True),
+            field=models.TextField(
+                default=b'', verbose_name=b'README HTML', blank=True
+            ),
         ),
         migrations.AlterField(
             model_name='namespace',
             name='namespace',
-            field=models.CharField(unique=True, max_length=256, verbose_name=b'GitHub namespace'),
+            field=models.CharField(
+                unique=True, max_length=256, verbose_name=b'GitHub namespace'
+            ),
         ),
         migrations.AlterField(
             model_name='role',
             name='readme',
-            field=models.TextField(default=b'', verbose_name=b'README raw content', blank=True),
+            field=models.TextField(
+                default=b'', verbose_name=b'README raw content', blank=True
+            ),
         ),
     ]

--- a/galaxy/main/migrations/0043_role_role_type.py
+++ b/galaxy/main/migrations/0043_role_role_type.py
@@ -6,14 +6,21 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0042_auto_20160721_2318'),
-    ]
+    dependencies = [('main', '0042_auto_20160721_2318')]
 
     operations = [
         migrations.AddField(
             model_name='role',
             name='role_type',
-            field=models.CharField(default=b'ANS', max_length=3, editable=False, choices=[(b'ANS', b'Ansible'), (b'CON', b'Container Role'), (b'APP', b'Container App')]),
-        ),
+            field=models.CharField(
+                default=b'ANS',
+                max_length=3,
+                editable=False,
+                choices=[
+                    (b'ANS', b'Ansible'),
+                    (b'CON', b'Container Role'),
+                    (b'APP', b'Container App'),
+                ],
+            ),
+        )
     ]

--- a/galaxy/main/migrations/0044_auto_20160916_0839.py
+++ b/galaxy/main/migrations/0044_auto_20160916_0839.py
@@ -6,14 +6,14 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0043_role_role_type'),
-    ]
+    dependencies = [('main', '0043_role_role_type')]
 
     operations = [
         migrations.AddField(
             model_name='role',
             name='container_yml',
-            field=models.TextField(null=True, verbose_name=b'container.yml', blank=True),
+            field=models.TextField(
+                null=True, verbose_name=b'container.yml', blank=True
+            ),
         )
     ]

--- a/galaxy/main/migrations/0045_role_commit_created.py
+++ b/galaxy/main/migrations/0045_role_commit_created.py
@@ -6,14 +6,14 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0044_auto_20160916_0839'),
-    ]
+    dependencies = [('main', '0044_auto_20160916_0839')]
 
     operations = [
         migrations.AddField(
             model_name='role',
             name='commit_created',
-            field=models.DateTimeField(null=True, verbose_name=b'Laste Commit DateTime'),
-        ),
+            field=models.DateTimeField(
+                null=True, verbose_name=b'Laste Commit DateTime'
+            ),
+        )
     ]

--- a/galaxy/main/migrations/0046_auto_20160930_1752.py
+++ b/galaxy/main/migrations/0046_auto_20160930_1752.py
@@ -6,24 +6,41 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0045_role_commit_created'),
-    ]
+    dependencies = [('main', '0045_role_commit_created')]
 
     operations = [
         migrations.AddField(
             model_name='role',
             name='min_ansible_container_version',
-            field=models.CharField(max_length=10, null=True, verbose_name=b'Min Ansible Container Version', blank=True),
+            field=models.CharField(
+                max_length=10,
+                null=True,
+                verbose_name=b'Min Ansible Container Version',
+                blank=True,
+            ),
         ),
         migrations.AlterField(
             model_name='role',
             name='min_ansible_version',
-            field=models.CharField(max_length=10, null=True, verbose_name=b'Min Ansible Version', blank=True),
+            field=models.CharField(
+                max_length=10,
+                null=True,
+                verbose_name=b'Min Ansible Version',
+                blank=True,
+            ),
         ),
         migrations.AlterField(
             model_name='role',
             name='role_type',
-            field=models.CharField(default=b'ANS', max_length=3, editable=False, choices=[(b'ANS', b'Ansible'), (b'CON', b'Container Enabled'), (b'APP', b'Container App')]),
+            field=models.CharField(
+                default=b'ANS',
+                max_length=3,
+                editable=False,
+                choices=[
+                    (b'ANS', b'Ansible'),
+                    (b'CON', b'Container Enabled'),
+                    (b'APP', b'Container App'),
+                ],
+            ),
         ),
     ]

--- a/galaxy/main/migrations/0050_auto_20171024_0354.py
+++ b/galaxy/main/migrations/0050_auto_20171024_0354.py
@@ -8,29 +8,44 @@ import galaxy.main.mixins
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0049_auto_20161013_1744'),
-    ]
+    dependencies = [('main', '0049_auto_20161013_1744')]
 
     operations = [
         migrations.CreateModel(
             name='Video',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(default=b'', max_length=255, blank=True)),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('active', models.BooleanField(default=True, db_index=True)),
                 ('url', models.CharField(unique=True, max_length=256)),
             ],
-            options={
-                'verbose_name': 'videos',
-            },
+            options={'verbose_name': 'videos'},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.AddField(
             model_name='role',
             name='videos',
-            field=models.ManyToManyField(related_name='videos', verbose_name=b'videos', editable=False, to='main.Video', blank=True),
+            field=models.ManyToManyField(
+                related_name='videos',
+                verbose_name=b'videos',
+                editable=False,
+                to='main.Video',
+                blank=True,
+            ),
         ),
     ]

--- a/galaxy/main/migrations/0051_auto_20171108_2028.py
+++ b/galaxy/main/migrations/0051_auto_20171108_2028.py
@@ -6,19 +6,16 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0050_auto_20171024_0354'),
-    ]
+    dependencies = [('main', '0050_auto_20171024_0354')]
 
     operations = [
-        migrations.RemoveField(
-            model_name='role',
-            name='videos',
-        ),
+        migrations.RemoveField(model_name='role', name='videos'),
         migrations.AddField(
             model_name='video',
             name='role',
-            field=models.ForeignKey(related_name='videos', to='main.Role', help_text=b'', null=True),
+            field=models.ForeignKey(
+                related_name='videos', to='main.Role', help_text=b'', null=True
+            ),
         ),
         migrations.AlterField(
             model_name='video',

--- a/galaxy/main/migrations/0053_cloudplatform.py
+++ b/galaxy/main/migrations/0053_cloudplatform.py
@@ -8,35 +8,50 @@ import galaxy.main.mixins
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0052_auto_20171108_2113'),
-    ]
+    dependencies = [('main', '0052_auto_20171108_2113')]
 
     operations = [
         migrations.CreateModel(
             name='CloudPlatform',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False,
-                                        auto_created=True, primary_key=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
-                ('description', galaxy.main.fields.TruncatingCharField(
-                    default=b'', max_length=255, blank=True)),
+                (
+                    'description',
+                    galaxy.main.fields.TruncatingCharField(
+                        default=b'', max_length=255, blank=True
+                    ),
+                ),
                 ('active', models.BooleanField(default=True, db_index=True)),
-                ('name', models.CharField(unique=True, max_length=512, db_index=True)),
+                (
+                    'name',
+                    models.CharField(
+                        unique=True, max_length=512, db_index=True
+                    ),
+                ),
                 ('original_name', models.CharField(max_length=512)),
             ],
-            options={
-                'ordering': ['name'],
-            },
+            options={'ordering': ['name']},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.AddField(
             model_name='role',
             name='cloud_platforms',
-            field=models.ManyToManyField(related_name='roles',
-                                         verbose_name=b'Cloud Platforms',
-                                         editable=False,
-                                         to='main.CloudPlatform', blank=True),
+            field=models.ManyToManyField(
+                related_name='roles',
+                verbose_name=b'Cloud Platforms',
+                editable=False,
+                to='main.CloudPlatform',
+                blank=True,
+            ),
         ),
     ]

--- a/galaxy/main/migrations/0055_contentblock.py
+++ b/galaxy/main/migrations/0055_contentblock.py
@@ -48,7 +48,7 @@ MAIN_DOWNLOADS_BLOCK = """
 $ ansible-galaxy install username.rolename
 </pre>
 </div>
-"""
+"""  # noqa: E501
 
 MAIN_FEATURED_BLOG_BLOCK = """
 <span class="upcase title">BLOG:</span>
@@ -61,13 +61,16 @@ in the Ansible universe.</a>
 def upgrade_contentblocks_data(apps, schema_editor):
     ContentBlock = apps.get_model("main", "ContentBlock")
     db_alias = schema_editor.connection.alias
-    ContentBlock.objects.using(db_alias).bulk_create([
-        ContentBlock(name='main-title', content=MAIN_TITLE_BLOCK),
-        ContentBlock(name='main-share', content=MAIN_SHARE_BLOCK),
-        ContentBlock(name='main-downloads', content=MAIN_DOWNLOADS_BLOCK),
-        ContentBlock(name='main-featured-blog',
-                     content=MAIN_FEATURED_BLOG_BLOCK),
-    ])
+    ContentBlock.objects.using(db_alias).bulk_create(
+        [
+            ContentBlock(name='main-title', content=MAIN_TITLE_BLOCK),
+            ContentBlock(name='main-share', content=MAIN_SHARE_BLOCK),
+            ContentBlock(name='main-downloads', content=MAIN_DOWNLOADS_BLOCK),
+            ContentBlock(
+                name='main-featured-blog', content=MAIN_FEATURED_BLOG_BLOCK
+            ),
+        ]
+    )
 
 
 def downgrade_contentblocks_data(apps, schema_editor):
@@ -76,27 +79,33 @@ def downgrade_contentblocks_data(apps, schema_editor):
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0054_role_type_demo'),
-    ]
+    dependencies = [('main', '0054_role_type_demo')]
 
     operations = [
         migrations.CreateModel(
             name='ContentBlock',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False,
-                                        auto_created=True, primary_key=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        verbose_name='ID',
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('name', models.SlugField(unique=True)),
-                ('content', models.TextField(verbose_name=b'content',
-                                             blank=True)),
+                (
+                    'content',
+                    models.TextField(verbose_name=b'content', blank=True),
+                ),
             ],
-            options={
-                'abstract': False,
-            },
+            options={'abstract': False},
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
-        migrations.RunPython(upgrade_contentblocks_data,
-                             downgrade_contentblocks_data)
+        migrations.RunPython(
+            upgrade_contentblocks_data, downgrade_contentblocks_data
+        ),
     ]

--- a/galaxy/main/migrations/0075_repo_namespace_ref.py
+++ b/galaxy/main/migrations/0075_repo_namespace_ref.py
@@ -36,7 +36,8 @@ FROM main_repository r
 LEFT JOIN main_content c
     ON r.id = c.repository_id
 WHERE
-    (r.provider_namespace_id, r.name) IN ({0}) AND (c.id IS NULL OR c.is_valid = FALSE)
+    (r.provider_namespace_id, r.name) IN ({0})
+    AND (c.id IS NULL OR c.is_valid = FALSE)
 """.format(SELECT_DUPLICATE_REPOS)
 
 

--- a/galaxy/main/migrations/0080_auto_20180212_1111.py
+++ b/galaxy/main/migrations/0080_auto_20180212_1111.py
@@ -7,14 +7,14 @@ import galaxy.main.fields
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0079_auto_20180208_0650'),
-    ]
+    dependencies = [('main', '0079_auto_20180208_0650')]
 
     operations = [
         migrations.AlterField(
             model_name='repository',
             name='commit_message',
-            field=galaxy.main.fields.TruncatingCharField(default=b'', max_length=256, blank=True),
-        ),
+            field=galaxy.main.fields.TruncatingCharField(
+                default=b'', max_length=256, blank=True
+            ),
+        )
     ]

--- a/galaxy/main/migrations/0085_auto_20180328_1130.py
+++ b/galaxy/main/migrations/0085_auto_20180328_1130.py
@@ -7,19 +7,50 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0084_content_block_update'),
-    ]
+    dependencies = [('main', '0084_content_block_update')]
 
     operations = [
         migrations.AlterField(
             model_name='content',
             name='role_type',
-            field=models.CharField(choices=[('ANS', 'Ansible'), ('CON', 'Container Enabled'), ('APP', 'Container App'), ('DEM', 'Demo')], default=None, editable=False, max_length=3, null=True),
+            field=models.CharField(
+                choices=[
+                    ('ANS', 'Ansible'),
+                    ('CON', 'Container Enabled'),
+                    ('APP', 'Container App'),
+                    ('DEM', 'Demo'),
+                ],
+                default=None,
+                editable=False,
+                max_length=3,
+                null=True,
+            ),
         ),
         migrations.AlterField(
             model_name='contenttype',
             name='name',
-            field=models.CharField(choices=[('role', 'Role'), ('module', 'Module'), ('apb', 'Ansible Playbook Bundle'), ('action_plugin', 'Action Plugin'), ('cache_plugin', 'Cache Plugin'), ('callback_plugin', 'Callback Plugin'), ('cliconf_plugin', 'CLI Conf Plugin'), ('connection_plugin', 'Connection Plugin'), ('filter_plugin', 'Filter Plugin'), ('inventory_plugin', 'Inventory Plugin'), ('lookup_plugin', 'Lookup Plugin'), ('netconf_plugin', 'Netconf Plugin'), ('shell_plugin', 'Shell Plugin'), ('strategy_plugin', 'Strategy Plugin'), ('terminal_plugin', 'Terminal Plugin'), ('test_plugin', 'Test Plugin')], db_index=True, max_length=512, unique=True),
+            field=models.CharField(
+                choices=[
+                    ('role', 'Role'),
+                    ('module', 'Module'),
+                    ('apb', 'Ansible Playbook Bundle'),
+                    ('action_plugin', 'Action Plugin'),
+                    ('cache_plugin', 'Cache Plugin'),
+                    ('callback_plugin', 'Callback Plugin'),
+                    ('cliconf_plugin', 'CLI Conf Plugin'),
+                    ('connection_plugin', 'Connection Plugin'),
+                    ('filter_plugin', 'Filter Plugin'),
+                    ('inventory_plugin', 'Inventory Plugin'),
+                    ('lookup_plugin', 'Lookup Plugin'),
+                    ('netconf_plugin', 'Netconf Plugin'),
+                    ('shell_plugin', 'Shell Plugin'),
+                    ('strategy_plugin', 'Strategy Plugin'),
+                    ('terminal_plugin', 'Terminal Plugin'),
+                    ('test_plugin', 'Test Plugin'),
+                ],
+                db_index=True,
+                max_length=512,
+                unique=True,
+            ),
         ),
     ]

--- a/galaxy/main/migrations/0090_issue_tracker_url.py
+++ b/galaxy/main/migrations/0090_issue_tracker_url.py
@@ -8,7 +8,8 @@ from django.db import migrations, models
 UPDATE_REPOSITORY = """
 UPDATE main_repository rp SET (issue_tracker_url) = (
   SELECT DISTINCT
-  regexp_replace(regexp_replace(issue_tracker_url, 'api.', ''), '\{/number\}', '')
+  regexp_replace(regexp_replace(issue_tracker_url, 'api.', ''),
+                 '\{/number\}', '')
   FROM main_content c
   WHERE c.repository_id = rp.id
   LIMIT 1
@@ -18,23 +19,19 @@ UPDATE main_repository rp SET (issue_tracker_url) = (
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0089_delete_invalid_contents'),
-    ]
+    dependencies = [('main', '0089_delete_invalid_contents')]
 
     operations = [
         migrations.AddField(
             model_name='repository',
             name='issue_tracker_url',
-            field=models.CharField(blank=True, max_length=256,
-                                   null=True,
-                                   verbose_name=b'Issue Tracker URL'),
+            field=models.CharField(
+                blank=True,
+                max_length=256,
+                null=True,
+                verbose_name=b'Issue Tracker URL',
+            ),
         ),
-        migrations.RunSQL(
-            sql=UPDATE_REPOSITORY
-        ),
-        migrations.RemoveField(
-            model_name='content',
-            name='issue_tracker_url',
-        )
+        migrations.RunSQL(sql=UPDATE_REPOSITORY),
+        migrations.RemoveField(model_name='content', name='issue_tracker_url'),
     ]

--- a/galaxy/main/migrations/0098_readme.py
+++ b/galaxy/main/migrations/0098_readme.py
@@ -14,7 +14,8 @@ DROP FUNCTION update_content_search_vector();
 """
 
 CREATE_SEARCH_VECTOR_UPDATE_FUNCTIONS = """
-CREATE OR REPLACE FUNCTION on_content_update_search_vector_trigger() RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION on_content_update_search_vector_trigger()
+RETURNS TRIGGER AS $$
 DECLARE readme_raw TEXT;
 BEGIN
   SELECT raw INTO readme_raw FROM main_readme WHERE id = NEW.readme_id;
@@ -41,16 +42,19 @@ def copy_readme_to_separate_table(apps, schema_editor):
     # NOTE(cutwater): This query will not include readme objects that
     # have text but no type.
     contents = Content.objects.using(db_alias).filter(
-        readme_raw__isnull=False,
-        readme_type__isnull=False)
+        readme_raw__isnull=False, readme_type__isnull=False
+    )
     for content_obj in contents:
         if content_obj.readme_type == 'md':
             mimetype = 'text/markdown'
         elif content_obj.readme_type == 'rst':
             mimetype = 'text/x-rst'
         else:
-            raise ValueError('Unexpected readme_type value: "{0}"'
-                             .format(content_obj.readme_type))
+            raise ValueError(
+                'Unexpected readme_type value: "{0}"'.format(
+                    content_obj.readme_type
+                )
+            )
 
         readme_bytes = content_obj.readme_raw.encode('utf-8')
         readme_hash = hashlib.sha256(readme_bytes).hexdigest()
@@ -62,44 +66,51 @@ def copy_readme_to_separate_table(apps, schema_editor):
                 'raw': readme_bytes,
                 'html': content_obj.readme_html,
                 'mimetype': mimetype,
-            }
+            },
         )
         content_obj.readme = readme_obj
         content_obj.save()
 
 
 class Migration(migrations.Migration):
-    dependencies = [
-        ('main', '0097_delete_empty_repos'),
-    ]
+    dependencies = [('main', '0097_delete_empty_repos')]
 
     operations = [
         migrations.RunSQL(DROP_SEARCH_VECTOR_UPDATE_TRIGGER),
         migrations.RenameField(
-            model_name='content',
-            old_name='readme',
-            new_name='readme_raw'),
+            model_name='content', old_name='readme', new_name='readme_raw'
+        ),
         migrations.CreateModel(
             name='Readme',
             fields=[
-                ('id', models.AutoField(
-                    auto_created=True, primary_key=True,
-                    serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('raw', models.TextField()),
                 ('raw_hash', models.CharField(max_length=128)),
                 ('mimetype', models.CharField(max_length=32)),
                 ('html', models.TextField()),
-                ('repository', models.ForeignKey(
-                    on_delete=models.CASCADE,
-                    related_name='+', to='main.Repository')),
+                (
+                    'repository',
+                    models.ForeignKey(
+                        on_delete=models.CASCADE,
+                        related_name='+',
+                        to='main.Repository',
+                    ),
+                ),
             ],
             bases=(models.Model, galaxy.main.mixins.DirtyMixin),
         ),
         migrations.AlterUniqueTogether(
-            name='readme',
-            unique_together={('repository', 'raw_hash')},
+            name='readme', unique_together={('repository', 'raw_hash')}
         ),
         migrations.AddField(
             model_name='content',
@@ -107,7 +118,9 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(
                 null=True,
                 on_delete=models.PROTECT,
-                related_name='+', to='main.Readme'),
+                related_name='+',
+                to='main.Readme',
+            ),
         ),
         migrations.AddField(
             model_name='repository',
@@ -115,20 +128,13 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(
                 null=True,
                 on_delete=models.PROTECT,
-                related_name='+', to='main.Readme'),
+                related_name='+',
+                to='main.Readme',
+            ),
         ),
         migrations.RunSQL(CREATE_SEARCH_VECTOR_UPDATE_FUNCTIONS),
         migrations.RunPython(copy_readme_to_separate_table),
-        migrations.RemoveField(
-            model_name='content',
-            name='readme_raw',
-        ),
-        migrations.RemoveField(
-            model_name='content',
-            name='readme_html',
-        ),
-        migrations.RemoveField(
-            model_name='content',
-            name='readme_type',
-        ),
+        migrations.RemoveField(model_name='content', name='readme_raw'),
+        migrations.RemoveField(model_name='content', name='readme_html'),
+        migrations.RemoveField(model_name='content', name='readme_type'),
     ]

--- a/galaxy/main/migrations/0105_content_block_update.py
+++ b/galaxy/main/migrations/0105_content_block_update.py
@@ -25,7 +25,7 @@ MAIN_DOWNLOADS_BLOCK = """
    <a href="https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html#the-command-line-tool"
    target="_blanck">ansible-galaxy</a>, the command line tool that comes
    bundled with Ansible.</p>
-"""
+"""  # noqa: E501
 
 MAIN_FEATURED_BLOG_BLOCK = """
 <a href="https://ansible.com/blog" target="_blank">
@@ -37,14 +37,18 @@ MAIN_FEATURED_BLOG_BLOCK = """
 def upgrade_contentblocks_data(apps, schema_editor):
     ContentBlock = apps.get_model("main", "ContentBlock")
     db_alias = schema_editor.connection.alias
+    ContentBlock.objects.using(db_alias).filter(name='main-title').update(
+        content=MAIN_TITLE_BLOCK
+    )
+    ContentBlock.objects.using(db_alias).filter(name='main-share').update(
+        content=MAIN_SHARE_BLOCK
+    )
+    ContentBlock.objects.using(db_alias).filter(name='main-downloads').update(
+        content=MAIN_DOWNLOADS_BLOCK
+    )
     ContentBlock.objects.using(db_alias).filter(
-        name='main-title').update(content=MAIN_TITLE_BLOCK)
-    ContentBlock.objects.using(db_alias).filter(
-        name='main-share').update(content=MAIN_SHARE_BLOCK)
-    ContentBlock.objects.using(db_alias).filter(
-        name='main-downloads').update(content=MAIN_DOWNLOADS_BLOCK)
-    ContentBlock.objects.using(db_alias).filter(
-        name='main-featured-blog').update(content=MAIN_FEATURED_BLOG_BLOCK)
+        name='main-featured-blog'
+    ).update(content=MAIN_FEATURED_BLOG_BLOCK)
 
 
 def downgrade_contentblocks_data(apps, schema_editor):
@@ -53,11 +57,10 @@ def downgrade_contentblocks_data(apps, schema_editor):
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0104_repository_version'),
-    ]
+    dependencies = [('main', '0104_repository_version')]
 
     operations = [
-        migrations.RunPython(upgrade_contentblocks_data,
-                             downgrade_contentblocks_data)
+        migrations.RunPython(
+            upgrade_contentblocks_data, downgrade_contentblocks_data
+        )
     ]

--- a/galaxy/main/migrations/0109_auto_20180626_1050.py
+++ b/galaxy/main/migrations/0109_auto_20180626_1050.py
@@ -7,21 +7,20 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('main', '0108_sanitize_namespace_names'),
-    ]
+    dependencies = [('main', '0108_sanitize_namespace_names')]
 
     operations = [
         migrations.AlterModelOptions(
             name='content',
-            options={'ordering': ['namespace', 'repository', 'name', 'content_type']},
+            options={
+                'ordering': ['namespace', 'repository', 'name', 'content_type']
+            },
         ),
-        migrations.AlterModelOptions(
-            name='repositoryversion',
-            options={},
-        ),
+        migrations.AlterModelOptions(name='repositoryversion', options={}),
         migrations.AlterUniqueTogether(
             name='content',
-            unique_together=set([('namespace', 'repository', 'name', 'content_type')]),
+            unique_together={
+                ('namespace', 'repository', 'name', 'content_type')
+            },
         ),
     ]

--- a/galaxy/main/mixins.py
+++ b/galaxy/main/mixins.py
@@ -17,11 +17,11 @@
 
 __all__ = ['DirtyMixin']
 
-###################################################################################
-# A mixin object that lets us check if a model object has been modified
-
 
 class DirtyMixin(object):
+    """
+    A mixin object that lets us check if a model object has been modified.
+    """
     def __init__(self, *args, **kwargs):
         super(DirtyMixin, self).__init__(*args, **kwargs)
         self._original_state = dict(self.__dict__)

--- a/galaxy/settings/development.py
+++ b/galaxy/settings/development.py
@@ -41,7 +41,11 @@ INSTALLED_APPS += (  # noqa: F405
 # ---------------------------------------------------------
 
 # Define GALAXY_DB_URL=postgres://USER:PASSWORD@HOST:PORT/NAME
-DATABASES = {'default': dj_database_url.config(env='GALAXY_DB_URL', conn_max_age=None)}
+DATABASES = {
+    'default': dj_database_url.config(
+        env='GALAXY_DB_URL', conn_max_age=None
+    )
+}
 
 # Create default alias for worker logging
 DATABASES['logging'] = DATABASES['default'].copy()

--- a/galaxy/worker/importers/role.py
+++ b/galaxy/worker/importers/role.py
@@ -97,7 +97,9 @@ class RoleImporter(base.ContentImporter):
             name = platform.name
             versions = platform.versions
             if 'all' in versions:
-                platform_objs = models.Platform.objects.filter(name__iexact=name)
+                platform_objs = models.Platform.objects.filter(
+                    name__iexact=name
+                )
                 if not platform_objs:
                     self.log.warning(
                         u'Invalid platform: "{}-all", skipping.'.format(name))
@@ -109,7 +111,9 @@ class RoleImporter(base.ContentImporter):
 
             for version in versions:
                 try:
-                    p = models.Platform.objects.get(name__iexact=name, release__iexact=str(version))
+                    p = models.Platform.objects.get(
+                        name__iexact=name, release__iexact=str(version)
+                    )
                 except models.Platform.DoesNotExist:
                     self.log.warning(
                         u'Invalid platform: "{0}-{1}", skipping.'

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ galaxy =
     templates/**/*.html
 
 [flake8]
-# E501 - Line too long
 # W503 - line break before binary operator, to be replaced with W504.
 #        Refer to https://github.com/PyCQA/pycodestyle/issues/498
-ignore=E501,W503
+ignore=W503


### PR DESCRIPTION
Code is formatted in accordance with PEP8 which defines maximum line length 79 characters.

Some files (i.e. migrations) were formatted automatically by calling "black" tool with the following parameters:

```
black -S -l 79 <filenames>
```