### PR TITLE
Remove unused APBImporter.MAX_TAGS_COUNT

### DIFF
--- a/galaxy/worker/importers/apb.py
+++ b/galaxy/worker/importers/apb.py
@@ -22,8 +22,6 @@ from galaxy import constants
 
 
 class APBImporter(base.ContentImporter):
-    MAX_TAGS_COUNT = 20
-
     def update_content(self, content):
         super(APBImporter, self).update_content(content)
         role_meta = self.data.role_meta


### PR DESCRIPTION
In APBImporter class definition it's also defined MAX_TAGS_COUNT
class-constant. But constants.MAX_TAGS_COUNT is used instead.
The constant has the same value.

So it looks like it's a lind of artifact of refactoring.
It's better to rmove it to avoid confusion.