### PR TITLE
Fix broken error handling

### DIFF
--- a/galaxyui/src/app/resources/namespaces/namespace.service.ts
+++ b/galaxyui/src/app/resources/namespaces/namespace.service.ts
@@ -1,14 +1,14 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Injectable }              from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import { Observable }           from 'rxjs/Observable';
-import { of }                   from 'rxjs/observable/of';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 import { catchError, map, tap } from 'rxjs/operators';
 
 import { Namespace } from './namespace';
 
 import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
-import { PagedResponse }       from '../paged-response';
+import { PagedResponse } from '../paged-response';
 
 const httpOptions = {
     headers: new HttpHeaders({
@@ -21,13 +21,13 @@ export class NamespaceService {
     private url = '/api/v1/namespaces';
 
     constructor(private http: HttpClient,
-                private notificationService: NotificationService) {
+        private notificationService: NotificationService) {
     }
 
     encounteredErrors = false;
 
     query(params?: any): Observable<Namespace[]> {
-        return this.http.get<PagedResponse>(this.url + '/', {params: params})
+        return this.http.get<PagedResponse>(this.url + '/', { params: params })
             .pipe(
                 map(response => response.results),
                 tap(_ => this.log('fetched namespaces')),
@@ -37,7 +37,7 @@ export class NamespaceService {
 
     pagedQuery(params: any): Observable<PagedResponse> {
         if (params && typeof params === 'object') {
-            return this.http.get<PagedResponse>(this.url + '/', {params: params})
+            return this.http.get<PagedResponse>(this.url + '/', { params: params })
                 .pipe(
                     tap(_ => this.log('fetched paged content')),
                     catchError(this.handleError('Query', {} as PagedResponse))
@@ -53,7 +53,7 @@ export class NamespaceService {
         return this.http.get<PagedResponse>(this.url + '/')
             .pipe(
                 tap(_ => this.log('fetched paged content')),
-                 catchError(this.handleError('Query', {} as PagedResponse))
+                catchError(this.handleError('Query', {} as PagedResponse))
             );
     }
 
@@ -93,19 +93,20 @@ export class NamespaceService {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} namespace error: ${error.message}`);
-            if ('error' in error && result !== undefined) {
+            if (typeof error === 'object' && 'error' in error && typeof error['error'] === 'object' &&
+                result !== undefined) {
                 // Unpack error messages, sending each to the notification service
                 for (const fld in error['error']) {
                     if (error['error'].hasOwnProperty(fld)) {
                         if (typeof error['error'][fld] !== 'object') {
                             const msg = result[fld];
-                            this.notificationService.httpError(error['error'][fld], {data: {message: msg}});
+                            this.notificationService.httpError(error['error'][fld], { data: { message: msg } });
                         } else {
                             for (const idx in error['error'][fld]) {
                                 if (result[fld]) {
                                     if (Array.isArray(result[fld]) && idx < result[fld].length) {
                                         const msg = result[fld][idx]['name'];
-                                        this.notificationService.httpError(error['error'][fld][idx], {data: {message: msg}});
+                                        this.notificationService.httpError(error['error'][fld][idx], { data: { message: msg } });
                                     }
                                 }
                             }
@@ -114,7 +115,7 @@ export class NamespaceService {
                 }
             } else {
                 // Nothing to unpack. Raise the raw error to the notification service.
-                this.notificationService.httpError(`${operation} namespace failed:`, {data: error});
+                this.notificationService.httpError(`${operation} namespace failed:`, { data: error });
             }
             // Let the app keep running by returning an empty result.
             this.encounteredErrors = true;

--- a/galaxyui/src/app/resources/repositories/repository.service.ts
+++ b/galaxyui/src/app/resources/repositories/repository.service.ts
@@ -1,13 +1,13 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Injectable }              from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import { Observable }           from 'rxjs/Observable';
-import { of }                   from 'rxjs/observable/of';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 import { catchError, map, tap } from 'rxjs/operators';
 
 import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
-import { PagedResponse }       from '../paged-response';
-import { Repository }          from './repository';
+import { PagedResponse } from '../paged-response';
+import { Repository } from './repository';
 
 const httpOptions = {
     headers: new HttpHeaders({
@@ -21,11 +21,11 @@ export class RepositoryService {
     private url = '/api/v1/repositories';
 
     constructor(private http: HttpClient,
-                private notificationService: NotificationService) {
+        private notificationService: NotificationService) {
     }
 
     query(params?: any): Observable<Repository[]> {
-        return this.http.get<PagedResponse>(this.url + '/', {params: params})
+        return this.http.get<PagedResponse>(this.url + '/', { params: params })
             .pipe(
                 map(response => response.results as Repository[]),
                 tap(_ => this.log('fetched repositories')),
@@ -35,7 +35,7 @@ export class RepositoryService {
 
     pagedQuery(params?: any): Observable<PagedResponse> {
         if (params && typeof params === 'object') {
-            return this.http.get<PagedResponse>(this.url + '/', {params: params})
+            return this.http.get<PagedResponse>(this.url + '/', { params: params })
                 .pipe(
                     tap(_ => this.log('fetched repositories')),
                     catchError(this.handleError('Query', {} as PagedResponse))
@@ -89,20 +89,20 @@ export class RepositoryService {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             let data = error;
-            if (error['error']) {
+            if (typeof error === 'object' && 'error' in error) {
                 // Check if API returned a field-level validation error
                 const msg = error['error'];
                 if (typeof msg === 'object') {
                     for (const key in msg) {
                         if (msg.hasOwnProperty(key)) {
-                            data = {message: msg[key]};
+                            data = { message: msg[key] };
                             break;
                         }
                     }
                 }
             }
             this.log(`${operation} repository error: ${error.message}`);
-            this.notificationService.httpError(`${operation} repository failed:`, {data: data});
+            this.notificationService.httpError(`${operation} repository failed:`, { data: data });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);


### PR DESCRIPTION
Fixes #981 

In the error object returned by the API, we assumed the `error` key pointed to an object, when sometimes it might actually point to a string.