### PR TITLE
 Remove unused methods for CustomUser model 

### DIFF
--- a/galaxy/accounts/models.py
+++ b/galaxy/accounts/models.py
@@ -55,6 +55,7 @@ class CustomUser(auth_models.AbstractBaseUser,
                                       'invalid')
         ])
     full_name = models.CharField(_('full name'), max_length=254, blank=True)
+    # FIXME: This field looks unused
     short_name = models.CharField(_('short name'), max_length=30, blank=True)
     email = models.EmailField(_('email address'), max_length=254, unique=True)
     is_staff = models.BooleanField(
@@ -90,9 +91,11 @@ class CustomUser(auth_models.AbstractBaseUser,
     def __str__(self):
         return self.username
 
+    # FIXME: replace with django.core.urlresolvers.reverse(..)
     def get_absolute_url(self):
         return "/users/%s/" % urlquote(self.username)
 
+    # FIXME: This method looks unused
     def get_full_name(self):
         """
         Returns the first_name plus the last_name, with a space in between.
@@ -100,19 +103,23 @@ class CustomUser(auth_models.AbstractBaseUser,
         full_name = self.full_name
         return full_name.strip()
 
+    # FIXME: This method looks unused
     def get_short_name(self):
         """Returns the short name for the user."""
         return self.short_name.strip()
 
+    # FIXME: This method looks unused
     def get_num_roles(self):
         return self.roles.filter(active=True, is_valid=True).count()
 
+    # FIXME: This method looks unused
     def email_user(self, subject, message, from_email=None):
         """
         Sends an email to this User.
         """
         send_mail(subject, message, from_email, [self.email])
 
+    # FIXME: This method looks unused
     def hasattr(self, attr):
         return hasattr(self, attr)
 
@@ -130,6 +137,7 @@ class CustomUser(auth_models.AbstractBaseUser,
             'github_repo': g.repository.github_repo,
         } for g in self.starred.select_related('repository').all()]
 
+    # FIXME: This method looks unused
     def get_subscriber(self, github_user, github_repo):
         try:
             return self.subscriptions.get(
@@ -138,6 +146,7 @@ class CustomUser(auth_models.AbstractBaseUser,
         except exceptions.ObjectDoesNotExist:
             return None
 
+    # FIXME: This method looks unused
     def get_stargazer(self, github_user, github_repo):
         try:
             star = self.starred.get(
@@ -147,6 +156,7 @@ class CustomUser(auth_models.AbstractBaseUser,
         except exceptions.ObjectDoesNotExist:
             return None
 
+    # FIXME: This method looks unused
     def is_connected_to_github(self):
         connected = False
         for account in self.socialaccount_set.all():

--- a/galaxy/accounts/tests/__init__.py
+++ b/galaxy/accounts/tests/__init__.py
@@ -1,5 +1,4 @@
-# (c) 2012-2018, Ansible by Red Hat
-#
+# (c) 2012-2018, Ansible
 # This file is part of Ansible Galaxy
 #
 # Ansible Galaxy is free software: you can redistribute it and/or modify
@@ -14,20 +13,3 @@
 #
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
-
-"""
-This file demonstrates writing tests using the unittest module. These will pass
-when you run "manage.py test".
-
-Replace this with more appropriate tests for your application.
-"""
-
-from django.test import TestCase
-
-
-class SimpleTest(TestCase):
-    def test_basic_addition(self):
-        """
-        Tests that 1 + 1 always equals 2.
-        """
-        self.assertEqual(1 + 1, 2)

--- a/galaxy/accounts/tests/test_custom_user_model.py
+++ b/galaxy/accounts/tests/test_custom_user_model.py
@@ -1,0 +1,312 @@
+# -*- coding: utf-8 -*-
+# (c) 2012-2018, Ansible
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+from django.core.exceptions import ValidationError
+from django.contrib.auth.models import UserManager
+from django.db.utils import DataError, IntegrityError
+from django.utils import timezone
+from django.test import TestCase
+
+import mock
+import pytest
+
+from galaxy.accounts.models import CustomUser
+
+
+class CustomUserModelTest(TestCase):
+    NOW = timezone.now()
+
+    VALID_EMAIL = "user@example.com"
+    VALID_PASSWORD = "****"
+    VALID_USERNAME = "USERNAME"
+
+    USERNAME_MAX_LENGTH = 30
+    FULL_NAME_MAX_LENGTH = 254
+    SHORT_NAME_MAX_LENGTH = 30
+    EMAIL_MAX_LENGTH = 254
+
+    def setUp(self):
+        CustomUser.objects.all().delete()
+
+    def test_manager_class(self):
+        assert isinstance(CustomUser.objects, UserManager)
+
+    def test_default(self):
+        assert CustomUser._meta.get_field('date_joined').default == \
+            timezone.now
+
+    @pytest.mark.model_fields_validation
+    @mock.patch.object(
+        CustomUser._meta.get_field('date_joined'),
+        "get_default",
+        side_effect=[NOW])
+    def test_create_minimal(self, fake_now):
+        # no mandatory fields
+        user = CustomUser.objects.create()
+        assert isinstance(user, CustomUser)
+
+        # check defaults
+        assert user.username == ""
+        assert user.full_name == ""
+        assert user.short_name == ""
+        assert not user.is_staff
+        assert user.email == ""
+        assert user.is_active
+        assert user.date_joined == self.NOW
+        assert user.karma == 0
+        assert user.avatar_url == ""
+        assert not user.cache_refreshed
+
+        fake_now.assert_called_once()
+
+    @pytest.mark.database_integrity
+    def test_username_length_is_limited_in_db(self):
+        # does not raise
+        CustomUser.objects.create(
+            username='*' * self.USERNAME_MAX_LENGTH)
+
+        with pytest.raises(DataError) as excinfo:
+            CustomUser.objects.create(
+                username='*' * (self.USERNAME_MAX_LENGTH + 1))
+        assert str(excinfo.value) == (
+            'value too long for type character varying({max_allowed})\n'
+            .format(max_allowed=self.USERNAME_MAX_LENGTH))
+
+    @pytest.mark.database_integrity
+    def test_username_must_be_unique_in_db(self):
+        duplicated_name = 'duplicated_name'
+        with pytest.raises(IntegrityError) as excinfo:
+            CustomUser.objects.create(username=duplicated_name)
+            CustomUser.objects.create(username=duplicated_name)
+        assert str(excinfo.value) == (
+            'duplicate key value violates unique constraint '
+            '"accounts_customuser_username_key"\n'
+            'DETAIL:  Key (username)=({duplicated_name}) already exists.\n'
+            .format(duplicated_name=duplicated_name))
+
+    @pytest.mark.model_fields_validation
+    def test_username_must_match_regex(self):
+        # does not raise
+        CustomUser(
+            username='Abc',
+            password=self.VALID_PASSWORD,
+            email=self.VALID_EMAIL).full_clean()
+
+        # does not raise
+        CustomUser(
+            username='A',
+            password=self.VALID_PASSWORD,
+            email=self.VALID_EMAIL).full_clean()
+
+        # does not raise
+        CustomUser(
+            username='007',
+            password=self.VALID_PASSWORD,
+            email=self.VALID_EMAIL).full_clean()
+
+        # does not raise
+        CustomUser(
+            username='@',
+            password=self.VALID_PASSWORD,
+            email=self.VALID_EMAIL).full_clean()
+
+        # does not raise
+        CustomUser(
+            username='+++',
+            password=self.VALID_PASSWORD,
+            email=self.VALID_EMAIL).full_clean()
+
+        # does not raise
+        CustomUser(
+            username='---',
+            password=self.VALID_PASSWORD,
+            email=self.VALID_EMAIL).full_clean()
+
+        with pytest.raises(ValidationError) as excinfo:
+            CustomUser(
+                username='',
+                password=self.VALID_PASSWORD,
+                email=self.VALID_EMAIL).full_clean()
+        assert str(excinfo.value) == (
+            "{'username': [u'This field cannot be blank.']}")
+
+        with pytest.raises(ValidationError) as excinfo:
+            CustomUser(
+                username='~',
+                password=self.VALID_PASSWORD,
+                email=self.VALID_EMAIL).full_clean()
+        assert str(excinfo.value) == (
+            "{'username': [u'Enter a valid username.']}")
+
+        with pytest.raises(ValidationError) as excinfo:
+            CustomUser(
+                username='$',
+                password=self.VALID_PASSWORD,
+                email=self.VALID_EMAIL).full_clean()
+        assert str(excinfo.value) == (
+            "{'username': [u'Enter a valid username.']}")
+
+        with pytest.raises(ValidationError) as excinfo:
+            CustomUser(
+                username='"',
+                password=self.VALID_PASSWORD,
+                email=self.VALID_EMAIL).full_clean()
+        assert str(excinfo.value) == (
+            "{'username': [u'Enter a valid username.']}")
+
+        with pytest.raises(ValidationError) as excinfo:
+            CustomUser(
+                username=u'юникод',
+                password=self.VALID_PASSWORD,
+                email=self.VALID_EMAIL).full_clean()
+        assert str(excinfo.value) == (
+            "{'username': [u'Enter a valid username.']}")
+
+        with pytest.raises(ValidationError) as excinfo:
+            CustomUser(
+                username=u'юникод',
+                password=self.VALID_PASSWORD,
+                email=self.VALID_EMAIL).full_clean()
+        assert str(excinfo.value) == (
+            "{'username': [u'Enter a valid username.']}")
+
+    @pytest.mark.database_integrity
+    def test_full_name_length_is_limited_in_db(self):
+        # does not raise
+        CustomUser.objects.create(
+            full_name='*' * self.FULL_NAME_MAX_LENGTH)
+
+        with pytest.raises(DataError) as excinfo:
+            CustomUser.objects.create(
+                full_name='*' * (self.FULL_NAME_MAX_LENGTH + 1))
+        assert str(excinfo.value) == (
+            'value too long for type character varying({max_allowed})\n'
+            .format(max_allowed=self.FULL_NAME_MAX_LENGTH))
+
+    @pytest.mark.model_fields_validation
+    def test_full_name_length_is_limited(self):
+        # does not raise
+        CustomUser(
+            username=self.VALID_USERNAME,
+            password=self.VALID_PASSWORD,
+            email=self.VALID_EMAIL,
+            full_name='*' * self.EMAIL_MAX_LENGTH).full_clean()
+
+        with pytest.raises(ValidationError) as excinfo:
+            CustomUser(
+                username=self.VALID_USERNAME,
+                password=self.VALID_PASSWORD,
+                email=self.VALID_EMAIL,
+                full_name='*' * (self.EMAIL_MAX_LENGTH + 1)).full_clean()
+        assert str(excinfo.value) == (
+            "{'full_name': [u'Ensure this value has at most 254 "
+            "characters (it has 255).']}")
+
+    @pytest.mark.database_integrity
+    def test_short_name_length_is_limited_in_db(self):
+        # does not raise
+        CustomUser.objects.create(
+            short_name='*' * self.SHORT_NAME_MAX_LENGTH)
+
+        with pytest.raises(DataError) as excinfo:
+            CustomUser.objects.create(
+                short_name='*' * (self.SHORT_NAME_MAX_LENGTH + 1))
+        assert str(excinfo.value) == (
+            'value too long for type character varying({max_allowed})\n'
+            .format(max_allowed=self.SHORT_NAME_MAX_LENGTH))
+
+    @pytest.mark.database_integrity
+    def test_email_length_is_limited_in_db(self):
+        # does not raise
+        CustomUser.objects.create(
+            email='*' * self.EMAIL_MAX_LENGTH)
+
+        with pytest.raises(DataError) as excinfo:
+            CustomUser.objects.create(
+                email='*' * (self.EMAIL_MAX_LENGTH + 1))
+        assert str(excinfo.value) == (
+            'value too long for type character varying({max_allowed})\n'
+            .format(max_allowed=self.EMAIL_MAX_LENGTH))
+
+    # testing custom methods
+
+    @pytest.mark.model_methods
+    def test_convert_to_string(self):
+        # __str__ will return username
+        user = CustomUser(
+            username=self.VALID_USERNAME,
+            password=self.VALID_PASSWORD,
+            email=self.VALID_EMAIL)
+
+        assert str(user) == self.VALID_USERNAME
+
+    @pytest.mark.model_methods
+    def test_repr(self):
+        # __str__ returns username, but it did not affected __repr__
+        user = CustomUser(
+            username=self.VALID_USERNAME,
+            password=self.VALID_PASSWORD,
+            email=self.VALID_EMAIL)
+
+        assert repr(user) == (
+            '<CustomUser: {username}>'
+            .format(username=self.VALID_USERNAME))
+
+    @pytest.mark.model_methods
+    def test_get_full_name(self):
+        # this method strips whitespaces from full name
+        user = CustomUser(
+            full_name="Full name")
+        assert user.get_full_name() == "Full name"
+
+        user = CustomUser(
+            full_name="Full name with trailing spaces         ")
+        assert user.get_full_name() == "Full name with trailing spaces"
+
+        user = CustomUser(
+            full_name="Full name with newlines \n\n\n")
+        assert user.get_full_name() == "Full name with newlines"
+
+    @pytest.mark.model_methods
+    def test_get_short_name(self):
+        # this method strips whitespaces from short name
+        user = CustomUser(
+            short_name="Short name")
+        assert user.get_short_name() == "Short name"
+
+        user = CustomUser(
+            short_name="Short name with trailing spaces         ")
+        assert user.get_short_name() == "Short name with trailing spaces"
+
+        user = CustomUser(
+            short_name="Short name with newlines \n\n\n")
+        assert user.get_short_name() == "Short name with newlines"
+
+    @pytest.mark.model_methods
+    def test_get_absolute_url(self):
+        # this method creates url with urlencoded username
+        user = CustomUser(
+            username=self.VALID_USERNAME)
+
+        assert user.get_absolute_url() == (
+            '/users/{username}/'
+            .format(username=self.VALID_USERNAME))
+
+        user = CustomUser(
+            username="Aaa123@")
+        assert user.get_absolute_url() == (
+            '/users/Aaa123%40/')


### PR DESCRIPTION
It's confirmed that a lot of methods in accounts.models.CustomUser are
unused and may be removed.

This patch removes such methods.