### PR TITLE
Remove unused utils.html_decode

### DIFF
--- a/galaxy/api/utils.py
+++ b/galaxy/api/utils.py
@@ -24,7 +24,7 @@ import sys
 from rest_framework.exceptions import ParseError, PermissionDenied
 
 __all__ = ['get_object_or_400', 'get_object_or_403', 'camelcase_to_underscore',
-           'get_ansible_version', 'get_version', 'html_decode']
+           'get_ansible_version', 'get_version']
 
 
 def get_object_or_400(klass, *args, **kwargs):
@@ -104,19 +104,3 @@ def get_encryption_key(instance, field_name):
     h.update(str(instance.pk))
     h.update(field_name)
     return h.digest()[:16]
-
-
-def html_decode(s):
-    """
-    Returns the ASCII decoded version of the given HTML string. This does
-    NOT remove normal HTML tags like <p>.
-    """
-    for code in (
-        ("'", '&#39;'),
-        ('"', '&quot;'),
-        ('>', '&gt;'),
-        ('<', '&lt;'),
-        ('&', '&amp;')
-        ):                                 # noqa
-        s = s.replace(code[1], code[0])    # noqa
-    return s


### PR DESCRIPTION
It appears that utils.html_decode is never used. This function looks
very specific with lmited use-cases. It's not covered with tests also.

So it's better to remove it entirely.