### PR TITLE
Fix Makefile dev/test target testing configs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,0 @@
-# pytest-cov config
-[run]
-omit = */migrations/*

--- a/Makefile
+++ b/Makefile
@@ -152,17 +152,16 @@ dev/shellcheck:
 .PHONY: dev/test
 dev/test:
 	@echo "Running tests"
-# TODO:  Revert to $(DOCKER_COMPOSE)
-# Currently `docker exec` offers -e option for setting Env variables, and `docker-compose exec` does not.
-# Setting the postgres connetion string to use postgres user, to have authority to create and destroy the test database.
-	@docker exec -e GALAXY_DB_URL=postgres://postgres:postgres@postgres:5432/galaxy galaxy_galaxy_1 \
-    bash -c '\
-      source $(VENV_BIN)/activate; \
-      pytest galaxy \
-        --cov galaxy \
-        --cov-report xml \
-        --cov-report term \
-        --cov-report html '
+# TODO: Revert to $(VENV_BIN)/python. Some tests (flake8 and yamllint) require
+# tools on $PATH, this cannot be chieved with just $(VENV_BIN)/python command.
+# So virtual environment must be activated in order to expose these utilities.
+# TODO: Since app is isolated in container already, it's probably acceptable to
+# get rid of virtual environment and install python packages in system dirs.
+# Other option are:
+# - install side packages globally or
+# - call tools using python api instead of shell commands.
+	@$(DOCKER_COMPOSE) exec galaxy bash -c '\
+		source $(VENV_BIN)/activate; pytest galaxy'
 
 .PHONY: dev/waitenv
 dev/waitenv:

--- a/galaxy/settings/testing.py
+++ b/galaxy/settings/testing.py
@@ -1,5 +1,3 @@
-# (c) 2012-2018, Ansible by Red Hat
-#
 # This file is part of Ansible Galaxy
 #
 # Ansible Galaxy is free software: you can redistribute it and/or modify
@@ -15,6 +13,8 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 # Django settings for galaxy project.
+
+# FIXME: This module is copy-paste of dev settings. It needs review and fixes.
 
 import os
 import dj_database_url
@@ -47,8 +47,15 @@ DATABASES = {
     )
 }
 
+# By default prod user is "galaxy", so we want to protect ourselves that
+# tests will not run on prod accidentally.
+assert DATABASES["default"]["USER"] != "galaxy"
+
 # Create default alias for worker logging
 DATABASES['logging'] = DATABASES['default'].copy()
+
+# Set the test database name
+DATABASES['default']['TEST'] = {'NAME': 'test_galaxy'}
 
 # Email settings
 # ---------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ mock
 pytest
 pytest-django
 pytest-cov==2.5.1
+pytest-env
 
 # Docs
 Sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,23 @@ galaxy =
     templates/*.html
     templates/**/*.html
 
+[tool:pytest]
+# NOTE: This way won't work because env vars are already defined by compose
+# DJANGO_SETTINGS_MODULE=..
+# So instead of pytest-django we use pytest-env to override envvars forcefully
+env =
+    DJANGO_SETTINGS_MODULE=galaxy.settings.testing
+    GALAXY_DB_URL=postgres://postgres:postgres@postgres:5432/galaxy
+addopts =
+    --cov galaxy
+    --cov-report xml
+    --cov-report term
+    --cov-report html
+    --cov-config setup.cfg
+
+[coverage:run]
+omit = */migrations/*
+
 [flake8]
 # W503 - line break before binary operator, to be replaced with W504.
 #        Refer to https://github.com/PyCQA/pycodestyle/issues/498


### PR DESCRIPTION
Currently `docker exec` offers -e option for setting Env variables,
and `docker-compose exec` does not, so setting the postgres connetion
string to use postgres user is done via Env variable, to have authority
to create and destroy the test database.
This was temporary solution and it required to be fixed.

This patch introduces another way to set env variables for testing
procedures. Instead of hardcoding connection string and pytest options
in Makefile, `setup.cfg` file is used where pytest configuration is
declared.

This requires additional pytest plugin, pytest-env and it's added too.

This refactoring also affects coverage configuration: instead of
separate .coveragerc file, this configuration is declared in the same
`setup.cfg` file.

To make testing configurations even more easier and handy, extra
django config is added. So development configuration and testing
configurations are now separated and may be configured independently.