### PR TITLE
Limit persistent connection lifetime

### DIFF
--- a/galaxy/settings/production.py
+++ b/galaxy/settings/production.py
@@ -85,7 +85,7 @@ DATABASES = {}
 
 if os.environ.get('GALAXY_DB_URL'):
     DATABASES['default'] = dj_database_url.config(
-        env='GALAXY_DB_URL', conn_max_age=None)
+        env='GALAXY_DB_URL', conn_max_age=60)
 else:
     DATABASES['default'] = {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
@@ -94,7 +94,7 @@ else:
         'PASSWORD': os.environ.get('GALAXY_DB_PASSWORD', ''),
         'HOST': os.environ.get('GALAXY_DB_HOST', ''),
         'PORT': int(os.environ.get('GALAXY_DB_PORT', 5432)),
-        'CONN_MAX_AGE': None,
+        'CONN_MAX_AGE': 60,
     }
 
 # Create default alias for worker logging


### PR DESCRIPTION
Limit max connection age to 60 seconds.

(cherry picked from commit 459f13c0c39f65a99dc1736a0fa09250f37e86ea)