### PR TITLE
Fix license in galaxyui package.json

### DIFF
--- a/galaxyui/package.json
+++ b/galaxyui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "galaxyui",
   "version": "0.0.0",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
galaxyui/package.json has MIT license, but all banners in this repo
state that license is Apache-2.

This patch fixes license field to be Apache-2.
