### PR TITLE
Fix tripple quotes to match PEP

### DIFF
--- a/galaxy/api/permissions.py
+++ b/galaxy/api/permissions.py
@@ -37,10 +37,10 @@ __all__ = ['ModelAccessPermission']
 
 
 class ModelAccessPermission(permissions.BasePermission):
-    '''
+    """
     Default permissions class to check user access based on the model and
     request method, optionally verifying the request data.
-    '''
+    """
 
     def check_options_permissions(self, request, view, obj=None):
         return self.check_get_permissions(request, view, obj)
@@ -95,10 +95,10 @@ class ModelAccessPermission(permissions.BasePermission):
         return check_user_access(request.user, view.model, 'delete', obj)
 
     def check_permissions(self, request, view, obj=None):
-        '''
+        """
         Perform basic permissions checking before delegating to the appropriate
         method based on the request method.
-        '''
+        """
 
         # Check that obj (if given) is active, otherwise raise a 404.
         active = getattr(obj, 'active', getattr(obj, 'is_active', True))

--- a/galaxy/api/renderers.py
+++ b/galaxy/api/renderers.py
@@ -21,14 +21,14 @@ from rest_framework import renderers
 
 
 class BrowsableAPIRenderer(renderers.BrowsableAPIRenderer):
-    '''
+    """
     Customizations to the default browsable API renderer.
-    '''
+    """
 
     def get_rendered_html_form(self, view, method, request):
-        '''
+        """
         Never show auto-generated form (only raw form).
-        '''
+        """
         obj = getattr(view, 'object', None)
         if not self.show_form_for_method(view, method, request, obj):
             return

--- a/galaxy/api/utils.py
+++ b/galaxy/api/utils.py
@@ -64,9 +64,9 @@ def camelcase_to_underscore(s):
 
 
 class RequireDebugTrueOrTest(logging.Filter):
-    '''
+    """
     Logging filter to output when in DEBUG mode or running tests.
-    '''
+    """
 
     def filter(self, record):
         from django.conf import settings

--- a/galaxy/api/views/search.py
+++ b/galaxy/api/views/search.py
@@ -265,11 +265,11 @@ class PlatformsSearchView(base.ListAPIView):
         if releases:
             queryset = queryset.filter(release__in=releases)
         if autocomplete:
-            where_clause = '''
+            where_clause = """
                 to_tsvector(
                     name || ' ' || release || ' ' || coalesce(alias, ''))
                 @@ to_tsquery(quote_literal(%s) || ':*')
-            '''
+            """
             queryset = queryset.extra(where=[where_clause],
                                       params=[autocomplete])
         return self.make_response(queryset)

--- a/galaxy/api/views/views.py
+++ b/galaxy/api/views/views.py
@@ -1104,9 +1104,9 @@ class RefreshUserRepos(base_views.APIView):
 
 
 class TokenView(base_views.APIView):
-    '''
+    """
     Allows ansible-galaxy CLI to retrieve an auth token
-    '''
+    """
     def post(self, request, *args, **kwargs):
 
         gh_user = None

--- a/galaxy/main/celerytasks/tasks.py
+++ b/galaxy/main/celerytasks/tasks.py
@@ -231,9 +231,9 @@ def refresh_user_stars(user, token):
 
 @celery.task(name="galaxy.main.celerytasks.tasks.refresh_role_counts")
 def refresh_role_counts(start, end, token, tracker):
-    '''
+    """
     Update each role with latest counts from GitHub
-    '''
+    """
     tracker.state = 'RUNNING'
     tracker.save()
 


### PR DESCRIPTION
Tripple-doubleqoutes (`"""`) are used almost everewhere in this project.
And they are PEP compliant. However there are few places where
tripple-singlequotes (`'''`) are still used.

This patch replaces quotes with correct ones (`'''` -> `"""`)