### PR TITLE
Style upgrades to clipboard

### DIFF
--- a/galaxyui/src/app/utilities/clipboard/clipboard.component.html
+++ b/galaxyui/src/app/utilities/clipboard/clipboard.component.html
@@ -1,4 +1,5 @@
 <div class="copy-to-clipboard">
-    <code [id]="guid">{{ copyText | lowercase }}</code>
+    <div class="code">$</div>
+    <div class="code" [id]="guid">{{ copyText | lowercase }}</div>
     <a [href]="" (click)="copyToClipboard()" class="btn btn-default" tooltip="Copy to clipboard"><i class="fa fa-copy"></i></a>
 </div>

--- a/galaxyui/src/app/utilities/clipboard/clipboard.component.less
+++ b/galaxyui/src/app/utilities/clipboard/clipboard.component.less
@@ -1,23 +1,29 @@
 /* clipboard.component.less */
 
-.copy-to-clipboard {
+@import '../../../variables';
 
-    code {
-        background-color: #fff;
-        border-top: 1px solid #bbb;
-        border-bottom: 1px solid #bbb;
-        border-left: 1px solid #bbb;
-        border-right: 1px solid #fff;
-        padding: 4px 5px 5px 5px;
-        border-radius: 1px;
-        margin: 0;
+.copy-to-clipboard {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+
+    .code {
+        vertical-align: middle;
+        padding-left: 5px;
+        padding-right: 5px;
+        font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+        display: inline-block;
+        background-color: #F9F2F4;
+        color: #C20F45;
+        height: 27px;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
     .btn {
-        margin-left: -5px;
-        padding-bottom: 2.75px;
-        padding-top: 2.75px;
-        margin-bottom: 1px;
+        display: inline-block;
+        height: 27px;
         box-shadow: none;
         text-shadow: none;
+        font-weight: bold;
     }
 }


### PR DESCRIPTION
Adds coloring scheme from [the mockups](https://tower-mockups.testing.ansible.com/galaxy/search/search-detail-partner/).

New look:
![screen shot 2018-07-26 at 10 57 49 am](https://user-images.githubusercontent.com/6063371/43270368-e3596138-90c2-11e8-80f6-4c02a2838577.png)

Button aligns correctly, unlike the previous version:
![screen shot 2018-07-26 at 10 51 21 am](https://user-images.githubusercontent.com/6063371/43269992-0aa63172-90c2-11e8-9563-69ef9b576c42.png)

#722