### PR TITLE
Add tests for galaxy/main models

### DIFF
--- a/galaxy/main/models.py
+++ b/galaxy/main/models.py
@@ -141,6 +141,7 @@ class Platform(CommonModelNameNotUnique):
     class Meta:
         ordering = ['name', 'release']
 
+    # FIXME: release should be required, because it's used in __str__
     release = models.CharField(
         max_length=50,
         verbose_name="Distribution Release Version",

--- a/galaxy/main/models.py
+++ b/galaxy/main/models.py
@@ -129,6 +129,7 @@ class Tag(CommonModel):
     def get_absolute_url(self):
         return reverse('api:tag_detail', args=(self.pk,))
 
+    # FIXME: This method looks unused
     def get_num_roles(self):
         return self.roles.filter(active=True, is_valid=True).count()
 

--- a/galaxy/main/tests/__init__.py
+++ b/galaxy/main/tests/__init__.py
@@ -1,0 +1,17 @@
+# (c) 2012-2018, Ansible
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+# Django settings for galaxy project.

--- a/galaxy/main/tests/test_category_model.py
+++ b/galaxy/main/tests/test_category_model.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+# (c) 2012-2018, Ansible
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+from datetime import timedelta
+
+from django.core.exceptions import ValidationError
+from django.db.models.manager import Manager
+from django.db.utils import DataError, IntegrityError
+from django.utils import timezone
+from django.test import TestCase
+
+import mock
+import pytest
+
+from galaxy.main.models import Category
+
+
+class CategoryModelTest(TestCase):
+    NOW = timezone.now()
+    LATER = NOW + timedelta(hours=1)
+
+    VALID_NAME = "NAME"
+
+    NAME_MAX_LENGTH = 512
+
+    def setUp(self):
+        Category.objects.all().delete()
+
+    def test_manager_class(self):
+        assert isinstance(Category.objects, Manager)
+
+    @pytest.mark.model_fields_validation
+    @mock.patch('django.utils.timezone.now', side_effect=[NOW, NOW, LATER])
+    def test_create_minimal(self, fake_now):
+        # no mandatory fields
+        category = Category.objects.create()
+        assert isinstance(category, Category)
+
+        # check defaults
+        assert category.name == ""
+        assert category.created == self.NOW
+        assert category.modified == self.NOW
+
+        category.save()
+        assert category.modified != self.NOW
+        assert category.modified == self.LATER
+        assert fake_now.call_count == 3
+
+    @pytest.mark.model_fields_validation
+    def test_name_is_required(self):
+        # does not raise
+        Category(name=self.VALID_NAME).full_clean()
+
+        with pytest.raises(ValidationError) as excinfo:
+            Category().full_clean()
+        assert str(excinfo.value) == (
+            "{'name': [u'This field cannot be blank.']}")
+
+    @pytest.mark.database_integrity
+    def test_name_must_be_unique_in_db(self):
+        duplicated_name = 'duplicated_name'
+        with pytest.raises(IntegrityError) as excinfo:
+            Category.objects.create(name=duplicated_name)
+            Category.objects.create(name=duplicated_name)
+        assert str(excinfo.value) == (
+            'duplicate key value violates unique constraint '
+            '"main_category_name_key"\n'
+            'DETAIL:  Key (name)=({duplicated_name}) already exists.\n'
+            .format(duplicated_name=duplicated_name))
+
+    @pytest.mark.database_integrity
+    def test_name_length_is_limited_in_db(self):
+        # does not raise
+        Category.objects.create(
+            name='*' * self.NAME_MAX_LENGTH)
+
+        with pytest.raises(DataError) as excinfo:
+            Category.objects.create(
+                name='*' * (self.NAME_MAX_LENGTH + 1))
+        assert str(excinfo.value) == (
+            'value too long for type character varying({max_allowed})\n'
+            .format(max_allowed=self.NAME_MAX_LENGTH))
+
+    @pytest.mark.model_fields_validation
+    def test_name_length_is_limited(self):
+        # does not raise
+        Category(name=self.VALID_NAME).full_clean()
+
+        with pytest.raises(ValidationError) as excinfo:
+            Category(name='*' * (self.NAME_MAX_LENGTH + 1)).full_clean()
+        assert str(excinfo.value) == (
+            "{{'name': [u'Ensure this value has at most {valid} "
+            "characters (it has {current}).']}}"
+            .format(
+                valid=self.NAME_MAX_LENGTH,
+                current=self.NAME_MAX_LENGTH + 1))
+
+    # testing custom methods
+
+    @pytest.mark.model_methods
+    def test_convert_to_string(self):
+        # __str__ will return name
+        category = Category(name=self.VALID_NAME)
+
+        assert str(category) == self.VALID_NAME
+
+    @pytest.mark.model_methods
+    def test_repr(self):
+        # __str__ returns name, but it did not affected __repr__
+        category = Category(name=self.VALID_NAME)
+
+        assert repr(category) == (
+            '<Category: {name}>'
+            .format(name=self.VALID_NAME))
+
+    @pytest.mark.model_methods
+    def test_get_absolute_url(self):
+        # this method creates url with category id
+        category = Category.objects.create(name=self.VALID_NAME)
+
+        assert category.get_absolute_url() == (
+            "/api/v1/categories/{category_id}/"
+            .format(category_id=category.id))

--- a/galaxy/main/tests/test_cloud_platform_model.py
+++ b/galaxy/main/tests/test_cloud_platform_model.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+# (c) 2012-2018, Ansible
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+from datetime import timedelta
+
+from django.core.exceptions import ValidationError
+from django.db.models.manager import Manager
+from django.db.utils import DataError, IntegrityError
+from django.utils import timezone
+from django.test import TestCase
+
+import mock
+import pytest
+
+from ..models import CloudPlatform
+
+
+class CloudPlatformModelTest(TestCase):
+    NOW = timezone.now()
+    LATER = NOW + timedelta(hours=1)
+
+    VALID_NAME = "NAME"
+
+    NAME_MAX_LENGTH = 512
+
+    def setUp(self):
+        CloudPlatform.objects.all().delete()
+
+    def test_manager_class(self):
+        assert isinstance(CloudPlatform.objects, Manager)
+
+    @pytest.mark.model_fields_validation
+    @mock.patch('django.utils.timezone.now', side_effect=[NOW, NOW, LATER])
+    def test_create_minimal(self, fake_now):
+        # no mandatory fields
+        cloud_platform = CloudPlatform.objects.create()
+        assert isinstance(cloud_platform, CloudPlatform)
+
+        # check defaults
+        assert cloud_platform.name == ""
+        assert cloud_platform.created == self.NOW
+        assert cloud_platform.modified == self.NOW
+
+        cloud_platform.save()
+        assert cloud_platform.modified != self.NOW
+        assert cloud_platform.modified == self.LATER
+        assert fake_now.call_count == 3
+
+    @pytest.mark.model_fields_validation
+    def test_name_is_required(self):
+        # does not raise
+        CloudPlatform(name=self.VALID_NAME).full_clean()
+
+        with pytest.raises(ValidationError) as excinfo:
+            CloudPlatform().full_clean()
+        assert str(excinfo.value) == (
+            "{'name': [u'This field cannot be blank.']}")
+
+    @pytest.mark.database_integrity
+    def test_name_must_be_unique_in_db(self):
+        duplicated_name = 'duplicated_name'
+        with pytest.raises(IntegrityError) as excinfo:
+            CloudPlatform.objects.create(name=duplicated_name)
+            CloudPlatform.objects.create(name=duplicated_name)
+        assert str(excinfo.value) == (
+            'duplicate key value violates unique constraint '
+            '"main_cloudplatform_name_key"\n'
+            'DETAIL:  Key (name)=({duplicated_name}) already exists.\n'
+            .format(duplicated_name=duplicated_name))
+
+    @pytest.mark.database_integrity
+    def test_name_length_is_limited_in_db(self):
+        # does not raise
+        CloudPlatform.objects.create(
+            name='*' * self.NAME_MAX_LENGTH)
+
+        with pytest.raises(DataError) as excinfo:
+            CloudPlatform.objects.create(
+                name='*' * (self.NAME_MAX_LENGTH + 1))
+        assert str(excinfo.value) == (
+            'value too long for type character varying({max_allowed})\n'
+            .format(max_allowed=self.NAME_MAX_LENGTH))
+
+    @pytest.mark.model_fields_validation
+    def test_name_length_is_limited(self):
+        # does not raise
+        CloudPlatform(name=self.VALID_NAME).full_clean()
+
+        with pytest.raises(ValidationError) as excinfo:
+            CloudPlatform(name='*' * (self.NAME_MAX_LENGTH + 1)).full_clean()
+        assert str(excinfo.value) == (
+            "{{'name': [u'Ensure this value has at most {valid} "
+            "characters (it has {given}).']}}"
+            .format(
+                valid=self.NAME_MAX_LENGTH,
+                given=self.NAME_MAX_LENGTH + 1))
+
+    # testing custom methods
+
+    @pytest.mark.model_methods
+    def test_convert_to_string(self):
+        # __str__ will return name
+        cloud_platform = CloudPlatform(name=self.VALID_NAME)
+
+        assert str(cloud_platform) == self.VALID_NAME
+
+    @pytest.mark.model_methods
+    def test_repr(self):
+        # __str__ returns name, but it did not affected __repr__
+        cloud_platform = CloudPlatform(name=self.VALID_NAME)
+
+        assert repr(cloud_platform) == (
+            '<CloudPlatform: {name}>'
+            .format(name=self.VALID_NAME))
+
+    @pytest.mark.model_methods
+    def test_get_absolute_url(self):
+        # this method creates url with cloud_platform id
+        cloud_platform = CloudPlatform.objects.create(name=self.VALID_NAME)
+
+        assert cloud_platform.get_absolute_url() == (
+            "/api/v1/cloud_platforms/{cloud_platform_id}/"
+            .format(cloud_platform_id=cloud_platform.id))

--- a/galaxy/main/tests/test_platform_model.py
+++ b/galaxy/main/tests/test_platform_model.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+# (c) 2012-2018, Ansible
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+from datetime import timedelta
+
+from django.core.exceptions import ValidationError
+from django.db.models.manager import Manager
+from django.db.utils import DataError
+from django.utils import timezone
+from django.test import TestCase
+
+import mock
+import pytest
+
+from ..models import Platform
+
+
+class PlatformModelTest(TestCase):
+    NOW = timezone.now()
+    LATER = NOW + timedelta(hours=1)
+
+    VALID_NAME = "NAME"
+    VALID_RELEASE = "RELEASE"
+    VALID_ALIAS = "ALIAS"
+
+    NAME_MAX_LENGTH = 512
+    RELEASE_MAX_LENGTH = 50
+    ALIAS_MAX_LENGTH = 256
+
+    def setUp(self):
+        Platform.objects.all().delete()
+
+    def test_manager_class(self):
+        assert isinstance(Platform.objects, Manager)
+
+    @pytest.mark.model_fields_validation
+    @mock.patch('django.utils.timezone.now', side_effect=[NOW, NOW, LATER])
+    def test_create_minimal(self, fake_now):
+        # no mandatory fields
+        platform = Platform.objects.create()
+        assert isinstance(platform, Platform)
+
+        # check defaults
+        assert platform.name == ""
+        assert platform.created == self.NOW
+        assert platform.modified == self.NOW
+
+        platform.save()
+        assert platform.modified != self.NOW
+        assert platform.modified == self.LATER
+        assert fake_now.call_count == 3
+
+    @pytest.mark.model_fields_validation
+    def test_name_and_release_are_required(self):
+        # does not raise
+        Platform(
+            name=self.VALID_NAME,
+            release=self.VALID_RELEASE).full_clean()
+
+        with pytest.raises(ValidationError) as excinfo:
+            Platform().full_clean()
+        assert str(excinfo.value) == (
+            "{'release': [u'This field cannot be blank.'], "
+            "'name': [u'This field cannot be blank.']}")
+
+    # FIXME: This behaviour looks like a bug
+    @pytest.mark.database_integrity
+    def test_platform_duplicates_are_allowed(self):
+        # does not raise
+        Platform.objects.create(
+            name=self.VALID_NAME,
+            release=self.VALID_RELEASE,
+            alias=self.VALID_ALIAS)
+        Platform.objects.create(
+            name=self.VALID_NAME,
+            release=self.VALID_RELEASE,
+            alias=self.VALID_ALIAS)
+
+    @pytest.mark.database_integrity
+    def test_name_length_is_limited_in_db(self):
+        # does not raise
+        Platform.objects.create(
+            name='*' * self.NAME_MAX_LENGTH,
+            release=self.VALID_RELEASE)
+
+        with pytest.raises(DataError) as excinfo:
+            Platform.objects.create(
+                name='*' * (self.NAME_MAX_LENGTH + 1))
+        assert str(excinfo.value) == (
+            'value too long for type character varying({max_allowed})\n'
+            .format(max_allowed=self.NAME_MAX_LENGTH))
+
+    @pytest.mark.model_fields_validation
+    def test_name_length_is_limited(self):
+        # does not raise
+        Platform(
+            name=self.VALID_NAME,
+            release=self.VALID_RELEASE).full_clean()
+
+        with pytest.raises(ValidationError) as excinfo:
+            Platform(
+                name='*' * (self.NAME_MAX_LENGTH + 1),
+                release=self.VALID_RELEASE).full_clean()
+        assert str(excinfo.value) == (
+            "{{'name': [u'Ensure this value has at most {valid} "
+            "characters (it has {given}).']}}"
+            .format(
+                valid=self.NAME_MAX_LENGTH,
+                given=self.NAME_MAX_LENGTH + 1))
+
+    @pytest.mark.database_integrity
+    def test_release_length_is_limited_in_db(self):
+        # does not raise
+        Platform.objects.create(
+            name=self.VALID_NAME,
+            release='*' * self.RELEASE_MAX_LENGTH)
+
+        with pytest.raises(DataError) as excinfo:
+            Platform.objects.create(
+                name=self.VALID_NAME,
+                release='*' * (self.RELEASE_MAX_LENGTH + 1))
+        assert str(excinfo.value) == (
+            'value too long for type character varying({max_allowed})\n'
+            .format(max_allowed=self.RELEASE_MAX_LENGTH))
+
+    @pytest.mark.model_fields_validation
+    def test_release_length_is_limited(self):
+        # does not raise
+        Platform(
+            name=self.VALID_NAME,
+            release='*' * self.RELEASE_MAX_LENGTH).full_clean()
+
+        with pytest.raises(ValidationError) as excinfo:
+            Platform(
+                name=self.VALID_NAME,
+                release='*' * (self.RELEASE_MAX_LENGTH + 1)).full_clean()
+        assert str(excinfo.value) == (
+            "{{'release': [u'Ensure this value has at most {valid} "
+            "characters (it has {given}).']}}".format(
+                valid=self.RELEASE_MAX_LENGTH,
+                given=self.RELEASE_MAX_LENGTH + 1))
+
+    @pytest.mark.database_integrity
+    def test_alias_length_is_limited_in_db(self):
+        # does not raise
+        Platform.objects.create(
+            name=self.VALID_NAME,
+            release=self.VALID_RELEASE,
+            alias='*' * self.ALIAS_MAX_LENGTH)
+
+        with pytest.raises(DataError) as excinfo:
+            Platform.objects.create(
+                name=self.VALID_NAME,
+                release=self.VALID_RELEASE,
+                alias='*' * (self.ALIAS_MAX_LENGTH + 1))
+        assert str(excinfo.value) == (
+            'value too long for type character varying({max_allowed})\n'
+            .format(max_allowed=self.ALIAS_MAX_LENGTH))
+
+    @pytest.mark.model_fields_validation
+    def test_alias_length_is_limited(self):
+        # does not raise
+        Platform(
+            name=self.VALID_NAME,
+            release=self.VALID_RELEASE,
+            alias='*' * self.ALIAS_MAX_LENGTH).full_clean()
+
+        with pytest.raises(ValidationError) as excinfo:
+            Platform(
+                name=self.VALID_NAME,
+                release=self.VALID_RELEASE,
+                alias='*' * (self.ALIAS_MAX_LENGTH + 1)).full_clean()
+        assert str(excinfo.value) == (
+            "{{'alias': [u'Ensure this value has at most {valid} "
+            "characters (it has {given}).']}}".format(
+                valid=self.ALIAS_MAX_LENGTH,
+                given=self.ALIAS_MAX_LENGTH + 1))
+
+    # testing custom methods
+
+    @pytest.mark.model_methods
+    def test_convert_to_string(self):
+        # __str__ will return name-release
+        platform = Platform(
+            name=self.VALID_NAME,
+            release=self.VALID_RELEASE)
+
+        assert str(platform) == self.VALID_NAME + "-" + self.VALID_RELEASE
+
+    @pytest.mark.model_methods
+    def test_repr(self):
+        # __str__ returns name, but and it affects __repr__
+        platform = Platform(
+            name=self.VALID_NAME,
+            release=self.VALID_RELEASE)
+
+        assert repr(platform) == (
+            '<Platform: {name}-{release}>'
+            .format(name=self.VALID_NAME, release=self.VALID_RELEASE))
+
+    @pytest.mark.model_methods
+    def test_get_absolute_url(self):
+        # this method creates url with platform id
+        platform = Platform.objects.create(name=self.VALID_NAME)
+
+        assert platform.get_absolute_url() == (
+            "/api/v1/platforms/{platform_id}/"
+            .format(platform_id=platform.id))

--- a/galaxy/main/tests/test_tag_model.py
+++ b/galaxy/main/tests/test_tag_model.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+# (c) 2012-2018, Ansible
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+from datetime import timedelta
+
+from django.core.exceptions import ValidationError
+from django.db.models.manager import Manager
+from django.db.utils import DataError, IntegrityError
+from django.utils import timezone
+from django.test import TestCase
+
+import mock
+import pytest
+
+from galaxy.main.models import Tag
+
+
+class TagModelTest(TestCase):
+    NOW = timezone.now()
+    LATER = NOW + timedelta(hours=1)
+
+    VALID_NAME = "NAME"
+
+    NAME_MAX_LENGTH = 512
+
+    def setUp(self):
+        Tag.objects.all().delete()
+
+    def test_manager_class(self):
+        assert isinstance(Tag.objects, Manager)
+
+    @pytest.mark.model_fields_validation
+    @mock.patch('django.utils.timezone.now', side_effect=[NOW, NOW, LATER])
+    def test_create_minimal(self, fake_now):
+        # no mandatory fields
+        tag = Tag.objects.create()
+        assert isinstance(tag, Tag)
+
+        # check defaults
+        assert tag.name == ""
+        assert tag.created == self.NOW
+        assert tag.modified == self.NOW
+
+        tag.save()
+        assert tag.modified != self.NOW
+        assert tag.modified == self.LATER
+        assert fake_now.call_count == 3
+
+    @pytest.mark.model_fields_validation
+    def test_name_is_required(self):
+        # does not raise
+        Tag(name=self.VALID_NAME).full_clean()
+
+        with pytest.raises(ValidationError) as excinfo:
+            Tag().full_clean()
+        assert str(excinfo.value) == (
+            "{'name': [u'This field cannot be blank.']}")
+
+    @pytest.mark.database_integrity
+    def test_name_must_be_unique_in_db(self):
+        duplicated_name = 'duplicated_name'
+        with pytest.raises(IntegrityError) as excinfo:
+            Tag.objects.create(name=duplicated_name)
+            Tag.objects.create(name=duplicated_name)
+        assert str(excinfo.value) == (
+            'duplicate key value violates unique constraint '
+            '"main_tag_name_key"\n'
+            'DETAIL:  Key (name)=({duplicated_name}) already exists.\n'
+            .format(duplicated_name=duplicated_name))
+
+    @pytest.mark.database_integrity
+    def test_name_length_is_limited_in_db(self):
+        # does not raise
+        Tag.objects.create(
+            name='*' * self.NAME_MAX_LENGTH)
+
+        with pytest.raises(DataError) as excinfo:
+            Tag.objects.create(
+                name='*' * (self.NAME_MAX_LENGTH + 1))
+        assert str(excinfo.value) == (
+            'value too long for type character varying({max_allowed})\n'
+            .format(max_allowed=self.NAME_MAX_LENGTH))
+
+    @pytest.mark.model_fields_validation
+    def test_name_length_is_limited(self):
+        # does not raise
+        Tag(name=self.VALID_NAME).full_clean()
+
+        with pytest.raises(ValidationError) as excinfo:
+            Tag(name='*' * (self.NAME_MAX_LENGTH + 1)).full_clean()
+        assert str(excinfo.value) == (
+            "{{'name': [u'Ensure this value has at most {valid} "
+            "characters (it has {given}).']}}".format(
+                valid=self.NAME_MAX_LENGTH,
+                given=self.NAME_MAX_LENGTH + 1))
+
+    # testing custom methods
+
+    @pytest.mark.model_methods
+    def test_convert_to_string(self):
+        # __str__ will return name
+        tag = Tag(name=self.VALID_NAME)
+
+        assert str(tag) == self.VALID_NAME
+
+    @pytest.mark.model_methods
+    def test_repr(self):
+        # __str__ returns name, but it did not affected __repr__
+        tag = Tag(name=self.VALID_NAME)
+
+        assert repr(tag) == (
+            '<Tag: {name}>'
+            .format(name=self.VALID_NAME))
+
+    @pytest.mark.model_methods
+    def test_get_absolute_url(self):
+        # this method creates url with tag id
+        tag = Tag.objects.create(name=self.VALID_NAME)
+
+        assert tag.get_absolute_url() == (
+            "/api/v1/tags/{tag_id}/"
+            .format(tag_id=tag.id))


### PR DESCRIPTION
This PR adds some test coverage for models:
* Category
* Tag
* Platform
* CloudPlatform