### PR TITLE
Improve doc for role_name and Git-installed roles

### DIFF
--- a/docs/docsite/rst/contributing/creating_role.rst
+++ b/docs/docsite/rst/contributing/creating_role.rst
@@ -190,3 +190,7 @@ To override the default name, set the ``role_name`` attribute in the role ``meta
     Setting the value of *role_name* on an existing role will change the name of the role by converting it
     to lowercase, and translating '-'  and '.' to '_'. If the name of an existing role should not be
     altered, don't set the value of *role_name*.
+
+.. note::
+
+    `role_name` is not used at all if the role is installed using its Git URL. Instead, the name of the repo is used.


### PR DESCRIPTION
+label: docsite_pr

Currently, the documentation does not reflect what happens for roles installed using a Git URL.

Closes https://github.com/ansible/galaxy/issues/939

Signed-off-by: Paul des Garets <paul.des-garets@illuin.tech>