### PR TITLE
Content detail UI fixes

### DIFF
--- a/galaxyui/src/app/content-detail/cards/cloud-platforms/cloud-platforms.component.less
+++ b/galaxyui/src/app/content-detail/cards/cloud-platforms/cloud-platforms.component.less
@@ -25,5 +25,7 @@
         background-color: @blue;
         min-width: 100%;
         border-bottom: 4px solid @white;
+        padding: 5px;
+        
     }
 }

--- a/galaxyui/src/app/content-detail/cards/dependencies/dependencies.component.less
+++ b/galaxyui/src/app/content-detail/cards/dependencies/dependencies.component.less
@@ -22,6 +22,8 @@
         background-color: @blue;
         /*min-width: 200px;*/
         border-bottom: 2px solid @white;
+        padding: 5px;
+        
     }
     a, a:visited, a:active {
         color: @white;

--- a/galaxyui/src/app/content-detail/cards/info/card-info.component.html
+++ b/galaxyui/src/app/content-detail/cards/info/card-info.component.html
@@ -9,7 +9,7 @@
             <table>
                 <tr>
                     <td>Minimum Ansible Version</td>
-                    <td>{{ repoContent.min_ansible_version }}</td>
+                    <td><span class="min-version">{{ repoContent.min_ansible_version }}</span></td>
                 </tr>
                 <tr>
                     <td>Installation</td>

--- a/galaxyui/src/app/content-detail/cards/info/card-info.component.less
+++ b/galaxyui/src/app/content-detail/cards/info/card-info.component.less
@@ -28,6 +28,12 @@
         td {
             padding-bottom: 20px;
             vertical-align: top;
+
+            .min-version {
+                background-color: @grey;
+                color: white;
+                padding: 3px;
+            }
         }
         td:first-child {
             padding-right: 15px;

--- a/galaxyui/src/app/content-detail/cards/platforms/platforms.component.less
+++ b/galaxyui/src/app/content-detail/cards/platforms/platforms.component.less
@@ -23,6 +23,7 @@
         color: @white;
         padding: 2px;
         border-bottom: 4px solid @white;
+        padding: 5px;
     }
     .name {
         background-color: @blue;

--- a/galaxyui/src/app/content-detail/cards/versions/versions.component.less
+++ b/galaxyui/src/app/content-detail/cards/versions/versions.component.less
@@ -23,6 +23,8 @@
         color: @white;
         padding: 2px;
         border-bottom: 4px solid @white;
+        padding: 5px;
+        
     }
     .name {
         background-color: @blue;

--- a/galaxyui/src/app/content-detail/content-detail.component.html
+++ b/galaxyui/src/app/content-detail/content-detail.component.html
@@ -17,33 +17,33 @@
 
         <div class="row btn-row" *ngIf="!showEmptyState">
             <div class="col-sm-12">
-                <button type="button" class="btn btn-primary" [disabled]="showingView === ViewTypes.detail"
+                <button type="button" class="btn btn-default" [ngClass]="{'btn-primary': showingView === ViewTypes.detail}"
                     tooltip="Return to main content view"
-                    (click)="toggleView(ViewTypes.detail)"><i class="fa fa-info-circle"></i> Details</button>
+                    (click)="toggleView(ViewTypes.detail)">Details</button>
                 <button type="button" class="btn btn-default"
-                    *ngIf="hasReadme" [disabled]="showingView === ViewTypes.readme"
+                    *ngIf="hasReadme" [ngClass]="{'btn-primary': showingView === ViewTypes.readme}"
                     tooltip="View the repository's README file"
-                    (click)="toggleView(ViewTypes.readme)"><i class="fa fa-eye"></i> README</button>
+                    (click)="toggleView(ViewTypes.readme)">Read Me</button>
                 <button type="button" class="btn btn-default"
-                    *ngIf="hasMetadata" [disabled]="showingView === ViewTypes.meta"
+                    *ngIf="hasMetadata" [ngClass]="{'btn-primary': showingView === ViewTypes.meta}"
                     tooltip="View the {{ metadataFilename }} file"
-                    (click)="toggleView(ViewTypes.meta)"><i class="fa fa-table"></i> Metadata</button>
+                    (click)="toggleView(ViewTypes.meta)">Metadata</button>
                 <button type="button" class="btn btn-default"
-                    *ngIf="contentCounts.module" [disabled]="showingView === ViewTypes.modules"
+                    *ngIf="contentCounts.module" [ngClass]="{'btn-primary': showingView === ViewTypes.modules}"
                     tooltip="View modules"
-                    (click)="toggleView(ViewTypes.modules)"><i class="fa fa-microchip"></i> {{ contentCounts.module }} Modules</button>
+                    (click)="toggleView(ViewTypes.modules)">{{ contentCounts.module }} Modules</button>
                 <button type="button" class="btn btn-default"
-                    *ngIf="contentCounts.moduleUtils" [disabled]="showingView === ViewTypes.moduleUtils"
+                    *ngIf="contentCounts.moduleUtils" [ngClass]="{'btn-primary': showingView === ViewTypes.moduleUtils}"
                     tooltip="View module utils"
-                    (click)="toggleView(ViewTypes.moduleUtils)"><i class="fa fa-microchip"></i>
+                    (click)="toggleView(ViewTypes.moduleUtils)">
                     {{ contentCounts.moduleUtils }} Module Utils</button>
                 <button type="button" class="btn btn-default"
-                    *ngIf="contentCounts.plugin" [disabled]="showingView === ViewTypes.plugins"
+                    *ngIf="contentCounts.plugin" [ngClass]="{'btn-primary': showingView === ViewTypes.plugins}"
                     tooltip="View plugins"
                     (click)="toggleView(ViewTypes.plugins)"><i class="fa fa-plug"></i>
                     {{ contentCounts.plugin }} Plugins</button>
                 <button type="button" class="btn btn-default"
-                    *ngIf="contentCounts.role" [disabled]="showingView === ViewTypes.roles"
+                    *ngIf="contentCounts.role" [ngClass]="{'btn-primary': showingView === ViewTypes.roles}"
                     tooltip="View modules"
                     (click)="toggleView(ViewTypes.roles)"><i class="fa fa-gear"></i>
                     {{ contentCounts.role }} Roles</button>

--- a/galaxyui/src/app/content-detail/repository/repository.component.html
+++ b/galaxyui/src/app/content-detail/repository/repository.component.html
@@ -1,71 +1,83 @@
 <div class="row repository-container">
 
-    <div class="col-lg-2">
+    <div class="col-lg-8 header-left">
         <div class="namespace-img">
             <div class="img-wrapper">
                 <a [routerLink]="['/', repositoryView.namespace]"
                     tooltip="View the author's profile." >
-                    <img class="namespace-avatar" [src]="namespace.avatar_url"></a>
+                    <img class="namespace-avatar" [src]="repositoryView.avatarUrl"></a>
             </div>
-            <a [routerLink]="['/', repositoryView.namespace]"
-                tooltip="View the author's profile.">
-                <span class="fa fa-user"></span> {{ namespace.name }}</a>
+            <div class="namespace-name" tooltip="{{ repositoryView.namespace }}">
+                <a [routerLink]="['/', repositoryView.namespace]">
+                    {{ repositoryView.namespace }}</a>
+            </div>
         </div>
-    </div>
 
-    <div class="col-lg-6">
-        <div class="text-overflow-pf">
-            <div class="repo-name">
-                <span class="fa" [ngClass]="repositoryView.iconClass" tooltip="{{ repositoryView.tooltip }}"></span> {{ repositoryView.name }}
-            </div>
+        <div class="valign-center-box">
             <div>
-                {{ repositoryView.description }}
+                <div class="description-box">
+                    <div class="repo-name text-overflow-pf">
+                        <span class="fa" [ngClass]="repositoryView.iconClass" tooltip="{{ repositoryView.tooltip }}"></span> {{ repositoryView.name }}
+                    </div>
+                    <div class="repo-description">
+                        {{ repositoryView.description }}
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 
     <div class="col-lg-4 repository-details">
 
-        <span class="columns">
-            <ul>
-                <li class="repo-count">
-                    <i class="fa fa-download fa"></i>
-                    <span class="count">{{ repositoryView.downloadCount }}</span>
-                    <span class="count-label">Downloads</span>
-                </li>
-                <li class="repo-count">
-                    <i class="fa fa-eye fa"></i>
-                    <span class="count">{{ repositoryView.watchersCount }}</span>
-                    <span class="count-label">Watchers</span>
-                </li>
-            </ul>
+        <div class="valign-center-box">
+            <div>
+                <span class="columns">
+                    <ul>
+                        <li class="repo-count">
+                            <i class="fa fa-download fa"></i>
+                            <span class="count">{{ repositoryView.downloadCount }}</span>
+                            <span class="count-label">Downloads</span>
+                        </li>
+                        <li class="repo-count">
+                            <i class="fa fa-eye fa"></i>
+                            <span class="count">{{ repositoryView.watchersCount }}</span>
+                            <span class="count-label">Watchers</span>
+                        </li>
+                    </ul>
 
-            <a [href]="repositoryView.issueTrackerUrl" *ngIf="repositoryView.issueTrackerUrl"
-                target="_blank"
-                tooltip="Visit the issue tracker. Opens in a new browser tab."
-                class="btn btn-default"><i class="fa fa-bug"></i> Issue Tracker</a>
-        </span>
+                    <a [href]="repositoryView.issueTrackerUrl" *ngIf="repositoryView.issueTrackerUrl"
+                        target="_blank"
+                        tooltip="Visit the issue tracker. Opens in a new browser tab."
+                        class="btn btn-default"><i class="fa fa-bug"></i> Issue Tracker</a>
 
-        &nbsp;
+                    <a *ngIf="!repositoryView.issueTrackerUrl"
+                        disabled
+                        tooltip="No issue tracker available."
+                        class="btn btn-default"><i class="fa fa-bug"></i> Issue Tracker</a>
+                </span>
 
-        <span class="columns">
-            <ul>
-                <li class="repo-count">
-                    <i class="fa fa-star fa"></i>
-                    <span class="count">{{ repositoryView.stargazersCount }}</span>
-                    <span class="count-label">Stars</span>
-                </li>
-                <li class="repo-count">
-                    <i class="fa fa-copy fa"></i>
-                    <span class="count">{{ repositoryView.forksCount }}</span>
-                    <span class="count-label">Forks</span>
-                </li>
-            </ul>
+                &nbsp;
 
-            <a [href]="repositoryView.scmUrl" target="_blank"
-                tooltip="Visit the repository. Opens in a new browser tab." class="btn btn-default">
-                    <i [ngClass]="repositoryView.scmIconClass"></i> {{ repositoryView.scmName }} Repo</a>
-        </span>
+                <span class="columns">
+                    <ul>
+                        <li class="repo-count">
+                            <i class="fa fa-star fa"></i>
+                            <span class="count">{{ repositoryView.stargazersCount }}</span>
+                            <span class="count-label">Stars</span>
+                        </li>
+                        <li class="repo-count">
+                            <i class="fa fa-copy fa"></i>
+                            <span class="count">{{ repositoryView.forksCount }}</span>
+                            <span class="count-label">Forks</span>
+                        </li>
+                    </ul>
 
+                    <a [href]="repositoryView.scmUrl" target="_blank"
+                        tooltip="Visit the repository. Opens in a new browser tab." class="btn btn-default">
+                            <i [ngClass]="repositoryView.scmIconClass"></i> {{ repositoryView.scmName }} Repo</a>
+                </span>
+
+            </div>
+        </div>
     </div>
 </div>

--- a/galaxyui/src/app/content-detail/repository/repository.component.less
+++ b/galaxyui/src/app/content-detail/repository/repository.component.less
@@ -2,6 +2,9 @@
 
 @import '../../../variables';
 
+@box-height: 100px;
+@image-height: 80px;
+
 .row.repository-container {
     margin-right: 0;
     margin-left: 0;
@@ -13,7 +16,7 @@
     padding-bottom: 15px;
 
     .repository-details {
-        height: 120px;
+        height: @box-height;
         min-width: 270px;
 
         .columns {
@@ -28,38 +31,65 @@
         }
     }
 
-    .namespace-img {
-        min-width: 150px;
-        cursor: pointer;
+    .description-box {
+        min-width: 200px;
+        .repo-description {
+            max-width: 400px;
+        }
+    }
 
-        @media(min-width: 1260px){
+    .header-left {
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    .namespace-img {
+        width: @box-height;
+        cursor: pointer;
+        margin-right: 20px;
+        padding-right: 20px;
+        text-align: center;
+
+        @media(min-width: 1000px){
             border-right: 1px solid #ccc;
-            text-align: center;
         }
 
         .img-wrapper {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            height: 120px;
+            height: @image-height;
             overflow: hidden;
         }
 
         .namespace-avatar {
-            width: 120px;
-            @media(min-width: 1200px){
-                margin: auto;
-            }
+            width: @image-height;
             padding: 0;
             border: 0;
             display: block;
         }
+
+        .namespace-name {
+            text-overflow: ellipsis;
+            overflow: hidden;
+            width: @image-height;
+            margin-top: 5px;
+        }
+    }
+
+    .valign-center-box {
+        display: flex;
+        align-items: center;
+        @media (min-width: 1200px){
+            height: @box-height;
+        }
     }
 
     .repo-name {
-        font-size: 14px;
         color: @black;
         font-weight: 700;
-        font-size: 18px;
+        font-size: 20px;
     }
+
+    .count {
+        font-weight: 600;
+    }
+
 }

--- a/galaxyui/src/app/content-detail/repository/repository.component.ts
+++ b/galaxyui/src/app/content-detail/repository/repository.component.ts
@@ -78,7 +78,14 @@ export class RepositoryComponent implements OnInit {
         this.repositoryView.iconClass = RepoFormatsIconClasses[this.repository.format];
         this.repositoryView.tooltip = RepoFormatsTooltips[this.repository.format];
         this.repositoryView.name = this.repository.name;
-        this.repositoryView.description = this.repository.description;
+
+        // description for legacy roles
+        if (!this.repository.description && this.repository.summary_fields.content_objects.length === 1) {
+            this.repositoryView.description = this.repository.summary_fields.content_objects[0].description;
+        } else {
+            this.repositoryView.description = this.repository.description;
+        }
+
         this.repositoryView.namespace = this.repository.summary_fields.namespace['name'];
 
         if (this.repository.summary_fields.namespace['is_vendor']) {

--- a/galaxyui/src/app/utilities/clipboard/clipboard.component.less
+++ b/galaxyui/src/app/utilities/clipboard/clipboard.component.less
@@ -1,6 +1,7 @@
 /* clipboard.component.less */
 
 .copy-to-clipboard {
+
     code {
         background-color: #fff;
         border-top: 1px solid #bbb;
@@ -13,5 +14,10 @@
     }
     .btn {
         margin-left: -5px;
+        padding-bottom: 2.75px;
+        padding-top: 2.75px;
+        margin-bottom: 1px;
+        box-shadow: none;
+        text-shadow: none;
     }
 }

--- a/galaxyui/src/variables.less
+++ b/galaxyui/src/variables.less
@@ -14,7 +14,7 @@
 @green:       #5bb75b;
 @blue:        #00659c;   /* logo blue */
 @blue-link:   #0088CE;
-@grey:        #848992;
+@grey:        #9C9C9C;
 @charcoal:    #808080;
 @well:        #f5f5f5;   /* well background color */
 @emphasis:    #ccc;


### PR DESCRIPTION
#722

Best effort attempt to make the content detail page look like [the mockups](https://tower-mockups.testing.ansible.com/galaxy/search/search-detail/) without sacrificing functionality that the mockups don't account for.

<img width="1679" alt="screen shot 2018-07-25 at 2 39 59 pm" src="https://user-images.githubusercontent.com/6063371/43220691-a626e7d6-9018-11e8-9075-156099b32739.png">


