### PR TITLE
Add linter for shell scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
 # start the application
 - make dev/up_detached
 - make dev/waitenv
+- make dev/shellcheck
 - make dev/test
 
 # check images running

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,11 @@ dev/jslint:
 	@echo "Linting Javascript..."
 	@$(DOCKER_COMPOSE) exec galaxy bash -c 'cd galaxyui; ng lint'
 
+.PHONY: dev/shellcheck
+dev/shellcheck:
+	@$(DOCKER_COMPOSE) exec galaxy bash -c '\
+		find ./scripts -name *.sh | xargs shellcheck'
+
 .PHONY: dev/test
 dev/test:
 	@echo "Running tests"

--- a/scripts/docker/dev/Dockerfile
+++ b/scripts/docker/dev/Dockerfile
@@ -31,7 +31,7 @@ RUN mkdir -p /var/lib/galaxy/ \
     && ${VENV_BIN}/pip install -U pip wheel \
     && ${VENV_BIN}/pip install -r /tmp/requirements.txt
 
-RUN yum -y install vim tmux make
+RUN yum -y install vim tmux make ShellCheck
 RUN ${VENV_BIN}/pip install honcho flake8
 RUN localedef -c -i en_US -f UTF-8 en_US.UTF-8
 

--- a/scripts/docker/dev/entrypoint.sh
+++ b/scripts/docker/dev/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# shellcheck disable=SC2034
 VIRTUAL_ENV_DISABLE_PROMPT=1
 source "${VENV_BIN}/activate"
 

--- a/scripts/docker/dev/start-develop.sh
+++ b/scripts/docker/dev/start-develop.sh
@@ -19,5 +19,5 @@ fi
 if [ "${TMUX}" == "1" ] || [ "${TEST}" == "1" ]; then
     scripts/docker/dev/sleep.sh
 else
-    ${VENV_BIN}/honcho start -f "scripts/docker/dev/Procfile"
+    "${VENV_BIN}/honcho" start -f "scripts/docker/dev/Procfile"
 fi

--- a/scripts/docker/release/build.sh
+++ b/scripts/docker/release/build.sh
@@ -5,8 +5,9 @@ set -o errexit
 
 readonly VENV_BIN=${VENV_BIN:-/var/lib/galaxy/venv/bin}
 
+# shellcheck disable=SC2034
 VIRTUAL_ENV_DISABLE_PROMPT=1
-source ${VENV_BIN}/activate
+source "${VENV_BIN}/activate"
 
 mkdir -p /galaxy/build/ \
          /galaxy/dist/

--- a/scripts/docker/release/entrypoint.sh
+++ b/scripts/docker/release/entrypoint.sh
@@ -5,8 +5,9 @@ set -o errexit
 
 readonly VENV_BIN=${VENV_BIN:-/var/lib/galaxy/venv/bin}
 
+# shellcheck disable=SC2034
 VIRTUAL_ENV_DISABLE_PROMPT=1
-source ${VENV_BIN}/activate
+source "${VENV_BIN}/activate"
 
 # FIXME(cutwater): Yet another workaround for running entrypoint not as PID 1
 # All run commands should be implemented outside entrypoint (e.g. in manage.py)

--- a/scripts/travis-publish-image.sh
+++ b/scripts/travis-publish-image.sh
@@ -24,7 +24,7 @@ elif [[ "$TRAVIS_TAG" =~ $GALAXY_VERSION_TAG ]]; then
 
     docker login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD"
     echo "Pushing docker image: ansible/galaxy:$IMAGE_TAG"
-    docker push ansible/galaxy:$IMAGE_TAG
+    docker push "ansible/galaxy:$IMAGE_TAG"
     echo "Updating ansible/galaxy:latest to ansible/galaxy:$IMAGE_TAG"
     docker push ansible/galaxy:latest
 else


### PR DESCRIPTION
This patch add linter for shell scripts.
It includes:
* Makefile target `dev/shellcheck`,
* checks for `scripts/**/*.sh`,
* corrections for code that did not pass shellcheck,
* travis integration.
