### PR TITLE
Improve breadcrumbs

### DIFF
--- a/galaxyui/src/app/authors/authors.component.html
+++ b/galaxyui/src/app/authors/authors.component.html
@@ -1,4 +1,4 @@
-<app-page-header [headerTitle]="pageTitle"></app-page-header>
+<app-page-header [headerTitle]="pageTitle" [headerIcon]="pageIcon"></app-page-header>
 
 <div id="authors-page">
     <div class="padding-15">

--- a/galaxyui/src/app/authors/authors.component.ts
+++ b/galaxyui/src/app/authors/authors.component.ts
@@ -48,7 +48,8 @@ export class AuthorsComponent implements OnInit {
           private namespaceService: NamespaceService
     ) {}
 
-    pageTitle = `<i class="fa fa-users"></i> Community Authors`;
+    pageTitle = 'Community Authors';
+    pageIcon = 'fa fa-users';
     pageLoading = true;
     items: Namespace[] = [];
 

--- a/galaxyui/src/app/authors/detail/author-detail.component.html
+++ b/galaxyui/src/app/authors/detail/author-detail.component.html
@@ -1,4 +1,4 @@
-<app-page-header [headerTitle]="pageTitle"></app-page-header>
+<app-page-header [headerTitle]="pageTitle" [headerIcon]="pageIcon"></app-page-header>
 
 <div id="author-detail" class="container-fluid">
 

--- a/galaxyui/src/app/authors/detail/author-detail.component.ts
+++ b/galaxyui/src/app/authors/detail/author-detail.component.ts
@@ -59,6 +59,7 @@ export class AuthorDetailComponent implements OnInit {
     ) {}
 
     pageTitle = '';
+    pageIcon = '';
     pageLoading = true;
 
     namespace: Namespace;
@@ -159,9 +160,11 @@ export class AuthorDetailComponent implements OnInit {
             this.pageLoading = false;
             if (this.namespace && this.namespace.name) {
                 if (this.namespace.is_vendor) {
-                    this.pageTitle = `<i class="fa fa-star"></i> Partners;/partners;${this.namespace.name}`;
+                    this.pageTitle = `Partners;/partners;${this.namespace.name}`;
+                    this.pageIcon = 'fa fa-star';
                 } else {
-                    this.pageTitle = `<i class="fa fa-users"></i> Community Authors;/community;${this.namespace.name}`;
+                    this.pageTitle = `Community Authors;/community;${this.namespace.name}`;
+                    this.pageIcon = 'fa fa-users';
                 }
                 this.parepareNamespace();
                 if (this.items && this.items.length) {

--- a/galaxyui/src/app/content-detail/content-detail.component.html
+++ b/galaxyui/src/app/content-detail/content-detail.component.html
@@ -1,5 +1,5 @@
 <div id="content-detail-page">
-    <app-page-header [headerTitle]="pageTitle"></app-page-header>
+    <app-page-header [headerTitle]="pageTitle" [headerIcon]="pageIcon"></app-page-header>
 
     <div class="container-fluid content-detail-container">
         <div class="row" *ngIf="showEmptyState">

--- a/galaxyui/src/app/content-detail/content-detail.component.ts
+++ b/galaxyui/src/app/content-detail/content-detail.component.ts
@@ -53,6 +53,7 @@ export class ContentDetailComponent implements OnInit {
     ) {}
 
     pageTitle = '';
+    pageIcon = '';
     content: Content[];
     repository: Repository;
     namespace: Namespace;
@@ -125,9 +126,11 @@ export class ContentDetailComponent implements OnInit {
 
                     // Append author type to breadcrumb
                     if (this.namespace.is_vendor) {
-                        this.pageTitle = `<i class="fa fa-star"></i> Vendors;/vendors;`;
+                        this.pageTitle = 'Vendors;/vendors;';
+                        this.pageIcon = 'fa fa-star';
                     } else {
-                        this.pageTitle = `<i class="fa fa-users"></i> Community Authors;/community;`;
+                        this.pageTitle = 'Community Authors;/community;';
+                        this.pageIcon = 'fa fa-users';
                     }
 
                     // Append author namespace and repository name to breadcrumb

--- a/galaxyui/src/app/exception-pages/access-denied/access-denied.component.html
+++ b/galaxyui/src/app/exception-pages/access-denied/access-denied.component.html
@@ -1,4 +1,4 @@
-<app-page-header [headerTitle]="pageTitle"></app-page-header>
+<app-page-header [headerTitle]="pageTitle" [headerIcon]="pageIcon"></app-page-header>
 
 <div class="container-fluid">
     <pfng-empty-state

--- a/galaxyui/src/app/exception-pages/access-denied/access-denied.component.ts
+++ b/galaxyui/src/app/exception-pages/access-denied/access-denied.component.ts
@@ -31,7 +31,8 @@ export class AccessDeniedComponent implements OnInit {
         private router: Router
     ) {}
 
-    pageTitle = '<i class="fa fa-exclamation-triangle"></i> Access Denied';
+    pageTitle = 'Access Denied';
+    pageIcon = 'fa fa-exclamation-triangle';
     actionConfig: ActionConfig;
     emptyStateConfig: EmptyStateConfig;
 

--- a/galaxyui/src/app/exception-pages/not-found/not-found.component.html
+++ b/galaxyui/src/app/exception-pages/not-found/not-found.component.html
@@ -1,4 +1,4 @@
-<app-page-header [headerTitle]="pageTitle"></app-page-header>
+<app-page-header [headerTitle]="pageTitle" [headerIcon]="pageIcon"></app-page-header>
 <div class="container-fluid">
     <pfng-empty-state
         [config]="emptyStateConfig"

--- a/galaxyui/src/app/exception-pages/not-found/not-found.component.ts
+++ b/galaxyui/src/app/exception-pages/not-found/not-found.component.ts
@@ -31,7 +31,8 @@ export class NotFoundComponent implements OnInit {
         private router: Router
     ) {}
 
-    pageTitle = '<i class="fa fa-frown-o"></i> Page Not Found';
+    pageTitle = 'Page Not Found';
+    pageIcon = 'fa fa-frown-o';
     actionConfig: ActionConfig;
     emptyStateConfig: EmptyStateConfig;
 

--- a/galaxyui/src/app/home/home.component.html
+++ b/galaxyui/src/app/home/home.component.html
@@ -1,4 +1,4 @@
-<app-page-header [headerTitle]="headerTitle"></app-page-header>
+<app-page-header [headerTitle]="headerTitle" [headerIcon]='headerIcon'></app-page-header>
 <div id="home-page" class="container-fluid" (window:resize)="onResize($event)">
 
     <carousel-component [vendors]="vendors"></carousel-component>

--- a/galaxyui/src/app/home/home.component.ts
+++ b/galaxyui/src/app/home/home.component.ts
@@ -31,7 +31,8 @@ export class HomeComponent implements OnInit, AfterViewInit {
     downloadContent: string;
     shareContent: string;
     featuredBlogContent: string;
-    headerTitle = '<i class="fa fa-home"></i> Home';
+    headerTitle = 'Home';
+    headerIcon = 'fa fa-home';
     searchText = '';
     showCards = false;
     vendors: Namespace[] = [];

--- a/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.html
+++ b/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.html
@@ -1,4 +1,4 @@
-<app-page-header [headerTitle]="pageTitle"></app-page-header>
+<app-page-header [headerTitle]="pageTitle" [headerIcon]="pageIcon"></app-page-header>
 <div class="padding-15">
     <form [formGroup]="namespaceForm" novalidate>
         <div class="form-group">

--- a/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.ts
+++ b/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.ts
@@ -72,6 +72,7 @@ export class NamespaceDetailComponent implements OnInit {
     me: IMe;
 
     pageTitle = 'My Content;/my-content;Add Namespace';
+    pageIcon = 'fa fa-list';
     pageLoading = true;
 
     namespaceForm: FormGroup;

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.html
@@ -1,4 +1,4 @@
-<app-page-header [headerTitle]="pageTitle"></app-page-header>
+<app-page-header [headerTitle]="pageTitle" [headerIcon]="pageIcon"></app-page-header>
 
 <div id="my-content-page">
 

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
@@ -49,7 +49,8 @@ export class NamespaceListComponent implements OnInit {
     namespaces: Namespace[] = [];
     me: IMe;
 
-    pageTitle = '<i class="fa fa-list"></i> My Content';
+    pageTitle = 'My Content';
+    pageIcon = 'fa fa-list';
     pageLoading = true;
 
     toolbarActionConfig: ActionConfig;

--- a/galaxyui/src/app/my-imports/import-list/import-list.component.html
+++ b/galaxyui/src/app/my-imports/import-list/import-list.component.html
@@ -1,4 +1,4 @@
-<app-page-header [headerTitle]="pageTitle"></app-page-header>
+<app-page-header [headerTitle]="pageTitle" [headerIcon]="pageIcon"></app-page-header>
 
 <div class="row padding-15" id="import-list-page">
     <div class="col-sm-4 list-column">

--- a/galaxyui/src/app/my-imports/import-list/import-list.component.ts
+++ b/galaxyui/src/app/my-imports/import-list/import-list.component.ts
@@ -69,7 +69,8 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
     selectedId: number;
     checking = false;
 
-    pageTitle = '<i class="fa fa-upload"></i> My Imports';
+    pageTitle = 'My Imports';
+    pageIcon = 'fa fa-upload';
     pageLoading = true;
     refreshing = false;
     polling = null;

--- a/galaxyui/src/app/page-header/page-header.component.html
+++ b/galaxyui/src/app/page-header/page-header.component.html
@@ -1,8 +1,10 @@
 <div class="page-header">
     <ul class="page-header-list">
-        <li *ngFor="let title of _headerTitle; index as i">
+        <li><span *ngIf="_headerIcon" class="{{ _headerIcon }}"></span></li>
+        <li *ngIf="_headerTitle.length > 1" class="show-on-mobile"><span class="fa fa-angle-double-right"></span></li>
+        <li *ngFor="let title of _headerTitle; index as i; let last=last" [ngClass]="{'hide-on-mobile': !last}">
             <a [routerLink]="[title.path]" *ngIf="title.path" [innerHTML]="title.name"></a>
-            <span *ngIf="i < _headerTitle.length - 1" class="separator">&gt;</span>
+            <span *ngIf="i < _headerTitle.length - 1" class="separator"><span class="fa fa-angle-right"></span></span>
             <span *ngIf="!title.path" [innerHTML]="title.name"></span>
         </li>
     </ul>

--- a/galaxyui/src/app/page-header/page-header.component.less
+++ b/galaxyui/src/app/page-header/page-header.component.less
@@ -1,9 +1,15 @@
 .page-header {
-    margin-top: 15px;
-    margin-left: 15px;
-    margin-right: 15px;
-    border-bottom: 1px solid #bbb;
+    margin-left: -20px;
+    margin-right: -20px;
+    margin-bottom: 20px;
+
+    margin-top: 0px;
+
+    padding-left: 35px;
+    padding-right: 35px;
     padding-bottom: 20px;
+
+    border-bottom: 1px solid #bbb;
     font-size: 16px;
 }
 
@@ -21,5 +27,17 @@
     }
     .separator {
         padding-left: 3px;
+    }
+
+    .hide-on-mobile {
+        @media(max-width: 1000px){
+            display: none;
+        }
+    }
+
+    .show-on-mobile {
+        @media(min-width: 1000px){
+            display: none;
+        }
     }
 }

--- a/galaxyui/src/app/page-header/page-header.component.ts
+++ b/galaxyui/src/app/page-header/page-header.component.ts
@@ -17,6 +17,7 @@ class Title {
 export class PageHeaderComponent implements OnInit {
 
     _headerTitle: Title[];
+    _headerIcon: string;
 
     @Input()
     set headerTitle(headerTitle: string) {
@@ -39,6 +40,11 @@ export class PageHeaderComponent implements OnInit {
                 this._headerTitle.push(title);
             }
         });
+    }
+
+    @Input()
+    set headerIcon(icon: string) {
+        this._headerIcon = icon;
     }
 
     constructor() {}

--- a/galaxyui/src/app/search/search.component.html
+++ b/galaxyui/src/app/search/search.component.html
@@ -1,4 +1,4 @@
-<app-page-header [headerTitle]="pageTitle"></app-page-header>
+<app-page-header [headerTitle]="pageTitle" [headerIcon]="pageIcon"></app-page-header>
 
 <div id="search-page" class="container-fluid">
     <div class="row">

--- a/galaxyui/src/app/search/search.component.ts
+++ b/galaxyui/src/app/search/search.component.ts
@@ -69,7 +69,8 @@ import * as moment        from 'moment';
 })
 export class SearchComponent implements OnInit, AfterViewInit {
 
-    pageTitle = '<i class="fa fa-search"></i> Search';
+    pageTitle = 'Search';
+    pageIcon = 'fa fa-search';
     toolbarConfig: ToolbarConfig;
     filterConfig: FilterConfig;
     sortConfig: SortConfig;

--- a/galaxyui/src/app/vendors/vendors.component.html
+++ b/galaxyui/src/app/vendors/vendors.component.html
@@ -1,4 +1,4 @@
-<app-page-header [headerTitle]="pageTitle"></app-page-header>
+<app-page-header [headerTitle]="pageTitle" [headerIcon]="headerIcon"></app-page-header>
 
 <div id="vendors-page" class="container-fluid">
 

--- a/galaxyui/src/app/vendors/vendors.component.ts
+++ b/galaxyui/src/app/vendors/vendors.component.ts
@@ -47,7 +47,8 @@ export class VendorsComponent implements OnInit {
           private namespaceService: NamespaceService
     ) {}
 
-    pageTitle = '<i class="fa fa-star"></i> Partners';
+    pageTitle = 'Partners';
+    headerIcon = 'fa fa-star';
     pageLoading = true;
     items: Namespace[] = [];
 


### PR DESCRIPTION
#718

- Update header to accept icon parameter.
- hide breadcrumbs on small devices
- Make line under header extend width of page.

<img width="1675" alt="screen shot 2018-07-25 at 6 06 43 pm" src="https://user-images.githubusercontent.com/6063371/43230369-f506de2a-9035-11e8-89cd-f57f2554090f.png">

Breadcrumbs collapse on smaller screens
<img width="469" alt="screen shot 2018-07-25 at 6 07 43 pm" src="https://user-images.githubusercontent.com/6063371/43230373-f732b1ce-9035-11e8-9529-47b74d85792e.png">
