### PR TITLE
Fix stack trace on my-content page

### DIFF
--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.ts
@@ -68,6 +68,7 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
     items: Repository[] = [];
 
     emptyStateConfig: EmptyStateConfig;
+    nonEmptyStateConfig: EmptyStateConfig;
     disabledStateConfig: EmptyStateConfig;
     paginationConfig: PaginationConfig = {
         pageSize: 10,
@@ -132,6 +133,17 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
             helpLink: {}
         } as EmptyStateConfig;
 
+        this.nonEmptyStateConfig = {
+            actions: {
+                primaryActions: [],
+                moreActions: []
+            } as ActionConfig,
+            iconStyleClass: '',
+            title: '',
+            info: '',
+            helpLink: {}
+        } as EmptyStateConfig;
+
         this.disabledStateConfig = {
             iconStyleClass: 'pficon-warning-triangle-o',
             info: `The Namespace ${this.namespace.name} is disabled. You'll need to re-enable it before viewing and modifying its content.`,
@@ -140,7 +152,7 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
 
         this.listConfig = {
             dblClick: false,
-            emptyStateConfig: null,
+            emptyStateConfig: this.nonEmptyStateConfig,
             multiSelect: false,
             selectItems: false,
             selectionMatchProp: 'name',
@@ -290,7 +302,7 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
         if (this.items.length === 0) {
             this.listConfig.emptyStateConfig = this.emptyStateConfig;
         } else {
-            this.listConfig.emptyStateConfig = null;
+            this.listConfig.emptyStateConfig = this.nonEmptyStateConfig;
         }
     }
 


### PR DESCRIPTION
Fixes the following stack trace when opening up namespaces on the My Content page. This was caused by setting the list empty state to null in patternfly.

```
ERROR TypeError: _co.config is null
Stack trace:
View_EmptyStateComponent_0/<@ng:///EmptyStateModule/EmptyStateComponent.ngfactory.js:165:9
debugUpdateDirectives@http://localhost:8000/vendor.js:59902:12
checkAndUpdateView@http://localhost:8000/vendor.js:59049:5
callViewAction@http://localhost:8000/vendor.js:59400:21
execComponentViewsAction@http://localhost:8000/vendor.js:59332:13
checkAndUpdateView@http://localhost:8000/vendor.js:59055:5
callViewAction@http://localhost:8000/vendor.js:59400:21
execEmbeddedViewsAction@http://localhost:8000/vendor.js:59358:17
checkAndUpdateView@http://localhost:8000/vendor.js:59050:5
callViewAction@http://localhost:8000/vendor.js:59400:21
execComponentViewsAction@http://localhost:8000/vendor.js:59332:13
checkAndUpdateView@http://localhost:8000/vendor.js:59055:5
callViewAction@http://localhost:8000/vendor.js:59400:21
execEmbeddedViewsAction@http://localhost:8000/vendor.js:59358:17
checkAndUpdateView@http://localhost:8000/vendor.js:59050:5
callViewAction@http://localhost:8000/vendor.js:59400:21
execComponentViewsAction@http://localhost:8000/vendor.js:59332:13
checkAndUpdateView@http://localhost:8000/vendor.js:59055:5
callViewAction@http://localhost:8000/vendor.js:59400:21
execEmbeddedViewsAction@http://localhost:8000/vendor.js:59358:17
checkAndUpdateView@http://localhost:8000/vendor.js:59050:5
callViewAction@http://localhost:8000/vendor.js:59400:21
execEmbeddedViewsAction@http://localhost:8000/vendor.js:59358:17
checkAndUpdateView@http://localhost:8000/vendor.js:59050:5
callViewAction@http://localhost:8000/vendor.js:59400:21
execEmbeddedViewsAction@http://localhost:8000/vendor.js:59358:17
checkAndUpdateView@http://localhost:8000/vendor.js:59050:5
callViewAction@http://localhost:8000/vendor.js:59400:21
execEmbeddedViewsAction@http://localhost:8000/vendor.js:59358:17
checkAndUpdateView@http://localhost:8000/vendor.js:59050:5
callViewAction@http://localhost:8000/vendor.js:59400:21
execEmbeddedViewsAction@http://localhost:8000/vendor.js:59358:17
checkAndUpdateView@http://localhost:8000/vendor.js:59050:5
callViewAction@http://localhost:8000/vendor.js:59400:21
execComponentViewsAction@http://localhost:8000/vendor.js:59332:13
checkAndUpdateView@http://localhost:8000/vendor.js:59055:5
callViewAction@http://localhost:8000/vendor.js:59400:21
execComponentViewsAction@http://localhost:8000/vendor.js:59332:13
checkAndUpdateView@http://localhost:8000/vendor.js:59055:5
callViewAction@http://localhost:8000/vendor.js:59400:21
execEmbeddedViewsAction@http://localhost:8000/vendor.js:59358:17
checkAndUpdateView@http://localhost:8000/vendor.js:59050:5
callViewAction@http://localhost:8000/vendor.js:59400:21
execComponentViewsAction@http://localhost:8000/vendor.js:59332:13
checkAndUpdateView@http://localhost:8000/vendor.js:59055:5
callWithDebugContext@http://localhost:8000/vendor.js:60303:39
debugCheckAndUpdateView@http://localhost:8000/vendor.js:59840:12
["./node_modules/@angular/core/esm5/core.js"]/ViewRef_.prototype.detectChanges@http://localhost:8000/vendor.js:56824:13
["./node_modules/@angular/core/esm5/core.js"]/ApplicationRef.prototype.tick/<@http://localhost:8000/vendor.js:51123:58
["./node_modules/@angular/core/esm5/core.js"]/ApplicationRef.prototype.tick@http://localhost:8000/vendor.js:51123:13
ApplicationRef/<.next/<@http://localhost:8000/vendor.js:50956:99
["./node_modules/zone.js/dist/zone.js"]/</ZoneDelegate.prototype.invoke@http://localhost:8000/polyfills.js:2705:17
forkInnerZoneWithAngularBehavior/zone._inner<.onInvoke@http://localhost:8000/vendor.js:49965:24
["./node_modules/zone.js/dist/zone.js"]/</ZoneDelegate.prototype.invoke@http://localhost:8000/polyfills.js:2704:17
["./node_modules/zone.js/dist/zone.js"]/</Zone.prototype.run@http://localhost:8000/polyfills.js:2455:24
["./node_modules/@angular/core/esm5/core.js"]/NgZone.prototype.run@http://localhost:8000/vendor.js:49782:54
ApplicationRef/<.next@http://localhost:8000/vendor.js:50956:69
["./node_modules/@angular/core/esm5/core.js"]/EventEmitter.prototype.subscribe/schedulerFn<@http://localhost:8000/vendor.js:49547:36
["./node_modules/rxjs/_esm5/Subscriber.js"]/SafeSubscriber.prototype.__tryOrUnsub@http://localhost:8000/vendor.js:212896:13
["./node_modules/rxjs/_esm5/Subscriber.js"]/SafeSubscriber.prototype.next@http://localhost:8000/vendor.js:212843:17
["./node_modules/rxjs/_esm5/Subscriber.js"]/Subscriber.prototype._next@http://localhost:8000/vendor.js:212784:9
["./node_modules/rxjs/_esm5/Subscriber.js"]/Subscriber.prototype.next@http://localhost:8000/vendor.js:212748:13
["./node_modules/rxjs/_esm5/Subject.js"]/Subject.prototype.next@http://localhost:8000/vendor.js:212471:17
["./node_modules/@angular/core/esm5/core.js"]/EventEmitter.prototype.emit@http://localhost:8000/vendor.js:49527:24
checkStable@http://localhost:8000/vendor.js:49930:13
onLeave@http://localhost:8000/vendor.js:50009:5
forkInnerZoneWithAngularBehavior/zone._inner<.onInvokeTask@http://localhost:8000/vendor.js:49959:17
["./node_modules/zone.js/dist/zone.js"]/</ZoneDelegate.prototype.invokeTask@http://localhost:8000/polyfills.js:2737:17
["./node_modules/zone.js/dist/zone.js"]/</Zone.prototype.runTask@http://localhost:8000/polyfills.js:2505:28
["./node_modules/zone.js/dist/zone.js"]/</ZoneTask.invokeTask@http://localhost:8000/polyfills.js:2813:24
ZoneTask/this.invoke@http://localhost:8000/polyfills.js:2802:28
scheduleTask/target[XHR_LISTENER]@http://localhost:8000/polyfills.js:5243:25
```