### PR TITLE
Enforce TypeScript and Less code formatting with prettier.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ script:
 - make dev/waitenv
 - make dev/shellcheck
 - make dev/test
+- make dev/jslint
+- make test/prettier
 
 # check images running
 - docker ps -a

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -432,6 +432,26 @@ To run lint checks against JavaScript/TypeScript sources, execute:
 
     $ make dev/jslint
 
+Formatting your code
+^^^^^^^^^^^^^^^^^^^^
+
+We use prettier to enforce code formatting for all of our TypeScript and less files.
+To automatically format your Angular code run:
+
+.. code-block:: console
+
+    $ make dev/prettier
+
+Unformatted code will cause the travis build to fail when you push your changes to
+GitHub.
+
+It's recommended that you set up prettier on your editor if you're making lots of
+changes to anything in ``galaxyui/``. Prettier is supported by most major editors
+and you can find more `information about that here <https://prettier.io/docs/en/editors.html>`_.
+
+Our prettier configuration can be found at ``galaxyui/.prettierrc.yaml``. Please
+use it when setting up your editor.
+
 Testing your code
 ^^^^^^^^^^^^^^^^^
 

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,13 @@ test/flake8:
 test/jslint:
 	cd galaxyui; ng lint
 
+# for some reason yarn won't add prettier to /usr/local/bin
+.PHONY: test/prettier
+test/prettier:
+	@echo "Checking formatting..."
+	@echo "If this fails, run make dev/prettier locally to format your code"
+	cd galaxyui; ./node_modules/.bin/prettier -l "{src/**/*.ts, src/**/*.less}"
+
 # ---------------------------------------------------------
 # Docker targets
 # ---------------------------------------------------------
@@ -143,6 +150,12 @@ dev/flake8:
 dev/jslint:
 	@echo "Linting Javascript..."
 	@$(DOCKER_COMPOSE) exec galaxy bash -c 'cd galaxyui; ng lint'
+
+# for some reason yarn won't add prettier to /usr/local/bin
+.PHONY: dev/prettier
+dev/prettier:
+	@echo "Running prettier..."
+	@$(DOCKER_COMPOSE) exec galaxy bash -c 'cd galaxyui; ./node_modules/.bin/prettier --write "{src/**/*.ts, src/**/*.less}"'
 
 .PHONY: dev/shellcheck
 dev/shellcheck:

--- a/galaxyui/.prettierrc.yaml
+++ b/galaxyui/.prettierrc.yaml
@@ -1,0 +1,3 @@
+printWidth: 140
+singleQuote: true
+trailingComma: "all"

--- a/galaxyui/package.json
+++ b/galaxyui/package.json
@@ -43,6 +43,7 @@
     "karma-coverage-istanbul-reporter": "^1.2.1",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
+    "prettier": "1.14.0",
     "protractor": "~5.1.2",
     "ts-node": "~4.1.0",
     "tslint": "~5.9.1",

--- a/galaxyui/src/app/app-routing.module.ts
+++ b/galaxyui/src/app/app-routing.module.ts
@@ -1,40 +1,35 @@
-import { NgModule }              from '@angular/core';
+import { NgModule } from '@angular/core';
 import { AuthorDetailComponent } from './authors/detail/author-detail.component';
 import { ContentDetailComponent } from './content-detail/content-detail.component';
-import { NotFoundComponent }     from './exception-pages/not-found/not-found.component';
+import { NotFoundComponent } from './exception-pages/not-found/not-found.component';
 
 import {
     ContentResolver,
     NamespaceResolver,
-    RepositoryResolver as ContentRepositoryResolver
+    RepositoryResolver as ContentRepositoryResolver,
 } from './content-detail/content-detail.resolver.service';
 
-import {
-    NamespaceDetailResolver,
-    RepositoryResolver as AuthorRepositoryResolver
-}  from './authors/authors.resolver.service';
+import { NamespaceDetailResolver, RepositoryResolver as AuthorRepositoryResolver } from './authors/authors.resolver.service';
 
-import {
-    PreloadAllModules,
-    RouterModule,
-    Routes
-}  from '@angular/router';
+import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
 
 const appRoutes: Routes = [
     {
         path: '',
         redirectTo: '/home',
-        pathMatch: 'full'
+        pathMatch: 'full',
     },
 
     // Lazily loaded modules
     {
         path: 'search',
-        loadChildren: './search/search.module#SearchModule'
-    }, {
+        loadChildren: './search/search.module#SearchModule',
+    },
+    {
         path: 'my-content',
         loadChildren: './my-content/my-content.module#MyContentModule',
-    }, {
+    },
+    {
         path: 'my-imports',
         loadChildren: './my-imports/my-imports.module#MyImportsModule',
     },
@@ -42,33 +37,36 @@ const appRoutes: Routes = [
     // Routes that resolve variables have to go in app-routing.module to ensure
     // that they are resolved between the static routes ('/search', '/my-content' etc)
     // and the wildcard ('**')
-     {
+    {
         path: ':namespace/:repository/:content_name',
         component: ContentDetailComponent,
         resolve: {
             content: ContentResolver,
             repository: ContentRepositoryResolver,
-            namespace: NamespaceResolver
-        }
-    }, {
+            namespace: NamespaceResolver,
+        },
+    },
+    {
         path: ':namespace/:repository',
         component: ContentDetailComponent,
         resolve: {
             content: ContentResolver,
             repository: ContentRepositoryResolver,
-            namespace: NamespaceResolver
-        }
-    }, {
+            namespace: NamespaceResolver,
+        },
+    },
+    {
         path: ':namespace',
         component: AuthorDetailComponent,
         resolve: {
             namespace: NamespaceDetailResolver,
-            repositories: AuthorRepositoryResolver
-        }
-    }, {
+            repositories: AuthorRepositoryResolver,
+        },
+    },
+    {
         path: '**',
-        component: NotFoundComponent
-    }
+        component: NotFoundComponent,
+    },
 ];
 
 @NgModule({
@@ -76,9 +74,9 @@ const appRoutes: Routes = [
         RouterModule.forRoot(appRoutes, {
             enableTracing: false,
             onSameUrlNavigation: 'reload',
-            preloadingStrategy: PreloadAllModules
-        })
+            preloadingStrategy: PreloadAllModules,
+        }),
     ],
-    exports: [ RouterModule ]
+    exports: [RouterModule],
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {}

--- a/galaxyui/src/app/app.component.spec.ts
+++ b/galaxyui/src/app/app.component.spec.ts
@@ -1,27 +1,25 @@
 import { async, TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 describe('AppComponent', () => {
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [
-        AppComponent
-      ],
-    }).compileComponents();
-  }));
-  it('should create the app', async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app).toBeTruthy();
-  }));
-  it(`should have as title 'app'`, async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('app');
-  }));
-  it('should render title in a h1 tag', async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Welcome to app!');
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [AppComponent],
+        }).compileComponents();
+    }));
+    it('should create the app', async(() => {
+        const fixture = TestBed.createComponent(AppComponent);
+        const app = fixture.debugElement.componentInstance;
+        expect(app).toBeTruthy();
+    }));
+    it(`should have as title 'app'`, async(() => {
+        const fixture = TestBed.createComponent(AppComponent);
+        const app = fixture.debugElement.componentInstance;
+        expect(app.title).toEqual('app');
+    }));
+    it('should render title in a h1 tag', async(() => {
+        const fixture = TestBed.createComponent(AppComponent);
+        fixture.detectChanges();
+        const compiled = fixture.debugElement.nativeElement;
+        expect(compiled.querySelector('h1').textContent).toContain('Welcome to app!');
+    }));
 });

--- a/galaxyui/src/app/app.component.ts
+++ b/galaxyui/src/app/app.component.ts
@@ -16,45 +16,33 @@
  * along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
  */
 
-import {
-    Component,
-    OnInit,
-    TemplateRef
-} from '@angular/core';
+import { Component, OnInit, TemplateRef } from '@angular/core';
 
-import {
-    NavigationEnd,
-    NavigationStart,
-    Router
-} from '@angular/router';
+import { NavigationEnd, NavigationStart, Router } from '@angular/router';
 
-import { BsModalService }       from 'ngx-bootstrap/modal';
-import { BsModalRef }           from 'ngx-bootstrap/modal/bs-modal-ref.service';
+import { BsModalService } from 'ngx-bootstrap/modal';
+import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
 
-import { AboutModalConfig }     from 'patternfly-ng/modal/about-modal-config';
-import { AboutModalEvent }      from 'patternfly-ng/modal/about-modal-event';
+import { AboutModalConfig } from 'patternfly-ng/modal/about-modal-config';
+import { AboutModalEvent } from 'patternfly-ng/modal/about-modal-event';
 import { NavigationItemConfig } from 'patternfly-ng/navigation/navigation-item-config';
-import { Notification }         from 'patternfly-ng/notification';
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
+import { Notification } from 'patternfly-ng/notification';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
 
-import { AuthService }          from './auth/auth.service';
-import { ApiRootService }       from './resources/api-root/api-root.service';
+import { AuthService } from './auth/auth.service';
+import { ApiRootService } from './resources/api-root/api-root.service';
 
-import {
-    BodyCommand,
-    PFBodyService
-} from './resources/pf-body/pf-body.service';
+import { BodyCommand, PFBodyService } from './resources/pf-body/pf-body.service';
 
 @Component({
     selector: 'galaxy-nav',
-    styleUrls:   ['./app.component.less'],
-    templateUrl: './app.component.html'
+    styleUrls: ['./app.component.less'],
+    templateUrl: './app.component.html',
 })
 export class AppComponent implements OnInit {
-
     constructor(
-        private router:       Router,
-        private authService:  AuthService,
+        private router: Router,
+        private authService: AuthService,
         private apiRootService: ApiRootService,
         private modalService: BsModalService,
         private notificationService: NotificationService,
@@ -71,14 +59,14 @@ export class AppComponent implements OnInit {
         });
     }
 
-    navItems:      NavigationItemConfig[] = [];
-    modalRef:      BsModalRef;
+    navItems: NavigationItemConfig[] = [];
+    modalRef: BsModalRef;
     authenticated = false;
-    username:      string = null;
+    username: string = null;
     showAbout = false;
-    aboutConfig:   AboutModalConfig;
-    redirectUrl:   string = null;
-    teamMembers:   string[];
+    aboutConfig: AboutModalConfig;
+    redirectUrl: string = null;
+    teamMembers: string[];
     pfBody: any;
 
     ngOnInit(): void {
@@ -93,11 +81,9 @@ export class AppComponent implements OnInit {
 
         this.pfBody = document.getElementById('pfContentBody');
 
-        this.pfBodyService.currentMessage.subscribe(
-            (message: BodyCommand) => {
-                this.pfBody[message.propertyName] = message.propertyValue;
-            }
-        );
+        this.pfBodyService.currentMessage.subscribe((message: BodyCommand) => {
+            this.pfBody[message.propertyName] = message.propertyValue;
+        });
 
         // TODO add unsecured API endpoint for retrieving Galaxy version
         this.aboutConfig = {
@@ -106,20 +92,18 @@ export class AppComponent implements OnInit {
             logoImageAlt: 'Ansible Galaxy',
             logoImageSrc: '/assets/galaxy-logo-03.svg',
             title: 'Galaxy',
-            productInfo: [
-                { name: 'Server', value: window.location.host }
-            ]
+            productInfo: [{ name: 'Server', value: window.location.host }],
         } as AboutModalConfig;
         this.navItems = [
             {
                 title: 'Home',
                 iconStyleClass: 'fa fa-home',
-                url: '/home'
+                url: '/home',
             },
             {
                 title: 'Search',
                 iconStyleClass: 'fa fa-search',
-                url: '/search'
+                url: '/search',
             },
             /*{
                 title: 'Partners',
@@ -129,41 +113,36 @@ export class AppComponent implements OnInit {
             {
                 title: 'Community',
                 iconStyleClass: 'fa fa-users',
-                url: '/community'
+                url: '/community',
             },
         ] as NavigationItemConfig[];
 
-        this.apiRootService.get().subscribe(
-            (apiInfo) => {
-                this.aboutConfig.productInfo.push({name: 'Server Version', value: apiInfo.server_version });
-                this.aboutConfig.productInfo.push({name: 'Version Name', value: apiInfo.version_name});
-                this.aboutConfig.productInfo.push({name: 'Api Version', value: apiInfo.current_version });
+        this.apiRootService.get().subscribe(apiInfo => {
+            this.aboutConfig.productInfo.push({ name: 'Server Version', value: apiInfo.server_version });
+            this.aboutConfig.productInfo.push({ name: 'Version Name', value: apiInfo.version_name });
+            this.aboutConfig.productInfo.push({ name: 'Api Version', value: apiInfo.current_version });
 
-                this.teamMembers = apiInfo.team_members;
+            this.teamMembers = apiInfo.team_members;
+        });
+
+        this.authService.me().subscribe(me => {
+            this.authenticated = me.authenticated;
+            this.username = me.username;
+            if (this.authenticated) {
+                this.aboutConfig.productInfo.push({
+                    name: 'User Name',
+                    value: me.username,
+                });
+                this.aboutConfig.productInfo.push({
+                    name: 'User Role',
+                    value: me.staff ? 'Staff' : 'User',
+                });
+
+                this.addNavButtons();
+            } else {
+                this.removeNavButtons();
             }
-        );
-
-        this.authService.me().subscribe(
-            (me) => {
-                this.authenticated = me.authenticated;
-                this.username = me.username;
-                if (this.authenticated) {
-
-                    this.aboutConfig.productInfo.push({
-                        name: 'User Name',
-                        value: me.username
-                    });
-                    this.aboutConfig.productInfo.push({
-                        name: 'User Role',
-                        value: (me.staff) ? 'Staff' : 'User'
-                    });
-
-                    this.addNavButtons();
-                } else {
-                    this.removeNavButtons();
-                }
-            }
-        );
+        });
         this.redirectUrl = this.authService.redirectUrl;
     }
 
@@ -190,25 +169,25 @@ export class AppComponent implements OnInit {
             {
                 title: 'My Content',
                 iconStyleClass: 'fa fa-list',
-                url: '/my-content'
+                url: '/my-content',
             },
             {
                 title: 'My Imports',
                 iconStyleClass: 'fa fa-upload',
-                url: '/my-imports'
-            }
+                url: '/my-imports',
+            },
         );
     }
 
     logout(): void {
         this.authenticated = false;
         this.authService.logout().subscribe(
-            (response) => {
+            response => {
                 this.router.navigate(['/home']);
             },
-            (error) => {
+            error => {
                 console.log(error);
-            }
+            },
         );
         this.removeNavButtons();
     }

--- a/galaxyui/src/app/app.module.ts
+++ b/galaxyui/src/app/app.module.ts
@@ -1,65 +1,47 @@
-import {
-    BrowserModule
-} from '@angular/platform-browser';
+import { BrowserModule } from '@angular/platform-browser';
 
-import {
-    CUSTOM_ELEMENTS_SCHEMA,
-    NgModule
-} from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 
-import {
-    HttpClientModule,
-    HttpClientXsrfModule
-} from '@angular/common/http';
+import { HttpClientModule, HttpClientXsrfModule } from '@angular/common/http';
 
-import {
-    ModalModule,
-    NavigationModule
-} from 'patternfly-ng';
+import { ModalModule, NavigationModule } from 'patternfly-ng';
 
-import {
-    BsDropdownModule,
-    ModalModule as BsModalModule,
-    TooltipModule
-} from 'ngx-bootstrap';
+import { BsDropdownModule, ModalModule as BsModalModule, TooltipModule } from 'ngx-bootstrap';
 
-import { NotificationService }        from 'patternfly-ng/notification/notification-service/notification.service';
-import { NotificationModule }         from 'patternfly-ng/notification/notification.module';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
+import { NotificationModule } from 'patternfly-ng/notification/notification.module';
 
-import { AppRoutingModule }           from './app-routing.module';
-import { AppComponent }               from './app.component';
-import { AuthService }                from './auth/auth.service';
-import { AuthorsModule }              from './authors/authors.module';
-import { ContentDetailModule }        from './content-detail/content-detail.module';
-import { ExceptionPagesModule }       from './exception-pages/exception-pages.module';
-import { HomeModule }                 from './home/home.module';
-import { LoginModule }                from './login/login.module';
-import { MyContentModule }            from './my-content/my-content.module';
-import { ApiRootService }             from './resources/api-root/api-root.service';
-import { CloudPlatformService }       from './resources/cloud-platforms/cloud-platform.service';
-import { ContentBlocksService }       from './resources/content-blocks/content-blocks.service';
-import { ContentSearchService }       from './resources/content-search/content-search.service';
-import { ContentTypeService }         from './resources/content-types/content-type.service';
-import { ContentService }             from './resources/content/content.service';
-import { ImportsService }             from './resources/imports/imports.service';
-import { NamespaceService }           from './resources/namespaces/namespace.service';
-import { PFBodyService }              from './resources/pf-body/pf-body.service';
-import { PlatformService }            from './resources/platforms/platform.service';
-import { ProviderSourceService }      from './resources/provider-namespaces/provider-source.service';
-import { RepositoryService }          from './resources/repositories/repository.service';
-import { RepositoryImportService }    from './resources/repository-imports/repository-import.service';
-import { TagsService }                from './resources/tags/tags.service';
-import { UserService }                from './resources/users/user.service';
+import { AppRoutingModule } from './app-routing.module';
+import { AppComponent } from './app.component';
+import { AuthService } from './auth/auth.service';
+import { AuthorsModule } from './authors/authors.module';
+import { ContentDetailModule } from './content-detail/content-detail.module';
+import { ExceptionPagesModule } from './exception-pages/exception-pages.module';
+import { HomeModule } from './home/home.module';
+import { LoginModule } from './login/login.module';
+import { MyContentModule } from './my-content/my-content.module';
+import { ApiRootService } from './resources/api-root/api-root.service';
+import { CloudPlatformService } from './resources/cloud-platforms/cloud-platform.service';
+import { ContentBlocksService } from './resources/content-blocks/content-blocks.service';
+import { ContentSearchService } from './resources/content-search/content-search.service';
+import { ContentTypeService } from './resources/content-types/content-type.service';
+import { ContentService } from './resources/content/content.service';
+import { ImportsService } from './resources/imports/imports.service';
+import { NamespaceService } from './resources/namespaces/namespace.service';
+import { PFBodyService } from './resources/pf-body/pf-body.service';
+import { PlatformService } from './resources/platforms/platform.service';
+import { ProviderSourceService } from './resources/provider-namespaces/provider-source.service';
+import { RepositoryService } from './resources/repositories/repository.service';
+import { RepositoryImportService } from './resources/repository-imports/repository-import.service';
+import { TagsService } from './resources/tags/tags.service';
+import { UserService } from './resources/users/user.service';
 // import { MyImportsModule }            from './my-imports/my-imports.module';
 // import { SearchModule }               from './search/search.module';
 import { UserNotificationsComponent } from './user-notifications/user-notifications.component';
-import { VendorsModule }              from './vendors/vendors.module';
+import { VendorsModule } from './vendors/vendors.module';
 
 @NgModule({
-    declarations: [
-        AppComponent,
-        UserNotificationsComponent
-    ],
+    declarations: [AppComponent, UserNotificationsComponent],
     imports: [
         HttpClientModule,
         HttpClientXsrfModule.withOptions({
@@ -82,7 +64,7 @@ import { VendorsModule }              from './vendors/vendors.module';
         ExceptionPagesModule,
         VendorsModule,
         AuthorsModule,
-        AppRoutingModule
+        AppRoutingModule,
     ],
     providers: [
         AuthService,
@@ -101,11 +83,9 @@ import { VendorsModule }              from './vendors/vendors.module';
         UserService,
         ContentService,
         ApiRootService,
-        PFBodyService
+        PFBodyService,
     ],
-    schemas: [
-        CUSTOM_ELEMENTS_SCHEMA
-    ],
-    bootstrap: [AppComponent]
+    schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/galaxyui/src/app/auth/auth.service.ts
+++ b/galaxyui/src/app/auth/auth.service.ts
@@ -1,41 +1,28 @@
-import {
-    Injectable
-} from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import {
-    HttpClient,
-    HttpHeaders
-} from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 
 import { Observable } from 'rxjs/Observable';
-import { of }         from 'rxjs/observable/of';
+import { of } from 'rxjs/observable/of';
 
-import {
-    ActivatedRouteSnapshot,
-    CanActivate,
-    Router,
-    RouterStateSnapshot
-} from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
 
 export interface IMe {
-    url:            string;
-    related:        object;
+    url: string;
+    related: object;
     summary_fields: object;
-    id:             number;
-    authenticated:  boolean;
-    staff:          boolean;
-    username:       string;
-    created:        string;
-    modified:       string;
-    active:         boolean;
+    id: number;
+    authenticated: boolean;
+    staff: boolean;
+    username: string;
+    created: string;
+    modified: string;
+    active: boolean;
 }
 
 @Injectable()
 export class AuthService implements CanActivate {
-    constructor(
-        private http:  HttpClient,
-        private router: Router
-    ) {}
+    constructor(private http: HttpClient, private router: Router) {}
 
     headers: HttpHeaders = new HttpHeaders().set('Content-Type', 'application/json');
     meCache: IMe = null;
@@ -46,31 +33,32 @@ export class AuthService implements CanActivate {
         if (this.meCache) {
             return of(this.meCache);
         }
-        return this.http.get<IMe>(this.meUrl, {headers: this.headers})
-            .map((result) => { this.meCache = result; return result; });
+        return this.http.get<IMe>(this.meUrl, { headers: this.headers }).map(result => {
+            this.meCache = result;
+            return result;
+        });
     }
 
     logout(): Observable<any> {
         this.meCache = null;
-        return this.http.post('/api/v1/account/logout', {}, {headers: this.headers})
-            .map((result) => {
-                this.meCache = null;
-                this.redirectUrl = '/home';
-                return result;
-            });
+        return this.http.post('/api/v1/account/logout', {}, { headers: this.headers }).map(result => {
+            this.meCache = null;
+            this.redirectUrl = '/home';
+            return result;
+        });
     }
 
     checkPermissions(route: ActivatedRouteSnapshot): boolean {
         let result = true;
         if (!this.meCache.authenticated) {
             // User is not authenticated
-            this.router.navigate(['/login', {error: true}]);
+            this.router.navigate(['/login', { error: true }]);
             result = false;
         }
         if (route['data'] && route['data']['expectedRole']) {
             if (route['data']['expectedRole'] === 'isStaff' && !this.meCache.staff) {
                 // User does not have is_staff=True
-                this.router.navigate(['/access-denied', {error: true}]);
+                this.router.navigate(['/access-denied', { error: true }]);
                 result = false;
             }
         }
@@ -85,10 +73,9 @@ export class AuthService implements CanActivate {
                 observer.complete();
             });
         }
-        return this.http.get<IMe>(this.meUrl, {headers: this.headers})
-            .map((result) => {
-                this.meCache = result;
-                return this.checkPermissions(route);
-            });
+        return this.http.get<IMe>(this.meUrl, { headers: this.headers }).map(result => {
+            this.meCache = result;
+            return this.checkPermissions(route);
+        });
     }
 }

--- a/galaxyui/src/app/authors/authors.component.spec.ts
+++ b/galaxyui/src/app/authors/authors.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { AuthorsComponent } from './authors.component';
 
 describe('AuthorsComponent', () => {
-  let component: AuthorsComponent;
-  let fixture: ComponentFixture<AuthorsComponent>;
+    let component: AuthorsComponent;
+    let fixture: ComponentFixture<AuthorsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ AuthorsComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [AuthorsComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AuthorsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(AuthorsComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/authors/authors.component.ts
+++ b/galaxyui/src/app/authors/authors.component.ts
@@ -1,49 +1,38 @@
-import {
-    Component,
-    OnInit
-} from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
-import {
-    ActivatedRoute,
-    Router
-} from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
-import { ActionConfig }       from 'patternfly-ng/action/action-config';
-import { EmptyStateConfig }   from 'patternfly-ng/empty-state/empty-state-config';
-import { Filter }             from 'patternfly-ng/filter/filter';
-import { FilterConfig }       from 'patternfly-ng/filter/filter-config';
-import { FilterField }        from 'patternfly-ng/filter/filter-field';
-import { FilterType }         from 'patternfly-ng/filter/filter-type';
-import { ListConfig }         from 'patternfly-ng/list/basic-list/list-config';
-import { ListEvent }          from 'patternfly-ng/list/list-event';
-import { PaginationConfig }   from 'patternfly-ng/pagination/pagination-config';
-import { PaginationEvent }    from 'patternfly-ng/pagination/pagination-event';
-import { SortConfig }         from 'patternfly-ng/sort/sort-config';
-import { SortEvent }          from 'patternfly-ng/sort/sort-event';
-import { ToolbarConfig }      from 'patternfly-ng/toolbar/toolbar-config';
+import { ActionConfig } from 'patternfly-ng/action/action-config';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state/empty-state-config';
+import { Filter } from 'patternfly-ng/filter/filter';
+import { FilterConfig } from 'patternfly-ng/filter/filter-config';
+import { FilterField } from 'patternfly-ng/filter/filter-field';
+import { FilterType } from 'patternfly-ng/filter/filter-type';
+import { ListConfig } from 'patternfly-ng/list/basic-list/list-config';
+import { ListEvent } from 'patternfly-ng/list/list-event';
+import { PaginationConfig } from 'patternfly-ng/pagination/pagination-config';
+import { PaginationEvent } from 'patternfly-ng/pagination/pagination-event';
+import { SortConfig } from 'patternfly-ng/sort/sort-config';
+import { SortEvent } from 'patternfly-ng/sort/sort-event';
+import { ToolbarConfig } from 'patternfly-ng/toolbar/toolbar-config';
 
-import { Namespace }          from '../resources/namespaces/namespace';
-import { NamespaceService }   from '../resources/namespaces/namespace.service';
-import { PFBodyService }      from '../resources/pf-body/pf-body.service';
+import { Namespace } from '../resources/namespaces/namespace';
+import { NamespaceService } from '../resources/namespaces/namespace.service';
+import { PFBodyService } from '../resources/pf-body/pf-body.service';
 
-import {
-    ContentTypes,
-    ContentTypesIconClasses,
-    ContentTypesPluralChoices
-} from '../enums/content-types.enum';
+import { ContentTypes, ContentTypesIconClasses, ContentTypesPluralChoices } from '../enums/content-types.enum';
 
 @Component({
     selector: 'app-authors',
     templateUrl: './authors.component.html',
-    styleUrls: ['./authors.component.less']
+    styleUrls: ['./authors.component.less'],
 })
 export class AuthorsComponent implements OnInit {
-
     constructor(
         private router: Router,
-          private route: ActivatedRoute,
-          private namespaceService: NamespaceService,
-          private pfBody: PFBodyService,
+        private route: ActivatedRoute,
+        private namespaceService: NamespaceService,
+        private pfBody: PFBodyService,
     ) {}
 
     pageTitle = 'Community Authors';
@@ -60,7 +49,7 @@ export class AuthorsComponent implements OnInit {
     paginationConfig: PaginationConfig;
     sortBy = 'name';
     filterBy: any = {
-        'is_vendor': false
+        is_vendor: false,
     };
     pageNumber = 1;
     pageSize = 10;
@@ -70,7 +59,7 @@ export class AuthorsComponent implements OnInit {
         this.emptyStateConfig = {
             info: '',
             title: 'No contributors match your search',
-            iconStyleClass: 'pficon pficon-filter'
+            iconStyleClass: 'pficon pficon-filter',
         } as EmptyStateConfig;
 
         this.filterConfig = {
@@ -79,17 +68,17 @@ export class AuthorsComponent implements OnInit {
                     id: 'name',
                     title: 'Name',
                     placeholder: 'Filter by Name...',
-                    type: FilterType.TEXT
+                    type: FilterType.TEXT,
                 },
                 {
                     id: 'description',
                     title: 'Description',
                     placeholder: 'Filter by Description...',
-                    type: FilterType.TEXT
-                }
+                    type: FilterType.TEXT,
+                },
             ] as FilterField[],
             resultsCount: 0,
-            appliedFilters: [] as Filter[]
+            appliedFilters: [] as Filter[],
         } as FilterConfig;
 
         this.sortConfig = {
@@ -97,27 +86,27 @@ export class AuthorsComponent implements OnInit {
                 {
                     id: 'name',
                     title: 'Name',
-                    sortType: 'alpha'
+                    sortType: 'alpha',
                 },
                 {
                     id: 'description',
                     title: 'Description',
-                    sortType: 'alpha'
-                }
+                    sortType: 'alpha',
+                },
             ],
-            isAscending: true
+            isAscending: true,
         } as SortConfig;
 
         this.toolbarActionConfig = {
             primaryActions: [],
-            moreActions: []
+            moreActions: [],
         } as ActionConfig;
 
         this.toolbarConfig = {
             actionConfig: this.toolbarActionConfig,
             filterConfig: this.filterConfig,
             sortConfig: this.sortConfig,
-            views: []
+            views: [],
         } as ToolbarConfig;
 
         this.listConfig = {
@@ -127,16 +116,16 @@ export class AuthorsComponent implements OnInit {
             selectionMatchProp: 'name',
             showCheckbox: false,
             useExpandItems: false,
-            emptyStateConfig: this.emptyStateConfig
+            emptyStateConfig: this.emptyStateConfig,
         } as ListConfig;
 
         this.paginationConfig = {
             pageSize: 10,
             pageNumber: 1,
-            totalItems: 0
+            totalItems: 0,
         } as PaginationConfig;
 
-        this.route.data.subscribe((data) => {
+        this.route.data.subscribe(data => {
             this.items = data['namespaces']['results'];
             this.paginationConfig.totalItems = data['namespaces']['count'];
             this.prepareNamespaces();
@@ -158,7 +147,7 @@ export class AuthorsComponent implements OnInit {
             });
         } else {
             this.filterBy = {
-                'is_vendor': false
+                is_vendor: false,
             };
         }
         this.pageNumber = 1;
@@ -243,13 +232,12 @@ export class AuthorsComponent implements OnInit {
         this.filterBy['page_size'] = this.pageSize;
         this.filterBy['page'] = this.pageNumber;
         this.filterBy['order'] = this.sortBy;
-        this.namespaceService.pagedQuery(this.filterBy)
-            .subscribe(result => {
-                this.items = result.results as Namespace[];
-                this.prepareNamespaces();
-                this.filterConfig.resultsCount = result.count;
-                this.paginationConfig.totalItems = result.count;
-                this.pageLoading = false;
-            });
+        this.namespaceService.pagedQuery(this.filterBy).subscribe(result => {
+            this.items = result.results as Namespace[];
+            this.prepareNamespaces();
+            this.filterConfig.resultsCount = result.count;
+            this.paginationConfig.totalItems = result.count;
+            this.pageLoading = false;
+        });
     }
 }

--- a/galaxyui/src/app/authors/authors.module.ts
+++ b/galaxyui/src/app/authors/authors.module.ts
@@ -1,20 +1,20 @@
-import { CommonModule }    from '@angular/common';
-import { NgModule }        from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
-import { TooltipModule }           from 'ngx-bootstrap/tooltip';
-import { ActionModule }            from 'patternfly-ng/action/action.module';
-import { EmptyStateModule }        from 'patternfly-ng/empty-state/empty-state.module';
-import { FilterModule }            from 'patternfly-ng/filter/filter.module';
-import { ListModule }              from 'patternfly-ng/list/basic-list/list.module';
-import { PaginationModule }        from 'patternfly-ng/pagination/pagination.module';
-import { ToolbarModule }           from 'patternfly-ng/toolbar/toolbar.module';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ActionModule } from 'patternfly-ng/action/action.module';
+import { EmptyStateModule } from 'patternfly-ng/empty-state/empty-state.module';
+import { FilterModule } from 'patternfly-ng/filter/filter.module';
+import { ListModule } from 'patternfly-ng/list/basic-list/list.module';
+import { PaginationModule } from 'patternfly-ng/pagination/pagination.module';
+import { ToolbarModule } from 'patternfly-ng/toolbar/toolbar.module';
 
-import { PageHeaderModule }          from '../page-header/page-header.module';
-import { PageLoadingModule }         from '../page-loading/page-loading.module';
-import { AuthorsComponent }          from './authors.component';
-import { AuthorsRoutingModule }      from './authors.routing.module';
-import { AuthorDetailComponent }     from './detail/author-detail.component';
-import { DetailActionsComponent }    from './detail/detail-actions/detail-actions.component';
+import { PageHeaderModule } from '../page-header/page-header.module';
+import { PageLoadingModule } from '../page-loading/page-loading.module';
+import { AuthorsComponent } from './authors.component';
+import { AuthorsRoutingModule } from './authors.routing.module';
+import { AuthorDetailComponent } from './detail/author-detail.component';
+import { DetailActionsComponent } from './detail/detail-actions/detail-actions.component';
 
 @NgModule({
     imports: [
@@ -28,12 +28,8 @@ import { DetailActionsComponent }    from './detail/detail-actions/detail-action
         AuthorsRoutingModule,
         PageHeaderModule,
         PageLoadingModule,
-        ActionModule
+        ActionModule,
     ],
-    declarations: [
-        DetailActionsComponent,
-        AuthorsComponent,
-        AuthorDetailComponent
-    ]
+    declarations: [DetailActionsComponent, AuthorsComponent, AuthorDetailComponent],
 })
-export class AuthorsModule { }
+export class AuthorsModule {}

--- a/galaxyui/src/app/authors/authors.resolver.service.ts
+++ b/galaxyui/src/app/authors/authors.resolver.service.ts
@@ -1,39 +1,29 @@
-import {
-    Injectable
-} from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import {
-    ActivatedRouteSnapshot,
-    Resolve,
-    RouterStateSnapshot
-} from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
 
-import { Observable }            from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 
-import { Namespace }             from '../resources/namespaces/namespace';
-import { NamespaceService }      from '../resources/namespaces/namespace.service';
-import { PagedResponse }         from '../resources/paged-response';
-import { RepositoryService }     from '../resources/repositories/repository.service';
+import { Namespace } from '../resources/namespaces/namespace';
+import { NamespaceService } from '../resources/namespaces/namespace.service';
+import { PagedResponse } from '../resources/paged-response';
+import { RepositoryService } from '../resources/repositories/repository.service';
 
 @Injectable()
 export class NamespaceListResolver implements Resolve<PagedResponse> {
-    constructor(
-        private namespaceService: NamespaceService,
-    ) {}
+    constructor(private namespaceService: NamespaceService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<PagedResponse> {
-        return this.namespaceService.pagedQuery({'is_vendor': false});
+        return this.namespaceService.pagedQuery({ is_vendor: false });
     }
 }
 
 @Injectable()
 export class NamespaceDetailResolver implements Resolve<Namespace> {
-    constructor(
-        private namespaceService: NamespaceService,
-    ) {}
+    constructor(private namespaceService: NamespaceService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Namespace> {
         const namespace = route.params['namespace'].toLowerCase();
         const params = {
-            name__iexact: namespace
+            name__iexact: namespace,
         };
         return this.namespaceService.query(params).map(results => {
             if (results && results.length) {
@@ -47,13 +37,11 @@ export class NamespaceDetailResolver implements Resolve<Namespace> {
 
 @Injectable()
 export class RepositoryResolver implements Resolve<PagedResponse> {
-    constructor(
-        private repositoryService: RepositoryService,
-    ) {}
+    constructor(private repositoryService: RepositoryService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<PagedResponse> {
         const namespace = route.params['namespace'].toLowerCase();
         const params = {
-            'provider_namespace__namespace__name__iexact': namespace,
+            provider_namespace__namespace__name__iexact: namespace,
         };
         return this.repositoryService.pagedQuery(params);
     }

--- a/galaxyui/src/app/authors/authors.routing.module.ts
+++ b/galaxyui/src/app/authors/authors.routing.module.ts
@@ -1,42 +1,25 @@
-import {
-       NgModule
+import { NgModule } from '@angular/core';
 
-} from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
 
-import {
-    RouterModule,
-    Routes
-} from '@angular/router';
+import { NamespaceDetailResolver, NamespaceListResolver, RepositoryResolver } from './authors.resolver.service';
 
-import {
-    NamespaceDetailResolver,
-    NamespaceListResolver,
-    RepositoryResolver
-}  from './authors.resolver.service';
+import { AuthorsComponent } from './authors.component';
 
-import { AuthorsComponent }         from './authors.component';
-
-const routes: Routes = [{
+const routes: Routes = [
+    {
         path: 'community',
         component: AuthorsComponent,
         resolve: {
-            namespaces: NamespaceListResolver
-        }
-    }
+            namespaces: NamespaceListResolver,
+        },
+    },
     // ':namespace/ moved to app-routing.module
 ];
 
 @NgModule({
-    imports: [
-        RouterModule.forChild(routes)
-    ],
-    exports: [
-        RouterModule
-    ],
-    providers: [
-        NamespaceDetailResolver,
-        NamespaceListResolver,
-        RepositoryResolver
-    ]
+    imports: [RouterModule.forChild(routes)],
+    exports: [RouterModule],
+    providers: [NamespaceDetailResolver, NamespaceListResolver, RepositoryResolver],
 })
-export class AuthorsRoutingModule { }
+export class AuthorsRoutingModule {}

--- a/galaxyui/src/app/authors/detail/author-detail.component.spec.ts
+++ b/galaxyui/src/app/authors/detail/author-detail.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { AuthorDetailComponent } from './author-detail.component';
 
 describe('AuthorsComponent', () => {
-  let component: AuthorDetailComponent;
-  let fixture: ComponentFixture<AuthorDetailComponent>;
+    let component: AuthorDetailComponent;
+    let fixture: ComponentFixture<AuthorDetailComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ AuthorDetailComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [AuthorDetailComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AuthorDetailComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(AuthorDetailComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/authors/detail/author-detail.component.ts
+++ b/galaxyui/src/app/authors/detail/author-detail.component.ts
@@ -1,55 +1,40 @@
-import {
-    Component,
-    OnInit
-} from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
-import {
-    ActivatedRoute,
-    Router
-} from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
-import * as moment            from 'moment';
+import * as moment from 'moment';
 
-import { ActionConfig }       from 'patternfly-ng/action/action-config';
-import { EmptyStateConfig }   from 'patternfly-ng/empty-state/empty-state-config';
-import { Filter }             from 'patternfly-ng/filter/filter';
-import { FilterConfig }       from 'patternfly-ng/filter/filter-config';
-import { FilterEvent }        from 'patternfly-ng/filter/filter-event';
-import { FilterField }        from 'patternfly-ng/filter/filter-field';
-import { FilterType }         from 'patternfly-ng/filter/filter-type';
-import { ListConfig }         from 'patternfly-ng/list/basic-list/list-config';
-import { ListEvent }          from 'patternfly-ng/list/list-event';
-import { PaginationConfig }   from 'patternfly-ng/pagination/pagination-config';
-import { PaginationEvent }    from 'patternfly-ng/pagination/pagination-event';
-import { SortConfig }         from 'patternfly-ng/sort/sort-config';
-import { SortEvent }          from 'patternfly-ng/sort/sort-event';
-import { ToolbarConfig }      from 'patternfly-ng/toolbar/toolbar-config';
+import { ActionConfig } from 'patternfly-ng/action/action-config';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state/empty-state-config';
+import { Filter } from 'patternfly-ng/filter/filter';
+import { FilterConfig } from 'patternfly-ng/filter/filter-config';
+import { FilterEvent } from 'patternfly-ng/filter/filter-event';
+import { FilterField } from 'patternfly-ng/filter/filter-field';
+import { FilterType } from 'patternfly-ng/filter/filter-type';
+import { ListConfig } from 'patternfly-ng/list/basic-list/list-config';
+import { ListEvent } from 'patternfly-ng/list/list-event';
+import { PaginationConfig } from 'patternfly-ng/pagination/pagination-config';
+import { PaginationEvent } from 'patternfly-ng/pagination/pagination-event';
+import { SortConfig } from 'patternfly-ng/sort/sort-config';
+import { SortEvent } from 'patternfly-ng/sort/sort-event';
+import { ToolbarConfig } from 'patternfly-ng/toolbar/toolbar-config';
 
-import { Namespace }          from '../../resources/namespaces/namespace';
-import { PFBodyService }      from '../../resources/pf-body/pf-body.service';
+import { Namespace } from '../../resources/namespaces/namespace';
+import { PFBodyService } from '../../resources/pf-body/pf-body.service';
 
-import { Repository }         from '../../resources/repositories/repository';
-import { RepositoryService }  from '../../resources/repositories/repository.service';
+import { Repository } from '../../resources/repositories/repository';
+import { RepositoryService } from '../../resources/repositories/repository.service';
 
-import {
-    ContentTypes,
-    ContentTypesIconClasses,
-    ContentTypesPluralChoices
-} from '../../enums/content-types.enum';
+import { ContentTypes, ContentTypesIconClasses, ContentTypesPluralChoices } from '../../enums/content-types.enum';
 
-import {
-    RepoFormats,
-    RepoFormatsIconClasses,
-    RepoFormatsTooltips
-} from '../../enums/repo-types.enum';
+import { RepoFormats, RepoFormatsIconClasses, RepoFormatsTooltips } from '../../enums/repo-types.enum';
 
 @Component({
     selector: 'app-author-detail',
     templateUrl: './author-detail.component.html',
-    styleUrls: ['./author-detail.component.less']
+    styleUrls: ['./author-detail.component.less'],
 })
 export class AuthorDetailComponent implements OnInit {
-
     constructor(
         private router: Router,
         private route: ActivatedRoute,
@@ -87,7 +72,7 @@ export class AuthorDetailComponent implements OnInit {
         this.emptyStateConfig = {
             info: '',
             title: 'No repositories match your search',
-            iconStyleClass: 'pficon pficon-filter'
+            iconStyleClass: 'pficon pficon-filter',
         } as EmptyStateConfig;
 
         this.filterConfig = {
@@ -96,17 +81,17 @@ export class AuthorDetailComponent implements OnInit {
                     id: 'name',
                     title: 'Name',
                     placeholder: 'Filter by Name...',
-                    type: FilterType.TEXT
+                    type: FilterType.TEXT,
                 },
                 {
                     id: 'description',
                     title: 'Description',
                     placeholder: 'Filter by Description...',
-                    type: FilterType.TEXT
-                }
+                    type: FilterType.TEXT,
+                },
             ] as FilterField[],
             resultsCount: 0,
-            appliedFilters: [] as Filter[]
+            appliedFilters: [] as Filter[],
         } as FilterConfig;
 
         this.sortConfig = {
@@ -114,42 +99,42 @@ export class AuthorDetailComponent implements OnInit {
                 {
                     id: 'name',
                     title: 'Name',
-                    sortType: 'alpha'
+                    sortType: 'alpha',
                 },
                 {
                     id: 'download_count',
                     title: 'Downloads',
-                    sortType: 'numeric'
+                    sortType: 'numeric',
                 },
                 {
                     id: 'stargazers_count',
                     title: 'Stars',
-                    sortType: 'numeric'
+                    sortType: 'numeric',
                 },
                 {
                     id: 'watchers_count',
                     title: 'Watchers',
-                    sortType: 'numeric'
+                    sortType: 'numeric',
                 },
                 {
                     id: 'forks_count',
                     title: 'Forks',
-                    sortType: 'numeric'
+                    sortType: 'numeric',
                 },
             ],
-            isAscending: true
+            isAscending: true,
         } as SortConfig;
 
         this.toolbarActionConfig = {
             primaryActions: [],
-            moreActions: []
+            moreActions: [],
         } as ActionConfig;
 
         this.toolbarConfig = {
             actionConfig: this.toolbarActionConfig,
             filterConfig: this.filterConfig,
             sortConfig: this.sortConfig,
-            views: []
+            views: [],
         } as ToolbarConfig;
 
         this.listConfig = {
@@ -159,16 +144,16 @@ export class AuthorDetailComponent implements OnInit {
             selectionMatchProp: 'name',
             showCheckbox: false,
             useExpandItems: false,
-            emptyStateConfig: this.emptyStateConfig
+            emptyStateConfig: this.emptyStateConfig,
         } as ListConfig;
 
         this.paginationConfig = {
             pageSize: 10,
             pageNumber: 1,
-            totalItems: 0
+            totalItems: 0,
         } as PaginationConfig;
 
-        this.route.data.subscribe((data) => {
+        this.route.data.subscribe(data => {
             this.namespace = data['namespace'];
             this.items = data['repositories']['results'];
             this.paginationConfig.totalItems = data['repositories']['count'];
@@ -194,8 +179,7 @@ export class AuthorDetailComponent implements OnInit {
 
     handleListClick($event: ListEvent): void {
         const repository = $event.item;
-        this.router.navigate(['/', repository.summary_fields['namespace']['name'],
-                    repository.name]);
+        this.router.navigate(['/', repository.summary_fields['namespace']['name'], repository.name]);
     }
 
     filterChanged($event: FilterEvent): void {
@@ -247,14 +231,13 @@ export class AuthorDetailComponent implements OnInit {
         this.filterBy['order'] = this.sortBy;
         this.filterBy['page_size'] = this.pageSize;
         this.filterBy['page'] = this.pageNumber;
-        this.repositoryService.pagedQuery(this.filterBy).subscribe(
-            response => {
-                this.items = response.results as Repository[];
-                this.prepareRepositories();
-                this.filterConfig.resultsCount = response.count;
-                this.paginationConfig.totalItems = response.count;
-                this.pageLoading = false;
-            });
+        this.repositoryService.pagedQuery(this.filterBy).subscribe(response => {
+            this.items = response.results as Repository[];
+            this.prepareRepositories();
+            this.filterConfig.resultsCount = response.count;
+            this.paginationConfig.totalItems = response.count;
+            this.pageLoading = false;
+        });
     }
 
     private parepareNamespace() {
@@ -325,6 +308,5 @@ export class AuthorDetailComponent implements OnInit {
                 }
             }
         });
-
     }
 }

--- a/galaxyui/src/app/authors/detail/detail-actions/detail-actions.component.ts
+++ b/galaxyui/src/app/authors/detail/detail-actions/detail-actions.component.ts
@@ -1,25 +1,18 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
-import { Router }           from '@angular/router';
+import { Router } from '@angular/router';
 
-import { ActionConfig }     from 'patternfly-ng/action/action-config';
+import { ActionConfig } from 'patternfly-ng/action/action-config';
 
-import { Repository }       from '../../../resources/repositories/repository';
+import { Repository } from '../../../resources/repositories/repository';
 
 @Component({
     selector: 'author-detail-actions',
     templateUrl: './detail-actions.component.html',
-    styleUrls: ['./detail-actions.component.less']
+    styleUrls: ['./detail-actions.component.less'],
 })
 export class DetailActionsComponent implements OnInit {
-
-    constructor(
-        private router: Router
-    ) {}
+    constructor(private router: Router) {}
 
     _repository: Repository;
     actionConfig: ActionConfig;
@@ -35,29 +28,33 @@ export class DetailActionsComponent implements OnInit {
 
     ngOnInit() {
         this.actionConfig = {
-            primaryActions: [{
-                id: 'more',
-                title: 'View content',
-                tooltip: 'View content details'
-            }],
-            moreActions: [{
-                id: 'scmView',
-                title: 'View SCM Repository',
-                tooltip: 'Opens the SCM repository in new browser window or tab'
-            }, {
-                disabled: (this._repository.issue_tracker_url) ? true : false,
-                id: 'issueLog',
-                title: 'Visit the Issue Log',
-                tooltip: 'Opens the Issue Log in new browser window or tab'
-            }],
+            primaryActions: [
+                {
+                    id: 'more',
+                    title: 'View content',
+                    tooltip: 'View content details',
+                },
+            ],
+            moreActions: [
+                {
+                    id: 'scmView',
+                    title: 'View SCM Repository',
+                    tooltip: 'Opens the SCM repository in new browser window or tab',
+                },
+                {
+                    disabled: this._repository.issue_tracker_url ? true : false,
+                    id: 'issueLog',
+                    title: 'Visit the Issue Log',
+                    tooltip: 'Opens the Issue Log in new browser window or tab',
+                },
+            ],
         } as ActionConfig;
     }
 
     handleAction($event) {
         switch ($event.id) {
             case 'more':
-                this.router.navigate(['/', this.repository.summary_fields['namespace']['name'],
-                    this.repository.name]);
+                this.router.navigate(['/', this.repository.summary_fields['namespace']['name'], this.repository.name]);
                 break;
             case 'scmView':
                 window.open(this.repository.external_url, '_blank');

--- a/galaxyui/src/app/content-detail/cards/cloud-platforms/cloud-platforms.component.ts
+++ b/galaxyui/src/app/content-detail/cards/cloud-platforms/cloud-platforms.component.ts
@@ -1,28 +1,24 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
-import { CardConfig }     from 'patternfly-ng/card/basic-card/card-config';
+import { CardConfig } from 'patternfly-ng/card/basic-card/card-config';
 
 @Component({
     selector: 'card-cloud-platforms',
     templateUrl: './cloud-platforms.component.html',
-    styleUrls: ['./cloud-platforms.component.less']
+    styleUrls: ['./cloud-platforms.component.less'],
 })
 export class CardCloudPlatformsComponent implements OnInit {
-
     constructor() {}
 
-    @Input() cloudPlatforms: any[];
+    @Input()
+    cloudPlatforms: any[];
 
     config: CardConfig;
 
     ngOnInit() {
         this.config = {
             titleBorder: true,
-            topBorder: true
+            topBorder: true,
         } as CardConfig;
     }
 }

--- a/galaxyui/src/app/content-detail/cards/dependencies/dependencies.component.ts
+++ b/galaxyui/src/app/content-detail/cards/dependencies/dependencies.component.ts
@@ -1,18 +1,13 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
-import { CardConfig }     from 'patternfly-ng/card/basic-card/card-config';
+import { CardConfig } from 'patternfly-ng/card/basic-card/card-config';
 
 @Component({
     selector: 'card-dependencies',
     templateUrl: './dependencies.component.html',
-    styleUrls: ['./dependencies.component.less']
+    styleUrls: ['./dependencies.component.less'],
 })
 export class CardDependenciesComponent implements OnInit {
-
     constructor() {}
 
     private _dependencies: any[];
@@ -24,7 +19,7 @@ export class CardDependenciesComponent implements OnInit {
             deps.forEach(d => {
                 this._dependencies.push({
                     name: `${d.namespace}.${d.name}`,
-                    url: `/${d.namespace}/${d.name}`
+                    url: `/${d.namespace}/${d.name}`,
                 });
             });
         }
@@ -39,7 +34,7 @@ export class CardDependenciesComponent implements OnInit {
     ngOnInit() {
         this.config = {
             titleBorder: true,
-            topBorder: true
+            topBorder: true,
         } as CardConfig;
     }
 }

--- a/galaxyui/src/app/content-detail/cards/info/card-info.component.ts
+++ b/galaxyui/src/app/content-detail/cards/info/card-info.component.ts
@@ -1,24 +1,19 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
-import { CardConfig }     from 'patternfly-ng/card/basic-card/card-config';
-import { RepoFormats }    from '../../../enums/repo-types.enum';
-import { ViewTypes }      from '../../../enums/view-types.enum';
-import { Content }        from '../../../resources/content/content';
-import { Repository }     from '../../../resources/repositories/repository';
+import { CardConfig } from 'patternfly-ng/card/basic-card/card-config';
+import { RepoFormats } from '../../../enums/repo-types.enum';
+import { ViewTypes } from '../../../enums/view-types.enum';
+import { Content } from '../../../resources/content/content';
+import { Repository } from '../../../resources/repositories/repository';
 
-import { ContentTypesPlural }   from '../../../enums/content-types.enum';
+import { ContentTypesPlural } from '../../../enums/content-types.enum';
 
 @Component({
     selector: 'card-info',
     templateUrl: './card-info.component.html',
-    styleUrls: ['./card-info.component.less']
+    styleUrls: ['./card-info.component.less'],
 })
 export class CardInfoComponent implements OnInit {
-
     constructor() {}
 
     _repoContent: Content;
@@ -64,12 +59,11 @@ export class CardInfoComponent implements OnInit {
                     `${this._repoContent.summary_fields['repository']['name']}`;
             } else {
                 this._repoContent['install_cmd'] =
-                    `ansible-galaxy install ${this._repoContent.summary_fields['namespace']['name']}.` +
-                    `${this._repoContent.name}`;
+                    `ansible-galaxy install ${this._repoContent.summary_fields['namespace']['name']}.` + `${this._repoContent.name}`;
             }
             this._repoContent['tags'] = this._repoContent.summary_fields['tags'];
             this._repoContent['hasTags'] =
-                (this.repoContent.summary_fields['tags'] && this._repoContent.summary_fields['tags'].length) ? true : false;
+                this.repoContent.summary_fields['tags'] && this._repoContent.summary_fields['tags'].length ? true : false;
             this.example_name = this._repoContent.name;
             this.example_type = this._repoContent.content_type;
             this.example_type_plural = ContentTypesPlural[this._repoContent.content_type];
@@ -88,7 +82,7 @@ export class CardInfoComponent implements OnInit {
         this.config = {
             title: 'Info',
             titleBorder: true,
-            topBorder: true
+            topBorder: true,
         } as CardConfig;
     }
 

--- a/galaxyui/src/app/content-detail/cards/platforms/platforms.component.ts
+++ b/galaxyui/src/app/content-detail/cards/platforms/platforms.component.ts
@@ -1,29 +1,25 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
-import { CardConfig }     from 'patternfly-ng/card/basic-card/card-config';
-import { Platform }       from '../../../resources/platforms/platform';
+import { CardConfig } from 'patternfly-ng/card/basic-card/card-config';
+import { Platform } from '../../../resources/platforms/platform';
 
 @Component({
     selector: 'card-platforms',
     templateUrl: './platforms.component.html',
-    styleUrls: ['./platforms.component.less']
+    styleUrls: ['./platforms.component.less'],
 })
 export class CardPlatformsComponent implements OnInit {
-
     constructor() {}
 
-    @Input() platforms: Platform[];
+    @Input()
+    platforms: Platform[];
 
     config: CardConfig;
 
     ngOnInit() {
         this.config = {
             titleBorder: true,
-            topBorder: true
+            topBorder: true,
         } as CardConfig;
     }
 }

--- a/galaxyui/src/app/content-detail/cards/versions/versions.component.ts
+++ b/galaxyui/src/app/content-detail/cards/versions/versions.component.ts
@@ -1,20 +1,15 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
-import { CardConfig }     from 'patternfly-ng/card/basic-card/card-config';
+import { CardConfig } from 'patternfly-ng/card/basic-card/card-config';
 
-import * as moment        from 'moment';
+import * as moment from 'moment';
 
 @Component({
     selector: 'card-versions',
     templateUrl: './versions.component.html',
-    styleUrls: ['./versions.component.less']
+    styleUrls: ['./versions.component.less'],
 })
 export class CardVersionsComponent implements OnInit {
-
     constructor() {}
 
     _versions: any[];
@@ -29,14 +24,16 @@ export class CardVersionsComponent implements OnInit {
         }
     }
 
-    get versions(): any[] { return this._versions; }
+    get versions(): any[] {
+        return this._versions;
+    }
 
     config: CardConfig;
 
     ngOnInit() {
         this.config = {
             titleBorder: true,
-            topBorder: true
+            topBorder: true,
         } as CardConfig;
     }
 }

--- a/galaxyui/src/app/content-detail/content-detail.component.spec.ts
+++ b/galaxyui/src/app/content-detail/content-detail.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ContentDetailComponent } from './content-detail.component';
 
 describe('ContentDetailComponent', () => {
-  let component: ContentDetailComponent;
-  let fixture: ComponentFixture<ContentDetailComponent>;
+    let component: ContentDetailComponent;
+    let fixture: ComponentFixture<ContentDetailComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ ContentDetailComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [ContentDetailComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ContentDetailComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(ContentDetailComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/content-detail/content-detail.component.ts
+++ b/galaxyui/src/app/content-detail/content-detail.component.ts
@@ -1,34 +1,25 @@
-import {
-    Component,
-    OnInit
-} from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
-import {
-    ActivatedRoute,
-    Router
-} from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
-import * as moment          from 'moment';
+import * as moment from 'moment';
 
-import { Observable }       from 'rxjs/Observable';
-import { forkJoin }         from 'rxjs/observable/forkJoin';
+import { Observable } from 'rxjs/Observable';
+import { forkJoin } from 'rxjs/observable/forkJoin';
 
 import { EmptyStateConfig } from 'patternfly-ng/empty-state/empty-state-config';
 
-import {
-    Action,
-    ActionConfig
-} from 'patternfly-ng/action';
+import { Action, ActionConfig } from 'patternfly-ng/action';
 
-import { ContentTypes }     from '../enums/content-types.enum';
-import { RepoFormats }      from '../enums/repo-types.enum';
-import { ViewTypes }        from '../enums/view-types.enum';
-import { Content }          from '../resources/content/content';
-import { Namespace }        from '../resources/namespaces/namespace';
-import { PagedResponse }    from '../resources/paged-response';
-import { Repository }       from '../resources/repositories/repository';
+import { ContentTypes } from '../enums/content-types.enum';
+import { RepoFormats } from '../enums/repo-types.enum';
+import { ViewTypes } from '../enums/view-types.enum';
+import { Content } from '../resources/content/content';
+import { Namespace } from '../resources/namespaces/namespace';
+import { PagedResponse } from '../resources/paged-response';
+import { Repository } from '../resources/repositories/repository';
 
-import { ContentService }   from '../resources/content/content.service';
+import { ContentService } from '../resources/content/content.service';
 
 class ContentTypeCounts {
     apb: number;
@@ -41,15 +32,10 @@ class ContentTypeCounts {
 @Component({
     selector: 'app-content-detail',
     templateUrl: './content-detail.component.html',
-    styleUrls: ['./content-detail.component.less']
+    styleUrls: ['./content-detail.component.less'],
 })
 export class ContentDetailComponent implements OnInit {
-
-    constructor(
-        private router: Router,
-        private route: ActivatedRoute,
-        private contentService: ContentService
-    ) {}
+    constructor(private router: Router, private route: ActivatedRoute, private contentService: ContentService) {}
 
     pageTitle = '';
     pageIcon = '';
@@ -70,7 +56,7 @@ export class ContentDetailComponent implements OnInit {
     hasReadme = false;
     hasMetadata = false;
     metadataFilename = '';
-    showingView: string = ViewTypes.detail;  // Control what's displayed on lower half of page
+    showingView: string = ViewTypes.detail; // Control what's displayed on lower half of page
     metadata: object;
 
     contentCounts: ContentTypeCounts = {
@@ -78,29 +64,32 @@ export class ContentDetailComponent implements OnInit {
         module: 0,
         moduleUtils: 0,
         plugin: 0,
-        role: 0
+        role: 0,
     } as ContentTypeCounts;
 
     ngOnInit() {
         this.actionConfig = {
-            primaryActions: [{
-                id: 'search',
-                title: 'Search',
-                tooltip: 'View the search page'
-            }]
+            primaryActions: [
+                {
+                    id: 'search',
+                    title: 'Search',
+                    tooltip: 'View the search page',
+                },
+            ],
         } as ActionConfig;
 
         this.emptyStateConfig = {
             actions: this.actionConfig,
             iconStyleClass: 'fa fa-frown-o',
-            info: 'Well this is embarrassing. The content you requested could not be found. ' +
-            'It may not exist in the Galaxy search index. Click the Search button below, ' +
-            'to search our index.',
-            title: 'Content Not Found'
+            info:
+                'Well this is embarrassing. The content you requested could not be found. ' +
+                'It may not exist in the Galaxy search index. Click the Search button below, ' +
+                'to search our index.',
+            title: 'Content Not Found',
         } as EmptyStateConfig;
 
         this.route.params.subscribe(params => {
-            this.route.data.subscribe((data) => {
+            this.route.data.subscribe(data => {
                 this.repository = data['repository'];
                 this.namespace = data['namespace'];
                 this.content = data['content'];
@@ -114,15 +103,16 @@ export class ContentDetailComponent implements OnInit {
                 if (req_content_name && data['content'] && data['content'].length) {
                     this.selectedContent = this.findSelectedContent(req_content_name);
                 }
-                if (!this.repository || !this.content ||
-                    (this.repository.format === RepoFormats.multi &&
-                    req_content_name && !this.selectedContent)) {
+                if (
+                    !this.repository ||
+                    !this.content ||
+                    (this.repository.format === RepoFormats.multi && req_content_name && !this.selectedContent)
+                ) {
                     // Requested content from a multicontent repo not found || No content found
                     this.showEmptyState = true;
                     this.pageTitle = '<i class="fa fa-frown-o"></i> Content Not Found';
                     this.pageLoading = false;
                 } else {
-
                     // Append author type to breadcrumb
                     if (this.namespace.is_vendor) {
                         this.pageTitle = 'Vendors;/vendors;';
@@ -141,15 +131,12 @@ export class ContentDetailComponent implements OnInit {
                     }
                     this.repository.last_import = 'NA';
                     this.repository.last_commit = 'NA';
-                    if (this.repository.summary_fields['latest_import'] &&
-                        this.repository.summary_fields['latest_import']['finished']) {
-                        this.repository.last_import =
-                            moment(this.repository.summary_fields['latest_import']['finished']).fromNow();
+                    if (this.repository.summary_fields['latest_import'] && this.repository.summary_fields['latest_import']['finished']) {
+                        this.repository.last_import = moment(this.repository.summary_fields['latest_import']['finished']).fromNow();
                     }
 
                     if (this.repository.commit_created) {
-                        this.repository.last_commit =
-                            moment(this.repository.commit_created).fromNow();
+                        this.repository.last_commit = moment(this.repository.commit_created).fromNow();
                     }
                     if (this.content && this.content.length) {
                         this.repoContent = this.content[0];
@@ -201,7 +188,7 @@ export class ContentDetailComponent implements OnInit {
                     this.metadataFilename = 'container.yml';
                     this.metadata = this.repoContent.metadata['container_meta'];
                 }
-                this.hasReadme = (this.repoContent.readme_html) ? true : false;
+                this.hasReadme = this.repoContent.readme_html ? true : false;
             }
             if (this.repoContent.content_type === RepoFormats.apb) {
                 if (this.repoContent.metadata['apb_metadata']) {
@@ -209,7 +196,7 @@ export class ContentDetailComponent implements OnInit {
                     this.metadataFilename = 'apb.yml';
                     this.metadata = this.repoContent.metadata['apb_metadata'];
                 }
-                this.hasReadme = (this.repoContent.readme_html) ? true : false;
+                this.hasReadme = this.repoContent.readme_html ? true : false;
             }
             if (this.repository.format === RepoFormats.multi) {
                 if (this.repository.readme_html) {
@@ -222,7 +209,7 @@ export class ContentDetailComponent implements OnInit {
                 this.repoContent[key] = this.repoContent.summary_fields[key];
                 let hasKey = 'has' + key[0].toUpperCase() + key.substring(1);
                 hasKey = hasKey.replace(/\_(\w)/, this.toCamel);
-                this.repoContent[hasKey] = (this.repoContent[key] && this.repoContent[key].length) ? true : false;
+                this.repoContent[hasKey] = this.repoContent[key] && this.repoContent[key].length ? true : false;
             });
             if (this.repository.format === RepoFormats.multi) {
                 this.getContentTypeCounts();
@@ -241,15 +228,19 @@ export class ContentDetailComponent implements OnInit {
         for (const content_type in ContentTypes) {
             if (ContentTypes.hasOwnProperty(content_type)) {
                 if (ContentTypes[content_type] === 'plugin') {
-                    queries.push(this.contentService.pagedQuery({
-                        'repository__id': this.repository.id,
-                        'content_type__name__icontains': ContentTypes[content_type]
-                    }));
+                    queries.push(
+                        this.contentService.pagedQuery({
+                            repository__id: this.repository.id,
+                            content_type__name__icontains: ContentTypes[content_type],
+                        }),
+                    );
                 } else {
-                    queries.push(this.contentService.pagedQuery({
-                        'repository__id': this.repository.id,
-                        'content_type__name': ContentTypes[content_type]
-                    }));
+                    queries.push(
+                        this.contentService.pagedQuery({
+                            repository__id: this.repository.id,
+                            content_type__name: ContentTypes[content_type],
+                        }),
+                    );
                 }
             }
         }

--- a/galaxyui/src/app/content-detail/content-detail.module.ts
+++ b/galaxyui/src/app/content-detail/content-detail.module.ts
@@ -1,30 +1,30 @@
 import { CommonModule } from '@angular/common';
-import { NgModule }     from '@angular/core';
+import { NgModule } from '@angular/core';
 
-import { CardModule }                  from 'patternfly-ng/card/basic-card/card.module';
-import { EmptyStateModule }            from 'patternfly-ng/empty-state/empty-state.module';
-import { FilterModule }                from 'patternfly-ng/filter/filter.module';
-import { ListModule }                  from 'patternfly-ng/list/basic-list/list.module';
-import { PaginationModule }            from 'patternfly-ng/pagination/pagination.module';
+import { CardModule } from 'patternfly-ng/card/basic-card/card.module';
+import { EmptyStateModule } from 'patternfly-ng/empty-state/empty-state.module';
+import { FilterModule } from 'patternfly-ng/filter/filter.module';
+import { ListModule } from 'patternfly-ng/list/basic-list/list.module';
+import { PaginationModule } from 'patternfly-ng/pagination/pagination.module';
 
-import { TooltipModule }               from 'ngx-bootstrap/tooltip';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
-import { UtilitiesModule }             from '../utilities/utilities.module';
+import { UtilitiesModule } from '../utilities/utilities.module';
 
-import { PageHeaderModule }            from '../page-header/page-header.module';
-import { PageLoadingModule }           from '../page-loading/page-loading.module';
+import { PageHeaderModule } from '../page-header/page-header.module';
+import { PageLoadingModule } from '../page-loading/page-loading.module';
 import { CardCloudPlatformsComponent } from './cards/cloud-platforms/cloud-platforms.component';
-import { CardDependenciesComponent }   from './cards/dependencies/dependencies.component';
-import { CardInfoComponent }           from './cards/info/card-info.component';
-import { CardPlatformsComponent }      from './cards/platforms/platforms.component';
-import { CardVersionsComponent }       from './cards/versions/versions.component';
-import { ContentDetailComponent }      from './content-detail.component';
-import { ContentDetailRoutingModule }  from './content-detail.routing.module';
-import { ModuleUtilsComponent }        from './content/module-utils/module-utils.component';
-import { ModulesComponent }            from './content/modules/modules.component';
-import { PluginsComponent }            from './content/plugins/plugins.component';
-import { RolesComponent }              from './content/roles/roles.component';
-import { RepositoryComponent }         from './repository/repository.component';
+import { CardDependenciesComponent } from './cards/dependencies/dependencies.component';
+import { CardInfoComponent } from './cards/info/card-info.component';
+import { CardPlatformsComponent } from './cards/platforms/platforms.component';
+import { CardVersionsComponent } from './cards/versions/versions.component';
+import { ContentDetailComponent } from './content-detail.component';
+import { ContentDetailRoutingModule } from './content-detail.routing.module';
+import { ModuleUtilsComponent } from './content/module-utils/module-utils.component';
+import { ModulesComponent } from './content/modules/modules.component';
+import { PluginsComponent } from './content/plugins/plugins.component';
+import { RolesComponent } from './content/roles/roles.component';
+import { RepositoryComponent } from './repository/repository.component';
 
 @NgModule({
     imports: [
@@ -38,10 +38,10 @@ import { RepositoryComponent }         from './repository/repository.component';
         PageLoadingModule,
         PageHeaderModule,
         ListModule,
-        UtilitiesModule
+        UtilitiesModule,
     ],
     declarations: [
-          ContentDetailComponent,
+        ContentDetailComponent,
         RepositoryComponent,
         CardInfoComponent,
         CardPlatformsComponent,
@@ -51,7 +51,7 @@ import { RepositoryComponent }         from './repository/repository.component';
         ModulesComponent,
         RolesComponent,
         ModuleUtilsComponent,
-        PluginsComponent
-    ]
+        PluginsComponent,
+    ],
 })
-export class ContentDetailModule { }
+export class ContentDetailModule {}

--- a/galaxyui/src/app/content-detail/content-detail.resolver.service.ts
+++ b/galaxyui/src/app/content-detail/content-detail.resolver.service.ts
@@ -1,34 +1,26 @@
-import {
-    Injectable
-} from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import {
-    ActivatedRouteSnapshot,
-    Resolve,
-    RouterStateSnapshot
-} from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
 
-import { Observable }            from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 
-import { Content }               from '../resources/content/content';
-import { ContentService }        from '../resources/content/content.service';
-import { Namespace }             from '../resources/namespaces/namespace';
-import { NamespaceService }      from '../resources/namespaces/namespace.service';
-import { Repository }            from '../resources/repositories/repository';
-import { RepositoryService }     from '../resources/repositories/repository.service';
+import { Content } from '../resources/content/content';
+import { ContentService } from '../resources/content/content.service';
+import { Namespace } from '../resources/namespaces/namespace';
+import { NamespaceService } from '../resources/namespaces/namespace.service';
+import { Repository } from '../resources/repositories/repository';
+import { RepositoryService } from '../resources/repositories/repository.service';
 
 @Injectable()
 export class ContentResolver implements Resolve<Content[]> {
-    constructor(
-        private contentService: ContentService,
-    ) {}
+    constructor(private contentService: ContentService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Content[]> {
         const repository = route.params['repository'].toLowerCase();
         const namespace = route.params['namespace'].toLowerCase();
         const name = route.params['content_name'];
         const params = {
-            'repository__name__iexact': repository,
-            'repository__provider_namespace__namespace__name__iexact': namespace
+            repository__name__iexact: repository,
+            repository__provider_namespace__namespace__name__iexact: namespace,
         };
         if (name) {
             params['name'] = name.toLowerCase();
@@ -39,15 +31,13 @@ export class ContentResolver implements Resolve<Content[]> {
 
 @Injectable()
 export class RepositoryResolver implements Resolve<Repository> {
-    constructor(
-        private repositoryService: RepositoryService,
-    ) {}
+    constructor(private repositoryService: RepositoryService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Repository> {
         const repository = route.params['repository'].toLowerCase();
         const namespace = route.params['namespace'].toLowerCase();
         const params = {
-            'name__iexact': repository,
-            'provider_namespace__namespace__name__iexact': namespace
+            name__iexact: repository,
+            provider_namespace__namespace__name__iexact: namespace,
         };
         return this.repositoryService.query(params).map(results => results[0]);
     }
@@ -55,13 +45,11 @@ export class RepositoryResolver implements Resolve<Repository> {
 
 @Injectable()
 export class NamespaceResolver implements Resolve<Namespace> {
-    constructor(
-        private namespaceService: NamespaceService,
-    ) {}
+    constructor(private namespaceService: NamespaceService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Namespace> {
         const namespace = route.params['namespace'].toLowerCase();
         const params = {
-            'name__iexact': namespace
+            name__iexact: namespace,
         };
         return this.namespaceService.query(params).map(results => results[0]);
     }

--- a/galaxyui/src/app/content-detail/content-detail.routing.module.ts
+++ b/galaxyui/src/app/content-detail/content-detail.routing.module.ts
@@ -1,15 +1,8 @@
 import { NgModule } from '@angular/core';
 
-import {
-    RouterModule,
-    Routes
-} from '@angular/router';
+import { RouterModule, Routes } from '@angular/router';
 
-import {
-    ContentResolver,
-    NamespaceResolver,
-    RepositoryResolver
-} from './content-detail.resolver.service';
+import { ContentResolver, NamespaceResolver, RepositoryResolver } from './content-detail.resolver.service';
 
 const routes: Routes = [
     // ':namespace/:repository/:content_name' and ':namespace/:repository/ moved
@@ -17,16 +10,8 @@ const routes: Routes = [
 ];
 
 @NgModule({
-    imports: [
-          RouterModule.forChild(routes)
-      ],
-      exports: [
-          RouterModule
-      ],
-      providers: [
-          ContentResolver,
-          RepositoryResolver,
-          NamespaceResolver
-      ]
+    imports: [RouterModule.forChild(routes)],
+    exports: [RouterModule],
+    providers: [ContentResolver, RepositoryResolver, NamespaceResolver],
 })
-export class ContentDetailRoutingModule { }
+export class ContentDetailRoutingModule {}

--- a/galaxyui/src/app/content-detail/content/module-utils/module-utils.component.ts
+++ b/galaxyui/src/app/content-detail/content/module-utils/module-utils.component.ts
@@ -1,41 +1,34 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
-import { EmptyStateConfig }  from 'patternfly-ng/empty-state/empty-state-config';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state/empty-state-config';
 
-import { ListConfig }        from 'patternfly-ng/list/basic-list/list-config';
+import { ListConfig } from 'patternfly-ng/list/basic-list/list-config';
 
-import { Content }           from '../../../resources/content/content';
-import { ContentService }    from '../../../resources/content/content.service';
-import { Repository }        from '../../../resources/repositories/repository';
+import { Content } from '../../../resources/content/content';
+import { ContentService } from '../../../resources/content/content.service';
+import { Repository } from '../../../resources/repositories/repository';
 
-import { ContentTypes }      from '../../../enums/content-types.enum';
+import { ContentTypes } from '../../../enums/content-types.enum';
 
-import { Filter }            from 'patternfly-ng/filter/filter';
-import { FilterConfig }      from 'patternfly-ng/filter/filter-config';
-import { FilterEvent }       from 'patternfly-ng/filter/filter-event';
-import { FilterField }       from 'patternfly-ng/filter/filter-field';
-import { FilterType }        from 'patternfly-ng/filter/filter-type';
+import { Filter } from 'patternfly-ng/filter/filter';
+import { FilterConfig } from 'patternfly-ng/filter/filter-config';
+import { FilterEvent } from 'patternfly-ng/filter/filter-event';
+import { FilterField } from 'patternfly-ng/filter/filter-field';
+import { FilterType } from 'patternfly-ng/filter/filter-type';
 
-import { PaginationConfig }  from 'patternfly-ng/pagination/pagination-config';
-import { PaginationEvent }   from 'patternfly-ng/pagination/pagination-event';
+import { PaginationConfig } from 'patternfly-ng/pagination/pagination-config';
+import { PaginationEvent } from 'patternfly-ng/pagination/pagination-event';
 
-import { Observable }        from 'rxjs/Observable';
-import { forkJoin }          from 'rxjs/observable/forkJoin';
+import { Observable } from 'rxjs/Observable';
+import { forkJoin } from 'rxjs/observable/forkJoin';
 
 @Component({
     selector: 'module-utils-detail',
     templateUrl: './module-utils.component.html',
-    styleUrls: ['./module-utils.component.less']
+    styleUrls: ['./module-utils.component.less'],
 })
 export class ModuleUtilsComponent implements OnInit {
-
-    constructor(
-        private contentService: ContentService
-    ) {}
+    constructor(private contentService: ContentService) {}
 
     emptyStateConfig: EmptyStateConfig;
     filterConfig: FilterConfig;
@@ -66,7 +59,7 @@ export class ModuleUtilsComponent implements OnInit {
             if (this.filterConfig && this.filterConfig.fields) {
                 this.filterConfig.appliedFilters.push({
                     field: this.filterConfig.fields[0],
-                    value: this._selectedContent.name
+                    value: this._selectedContent.name,
                 } as Filter);
                 this.queryContentList(this._selectedContent.name);
             }
@@ -81,7 +74,7 @@ export class ModuleUtilsComponent implements OnInit {
         this.emptyStateConfig = {
             iconStyleClass: 'pficon-warning-triangle-o',
             info: 'This plugin does not contain any documentation or metadata.',
-            title: 'No Metdata Found'
+            title: 'No Metdata Found',
         } as EmptyStateConfig;
 
         this.listConfig = {
@@ -89,39 +82,42 @@ export class ModuleUtilsComponent implements OnInit {
             multiSelect: false,
             selectItems: false,
             showCheckbox: false,
-            useExpandItems: true
+            useExpandItems: true,
         } as ListConfig;
 
         this.paginationConfig = {
             pageSize: 10,
             pageNumber: 1,
-            totalItems: 0
+            totalItems: 0,
         } as PaginationConfig;
 
         this.filterConfig = {
-            fields: [{
-                id: 'name',
-                title: 'Name',
-                placeholder: 'Filter by Name...',
-                type: FilterType.TEXT,
-            }, {
-                id: 'description',
-                title: 'Description',
-                placeholder: 'Filter by Description...',
-                type: FilterType.TEXT,
-            }] as FilterField[],
+            fields: [
+                {
+                    id: 'name',
+                    title: 'Name',
+                    placeholder: 'Filter by Name...',
+                    type: FilterType.TEXT,
+                },
+                {
+                    id: 'description',
+                    title: 'Description',
+                    placeholder: 'Filter by Description...',
+                    type: FilterType.TEXT,
+                },
+            ] as FilterField[],
             resultsCount: 0,
-            appliedFilters: []
+            appliedFilters: [],
         } as FilterConfig;
 
         if (this._selectedContent) {
             this.filterConfig.appliedFilters.push({
                 field: this.filterConfig.fields[0],
-                value: this._selectedContent.name
+                value: this._selectedContent.name,
             } as Filter);
         }
 
-        this.queryContentList((this.selectedContent) ? this.selectedContent.name : null);
+        this.queryContentList(this.selectedContent ? this.selectedContent.name : null);
     }
 
     handlePageSizeChange($event: PaginationEvent) {
@@ -159,12 +155,12 @@ export class ModuleUtilsComponent implements OnInit {
 
     private queryContentList(contentName?: string) {
         this.loading = true;
-        let queryString = (this.query) ? this.query : '?';
+        let queryString = this.query ? this.query : '?';
         const params = {
-            'page_size': this.pageSize,
-            'page': this.pageNumber,
-            'content_type__name': ContentTypes.moduleUtils,
-            'repository__id': this.repository.id
+            page_size: this.pageSize,
+            page: this.pageNumber,
+            content_type__name: ContentTypes.moduleUtils,
+            repository__id: this.repository.id,
         };
         if (contentName) {
             params['name'] = contentName;
@@ -175,15 +171,13 @@ export class ModuleUtilsComponent implements OnInit {
                 _tmp.push(`${key}=${params[key]}`);
             }
         }
-        queryString += (queryString === '?') ? _tmp.join('&') : '&' + _tmp.join('&');
-        this.contentService.pagedQuery(queryString).subscribe(
-            results => {
-                this._modules = results.results as Content[];
-                this.filterConfig.resultsCount = results.count;
-                this.paginationConfig.totalItems = results.count;
-                this.getContentDetail();
-            }
-        );
+        queryString += queryString === '?' ? _tmp.join('&') : '&' + _tmp.join('&');
+        this.contentService.pagedQuery(queryString).subscribe(results => {
+            this._modules = results.results as Content[];
+            this.filterConfig.resultsCount = results.count;
+            this.paginationConfig.totalItems = results.count;
+            this.getContentDetail();
+        });
     }
 
     private getContentDetail() {

--- a/galaxyui/src/app/content-detail/content/modules/modules.component.ts
+++ b/galaxyui/src/app/content-detail/content/modules/modules.component.ts
@@ -1,41 +1,34 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
-import { EmptyStateConfig }  from 'patternfly-ng/empty-state/empty-state-config';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state/empty-state-config';
 
-import { ListConfig }        from 'patternfly-ng/list/basic-list/list-config';
+import { ListConfig } from 'patternfly-ng/list/basic-list/list-config';
 
-import { Content }           from '../../../resources/content/content';
-import { ContentService }    from '../../../resources/content/content.service';
-import { Repository }        from '../../../resources/repositories/repository';
+import { Content } from '../../../resources/content/content';
+import { ContentService } from '../../../resources/content/content.service';
+import { Repository } from '../../../resources/repositories/repository';
 
-import { ContentTypes }      from '../../../enums/content-types.enum';
+import { ContentTypes } from '../../../enums/content-types.enum';
 
-import { Filter }            from 'patternfly-ng/filter/filter';
-import { FilterConfig }      from 'patternfly-ng/filter/filter-config';
-import { FilterEvent }       from 'patternfly-ng/filter/filter-event';
-import { FilterField }       from 'patternfly-ng/filter/filter-field';
-import { FilterType }        from 'patternfly-ng/filter/filter-type';
+import { Filter } from 'patternfly-ng/filter/filter';
+import { FilterConfig } from 'patternfly-ng/filter/filter-config';
+import { FilterEvent } from 'patternfly-ng/filter/filter-event';
+import { FilterField } from 'patternfly-ng/filter/filter-field';
+import { FilterType } from 'patternfly-ng/filter/filter-type';
 
-import { PaginationConfig }  from 'patternfly-ng/pagination/pagination-config';
-import { PaginationEvent }   from 'patternfly-ng/pagination/pagination-event';
+import { PaginationConfig } from 'patternfly-ng/pagination/pagination-config';
+import { PaginationEvent } from 'patternfly-ng/pagination/pagination-event';
 
-import { Observable }        from 'rxjs/Observable';
-import { forkJoin }          from 'rxjs/observable/forkJoin';
+import { Observable } from 'rxjs/Observable';
+import { forkJoin } from 'rxjs/observable/forkJoin';
 
 @Component({
     selector: 'modules-detail',
     templateUrl: './modules.component.html',
-    styleUrls: ['./modules.component.less']
+    styleUrls: ['./modules.component.less'],
 })
 export class ModulesComponent implements OnInit {
-
-    constructor(
-        private contentService: ContentService
-    ) {}
+    constructor(private contentService: ContentService) {}
 
     emptyStateConfig: EmptyStateConfig;
     filterConfig: FilterConfig;
@@ -66,7 +59,7 @@ export class ModulesComponent implements OnInit {
             if (this.filterConfig && this.filterConfig.fields) {
                 this.filterConfig.appliedFilters.push({
                     field: this.filterConfig.fields[0],
-                    value: this._selectedContent.name
+                    value: this._selectedContent.name,
                 } as Filter);
                 this.queryContentList(this._selectedContent.name);
             }
@@ -81,7 +74,7 @@ export class ModulesComponent implements OnInit {
         this.emptyStateConfig = {
             iconStyleClass: 'pficon-warning-triangle-o',
             info: 'This module does not contain any documentation or metadata.',
-            title: 'No Metadata Found'
+            title: 'No Metadata Found',
         } as EmptyStateConfig;
 
         this.listConfig = {
@@ -89,39 +82,42 @@ export class ModulesComponent implements OnInit {
             multiSelect: false,
             selectItems: false,
             showCheckbox: false,
-            useExpandItems: true
+            useExpandItems: true,
         } as ListConfig;
 
         this.paginationConfig = {
             pageSize: 10,
             pageNumber: 1,
-            totalItems: 0
+            totalItems: 0,
         } as PaginationConfig;
 
         this.filterConfig = {
-            fields: [{
-                id: 'name',
-                title: 'Name',
-                placeholder: 'Filter by Name...',
-                type: FilterType.TEXT,
-            }, {
-                id: 'description',
-                title: 'Description',
-                placeholder: 'Filter by Description...',
-                type: FilterType.TEXT,
-            }] as FilterField[],
+            fields: [
+                {
+                    id: 'name',
+                    title: 'Name',
+                    placeholder: 'Filter by Name...',
+                    type: FilterType.TEXT,
+                },
+                {
+                    id: 'description',
+                    title: 'Description',
+                    placeholder: 'Filter by Description...',
+                    type: FilterType.TEXT,
+                },
+            ] as FilterField[],
             resultsCount: 0,
-            appliedFilters: []
+            appliedFilters: [],
         } as FilterConfig;
 
         if (this._selectedContent) {
             this.filterConfig.appliedFilters.push({
                 field: this.filterConfig.fields[0],
-                value: this._selectedContent.name
+                value: this._selectedContent.name,
             } as Filter);
         }
 
-        this.queryContentList((this.selectedContent) ? this.selectedContent.name : null);
+        this.queryContentList(this.selectedContent ? this.selectedContent.name : null);
     }
 
     handlePageSizeChange($event: PaginationEvent) {
@@ -156,12 +152,12 @@ export class ModulesComponent implements OnInit {
 
     private queryContentList(contentName?: string) {
         this.loading = true;
-        let queryString = (this.query) ? this.query : '?';
+        let queryString = this.query ? this.query : '?';
         const params = {
-            'page_size': this.pageSize,
-            'page': this.pageNumber,
-            'content_type__name': ContentTypes.module,
-            'repository__id': this.repository.id
+            page_size: this.pageSize,
+            page: this.pageNumber,
+            content_type__name: ContentTypes.module,
+            repository__id: this.repository.id,
         };
         if (contentName) {
             params['name'] = contentName;
@@ -172,15 +168,13 @@ export class ModulesComponent implements OnInit {
                 _tmp.push(`${key}=${params[key]}`);
             }
         }
-        queryString += (queryString === '?') ? _tmp.join('&') : '&' + _tmp.join('&');
-        this.contentService.pagedQuery(queryString).subscribe(
-            results => {
-                this._modules = results.results as Content[];
-                this.filterConfig.resultsCount = results.count;
-                this.paginationConfig.totalItems = results.count;
-                this.getContentDetail();
-            }
-        );
+        queryString += queryString === '?' ? _tmp.join('&') : '&' + _tmp.join('&');
+        this.contentService.pagedQuery(queryString).subscribe(results => {
+            this._modules = results.results as Content[];
+            this.filterConfig.resultsCount = results.count;
+            this.paginationConfig.totalItems = results.count;
+            this.getContentDetail();
+        });
     }
 
     private getContentDetail() {

--- a/galaxyui/src/app/content-detail/content/plugins/plugins.component.ts
+++ b/galaxyui/src/app/content-detail/content/plugins/plugins.component.ts
@@ -1,46 +1,36 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
-import { EmptyStateConfig }  from 'patternfly-ng/empty-state/empty-state-config';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state/empty-state-config';
 
-import { ListConfig }        from 'patternfly-ng/list/basic-list/list-config';
+import { ListConfig } from 'patternfly-ng/list/basic-list/list-config';
 
-import { Content }           from '../../../resources/content/content';
-import { ContentService }    from '../../../resources/content/content.service';
-import { Repository }        from '../../../resources/repositories/repository';
+import { Content } from '../../../resources/content/content';
+import { ContentService } from '../../../resources/content/content.service';
+import { Repository } from '../../../resources/repositories/repository';
 
-import { ContentTypes }      from '../../../enums/content-types.enum';
+import { ContentTypes } from '../../../enums/content-types.enum';
 
-import {
-    PluginNames,
-    PluginTypes
-} from '../../../enums/plugin-types.enum';
+import { PluginNames, PluginTypes } from '../../../enums/plugin-types.enum';
 
-import { Filter }            from 'patternfly-ng/filter/filter';
-import { FilterConfig }      from 'patternfly-ng/filter/filter-config';
-import { FilterEvent }       from 'patternfly-ng/filter/filter-event';
-import { FilterField }       from 'patternfly-ng/filter/filter-field';
-import { FilterType }        from 'patternfly-ng/filter/filter-type';
+import { Filter } from 'patternfly-ng/filter/filter';
+import { FilterConfig } from 'patternfly-ng/filter/filter-config';
+import { FilterEvent } from 'patternfly-ng/filter/filter-event';
+import { FilterField } from 'patternfly-ng/filter/filter-field';
+import { FilterType } from 'patternfly-ng/filter/filter-type';
 
-import { PaginationConfig }  from 'patternfly-ng/pagination/pagination-config';
-import { PaginationEvent }   from 'patternfly-ng/pagination/pagination-event';
+import { PaginationConfig } from 'patternfly-ng/pagination/pagination-config';
+import { PaginationEvent } from 'patternfly-ng/pagination/pagination-event';
 
-import { Observable }        from 'rxjs/Observable';
-import { forkJoin }          from 'rxjs/observable/forkJoin';
+import { Observable } from 'rxjs/Observable';
+import { forkJoin } from 'rxjs/observable/forkJoin';
 
 @Component({
     selector: 'plugins-detail',
     templateUrl: './plugins.component.html',
-    styleUrls: ['./plugins.component.less']
+    styleUrls: ['./plugins.component.less'],
 })
 export class PluginsComponent implements OnInit {
-
-    constructor(
-        private contentService: ContentService
-    ) {}
+    constructor(private contentService: ContentService) {}
 
     emptyStateConfig: EmptyStateConfig;
     filterConfig: FilterConfig;
@@ -74,7 +64,7 @@ export class PluginsComponent implements OnInit {
             if (this.filterConfig && this.filterConfig.fields) {
                 this.filterConfig.appliedFilters.push({
                     field: this.filterConfig.fields[0],
-                    value: this._selectedContent.name
+                    value: this._selectedContent.name,
                 } as Filter);
                 this.queryContentList(this._selectedContent.name);
             }
@@ -89,7 +79,7 @@ export class PluginsComponent implements OnInit {
         this.emptyStateConfig = {
             iconStyleClass: 'pficon-warning-triangle-o',
             info: 'This plugin does not contain any documentation or metadata.',
-            title: 'No Metadata Found'
+            title: 'No Metadata Found',
         } as EmptyStateConfig;
 
         this.listConfig = {
@@ -97,42 +87,46 @@ export class PluginsComponent implements OnInit {
             multiSelect: false,
             selectItems: false,
             showCheckbox: false,
-            useExpandItems: true
+            useExpandItems: true,
         } as ListConfig;
 
         this.paginationConfig = {
             pageSize: 10,
             pageNumber: 1,
-            totalItems: 0
+            totalItems: 0,
         } as PaginationConfig;
 
         this.filterConfig = {
-            fields: [{
-                id: 'name',
-                title: 'Name',
-                placeholder: 'Filter by Name...',
-                type: FilterType.TEXT,
-            }, {
-                id: 'description',
-                title: 'Description',
-                placeholder: 'Filter by Description...',
-                type: FilterType.TEXT,
-            }, {
-                id: 'plugin_type',
-                title: 'Plugin Type',
-                placeholder: 'Plugin Type',
-                type: FilterType.TYPEAHEAD,
-                queries: []
-            }] as FilterField[],
+            fields: [
+                {
+                    id: 'name',
+                    title: 'Name',
+                    placeholder: 'Filter by Name...',
+                    type: FilterType.TEXT,
+                },
+                {
+                    id: 'description',
+                    title: 'Description',
+                    placeholder: 'Filter by Description...',
+                    type: FilterType.TEXT,
+                },
+                {
+                    id: 'plugin_type',
+                    title: 'Plugin Type',
+                    placeholder: 'Plugin Type',
+                    type: FilterType.TYPEAHEAD,
+                    queries: [],
+                },
+            ] as FilterField[],
             resultsCount: 0,
-            appliedFilters: []
+            appliedFilters: [],
         } as FilterConfig;
 
         for (const key in PluginTypes) {
             if (PluginTypes.hasOwnProperty(key)) {
                 this.filterConfig.fields[2].queries.push({
                     id: key,
-                    value: PluginTypes[key]
+                    value: PluginTypes[key],
                 });
             }
         }
@@ -140,11 +134,11 @@ export class PluginsComponent implements OnInit {
         if (this._selectedContent) {
             this.filterConfig.appliedFilters.push({
                 field: this.filterConfig.fields[0],
-                value: this._selectedContent.name
+                value: this._selectedContent.name,
             } as Filter);
         }
 
-        this.queryContentList((this.selectedContent) ? this.selectedContent.name : null);
+        this.queryContentList(this.selectedContent ? this.selectedContent.name : null);
     }
 
     handlePageSizeChange($event: PaginationEvent) {
@@ -186,11 +180,11 @@ export class PluginsComponent implements OnInit {
 
     private queryContentList(contentName?: string) {
         this.loading = true;
-        let queryString = (this.query) ? this.query : '?';
+        let queryString = this.query ? this.query : '?';
         const params = {
-            'page_size': this.pageSize,
-            'page': this.pageNumber,
-            'repository__id': this.repository.id
+            page_size: this.pageSize,
+            page: this.pageNumber,
+            repository__id: this.repository.id,
         };
         if (queryString.indexOf('content_type__name') < 0) {
             params['content_type__name__icontains'] = ContentTypes.plugin;
@@ -204,15 +198,13 @@ export class PluginsComponent implements OnInit {
                 _tmp.push(`${key}=${params[key]}`);
             }
         }
-        queryString += (queryString === '?') ? _tmp.join('&') : '&' + _tmp.join('&');
-        this.contentService.pagedQuery(queryString).subscribe(
-            results => {
-                this._plugins = results.results as Content[];
-                this.filterConfig.resultsCount = results.count;
-                this.paginationConfig.totalItems = results.count;
-                this.getContentDetail();
-            }
-        );
+        queryString += queryString === '?' ? _tmp.join('&') : '&' + _tmp.join('&');
+        this.contentService.pagedQuery(queryString).subscribe(results => {
+            this._plugins = results.results as Content[];
+            this.filterConfig.resultsCount = results.count;
+            this.paginationConfig.totalItems = results.count;
+            this.getContentDetail();
+        });
     }
 
     private getContentDetail() {

--- a/galaxyui/src/app/content-detail/content/roles/roles.component.ts
+++ b/galaxyui/src/app/content-detail/content/roles/roles.component.ts
@@ -1,39 +1,32 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
-import { ListConfig }        from 'patternfly-ng/list/basic-list/list-config';
+import { ListConfig } from 'patternfly-ng/list/basic-list/list-config';
 
-import { Content }           from '../../../resources/content/content';
-import { ContentService }    from '../../../resources/content/content.service';
-import { Repository }        from '../../../resources/repositories/repository';
+import { Content } from '../../../resources/content/content';
+import { ContentService } from '../../../resources/content/content.service';
+import { Repository } from '../../../resources/repositories/repository';
 
-import { ContentTypes }      from '../../../enums/content-types.enum';
+import { ContentTypes } from '../../../enums/content-types.enum';
 
-import { Filter }            from 'patternfly-ng/filter/filter';
-import { FilterConfig }      from 'patternfly-ng/filter/filter-config';
-import { FilterEvent }       from 'patternfly-ng/filter/filter-event';
-import { FilterField }       from 'patternfly-ng/filter/filter-field';
-import { FilterType }        from 'patternfly-ng/filter/filter-type';
+import { Filter } from 'patternfly-ng/filter/filter';
+import { FilterConfig } from 'patternfly-ng/filter/filter-config';
+import { FilterEvent } from 'patternfly-ng/filter/filter-event';
+import { FilterField } from 'patternfly-ng/filter/filter-field';
+import { FilterType } from 'patternfly-ng/filter/filter-type';
 
-import { PaginationConfig }  from 'patternfly-ng/pagination/pagination-config';
-import { PaginationEvent }   from 'patternfly-ng/pagination/pagination-event';
+import { PaginationConfig } from 'patternfly-ng/pagination/pagination-config';
+import { PaginationEvent } from 'patternfly-ng/pagination/pagination-event';
 
-import { Observable }        from 'rxjs/Observable';
-import { forkJoin }          from 'rxjs/observable/forkJoin';
+import { Observable } from 'rxjs/Observable';
+import { forkJoin } from 'rxjs/observable/forkJoin';
 
 @Component({
     selector: 'roles-detail',
     templateUrl: './roles.component.html',
-    styleUrls: ['./roles.component.less']
+    styleUrls: ['./roles.component.less'],
 })
 export class RolesComponent implements OnInit {
-
-    constructor(
-        private contentService: ContentService
-    ) {}
+    constructor(private contentService: ContentService) {}
 
     filterConfig: FilterConfig;
     listConfig: ListConfig;
@@ -63,7 +56,7 @@ export class RolesComponent implements OnInit {
             if (this.filterConfig && this.filterConfig.fields) {
                 this.filterConfig.appliedFilters.push({
                     field: this.filterConfig.fields[0],
-                    value: this._selectedContent.name
+                    value: this._selectedContent.name,
                 } as Filter);
                 this.queryContentList(this._selectedContent.name);
             }
@@ -80,39 +73,42 @@ export class RolesComponent implements OnInit {
             multiSelect: false,
             selectItems: false,
             showCheckbox: false,
-            useExpandItems: true
+            useExpandItems: true,
         } as ListConfig;
 
         this.paginationConfig = {
             pageSize: 10,
             pageNumber: 1,
-            totalItems: 0
+            totalItems: 0,
         } as PaginationConfig;
 
         this.filterConfig = {
-            fields: [{
-                id: 'name',
-                title: 'Name',
-                placeholder: 'Filter by Name...',
-                type: FilterType.TEXT,
-            }, {
-                id: 'description',
-                title: 'Description',
-                placeholder: 'Filter by Description...',
-                type: FilterType.TEXT,
-            }] as FilterField[],
+            fields: [
+                {
+                    id: 'name',
+                    title: 'Name',
+                    placeholder: 'Filter by Name...',
+                    type: FilterType.TEXT,
+                },
+                {
+                    id: 'description',
+                    title: 'Description',
+                    placeholder: 'Filter by Description...',
+                    type: FilterType.TEXT,
+                },
+            ] as FilterField[],
             resultsCount: 0,
-            appliedFilters: []
+            appliedFilters: [],
         } as FilterConfig;
 
         if (this._selectedContent) {
             this.filterConfig.appliedFilters.push({
                 field: this.filterConfig.fields[0],
-                value: this._selectedContent.name
+                value: this._selectedContent.name,
             } as Filter);
         }
 
-        this.queryContentList((this.selectedContent) ? this.selectedContent.name : null);
+        this.queryContentList(this.selectedContent ? this.selectedContent.name : null);
     }
 
     handlePageSizeChange($event: PaginationEvent) {
@@ -150,12 +146,12 @@ export class RolesComponent implements OnInit {
 
     private queryContentList(contentName?: string) {
         this.loading = true;
-        let queryString = (this.query) ? this.query : '?';
+        let queryString = this.query ? this.query : '?';
         const params = {
-            'page_size': this.pageSize,
-            'page': this.pageNumber,
-            'content_type__name': ContentTypes.role,
-            'repository__id': this.repository.id
+            page_size: this.pageSize,
+            page: this.pageNumber,
+            content_type__name: ContentTypes.role,
+            repository__id: this.repository.id,
         };
         if (contentName) {
             params['name'] = contentName;
@@ -166,15 +162,13 @@ export class RolesComponent implements OnInit {
                 _tmp.push(`${key}=${params[key]}`);
             }
         }
-        queryString += (queryString === '?') ? _tmp.join('&') : '&' + _tmp.join('&');
-        this.contentService.pagedQuery(queryString).subscribe(
-            results => {
-                this._roles = results.results as Content[];
-                this.filterConfig.resultsCount = results.count;
-                this.paginationConfig.totalItems = results.count;
-                this.getContentDetail();
-            }
-        );
+        queryString += queryString === '?' ? _tmp.join('&') : '&' + _tmp.join('&');
+        this.contentService.pagedQuery(queryString).subscribe(results => {
+            this._roles = results.results as Content[];
+            this.filterConfig.resultsCount = results.count;
+            this.paginationConfig.totalItems = results.count;
+            this.getContentDetail();
+        });
     }
 
     private getContentDetail() {
@@ -192,8 +186,9 @@ export class RolesComponent implements OnInit {
         forkJoin(queries).subscribe((results: Content[]) => {
             this.items = JSON.parse(JSON.stringify(results));
             this.items.forEach(item => {
-                item['install_cmd'] =
-                    `mazer install ${item.summary_fields['namespace']['name']}.${item.summary_fields['repository']['name']}`;
+                item['install_cmd'] = `mazer install ${item.summary_fields['namespace']['name']}.${
+                    item.summary_fields['repository']['name']
+                }`;
                 item['hasTags'] = false;
                 if (item.summary_fields['tags'] && item.summary_fields['tags'].length) {
                     item['tags'] = item.summary_fields['tags'];

--- a/galaxyui/src/app/content-detail/repository/repository.component.ts
+++ b/galaxyui/src/app/content-detail/repository/repository.component.ts
@@ -1,18 +1,10 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
-import { Content }          from '../../resources/content/content';
-import { Namespace }        from '../../resources/namespaces/namespace';
-import { Repository }       from '../../resources/repositories/repository';
+import { Content } from '../../resources/content/content';
+import { Namespace } from '../../resources/namespaces/namespace';
+import { Repository } from '../../resources/repositories/repository';
 
-import {
-    RepoFormats,
-    RepoFormatsIconClasses,
-    RepoFormatsTooltips
-} from '../../enums/repo-types.enum';
+import { RepoFormats, RepoFormatsIconClasses, RepoFormatsTooltips } from '../../enums/repo-types.enum';
 
 class RepositoryView {
     repoType: RepoFormats;
@@ -41,14 +33,15 @@ export class RepoChangeEvent {
 @Component({
     selector: 'content-detail-repo',
     templateUrl: './repository.component.html',
-    styleUrls: ['./repository.component.less']
+    styleUrls: ['./repository.component.less'],
 })
 export class RepositoryComponent implements OnInit {
-
     constructor() {}
 
-    @Input() repository: Repository;
-    @Input() namespace: Namespace;
+    @Input()
+    repository: Repository;
+    @Input()
+    namespace: Namespace;
 
     mainContent: Content = {} as Content;
     repositoryView: RepositoryView;

--- a/galaxyui/src/app/enums/content-types.enum.ts
+++ b/galaxyui/src/app/enums/content-types.enum.ts
@@ -1,10 +1,9 @@
-
 export enum ContentTypes {
     apb = 'apb',
     module = 'module',
     plugin = 'plugin',
     role = 'role',
-    moduleUtils = 'module_utils'
+    moduleUtils = 'module_utils',
 }
 
 export enum ContentTypesPlural {
@@ -12,7 +11,7 @@ export enum ContentTypesPlural {
     module = 'modules',
     plugin = 'plugins',
     role = 'roles',
-    moduleUtils = 'module_utils'
+    moduleUtils = 'module_utils',
 }
 
 export enum ContentTypesChoices {
@@ -20,7 +19,7 @@ export enum ContentTypesChoices {
     module = 'Module',
     plugin = 'Plugin',
     role = 'Role',
-    moduleUtils = 'Module Utils'
+    moduleUtils = 'Module Utils',
 }
 
 export enum ContentTypesPluralChoices {
@@ -28,7 +27,7 @@ export enum ContentTypesPluralChoices {
     module = 'Modules',
     plugin = 'Plugins',
     role = 'Roles',
-    moduleUtils = 'Module Utils'
+    moduleUtils = 'Module Utils',
 }
 
 export enum ContentTypesIconClasses {
@@ -36,5 +35,5 @@ export enum ContentTypesIconClasses {
     module = 'fa fa-microchip',
     plugin = 'fa fa-plug',
     role = 'fa fa-gear',
-    moduleUtils = 'fa fa-microchip'
+    moduleUtils = 'fa fa-microchip',
 }

--- a/galaxyui/src/app/enums/contributor-types.enum.ts
+++ b/galaxyui/src/app/enums/contributor-types.enum.ts
@@ -1,9 +1,9 @@
 export enum ContributorTypes {
     vendor = 'partner',
-    community = 'community'
+    community = 'community',
 }
 
 export enum ContributorTypesIconClasses {
     vendor = 'fa fa-star',
-    community = 'fa fa-users'
+    community = 'fa fa-users',
 }

--- a/galaxyui/src/app/enums/import-state.enum.ts
+++ b/galaxyui/src/app/enums/import-state.enum.ts
@@ -2,5 +2,5 @@ export enum ImportState {
     pending = 'PENDING',
     running = 'RUNNING',
     failed = 'FAILED',
-    success = 'SUCCESS'
+    success = 'SUCCESS',
 }

--- a/galaxyui/src/app/enums/repo-types.enum.ts
+++ b/galaxyui/src/app/enums/repo-types.enum.ts
@@ -6,8 +6,8 @@ export enum RepoFormats {
 
 export enum RepoFormatsIconClasses {
     apb = 'pficon-bundle',
-    role = 'fa fa-gear'    ,
-    multi= 'pficon-repository',
+    role = 'fa fa-gear',
+    multi = 'pficon-repository',
 }
 
 export enum RepoFormatsTooltips {

--- a/galaxyui/src/app/enums/view-types.enum.ts
+++ b/galaxyui/src/app/enums/view-types.enum.ts
@@ -2,8 +2,8 @@ export enum ViewTypes {
     readme = 'readme',
     meta = 'meta',
     detail = 'detail',
-       modules = 'modules',
-       moduleUtils = 'moduleUtils',
-       roles = 'roles',
-       plugins = 'plugins'
+    modules = 'modules',
+    moduleUtils = 'moduleUtils',
+    roles = 'roles',
+    plugins = 'plugins',
 }

--- a/galaxyui/src/app/exception-pages/access-denied/access-denied.component.ts
+++ b/galaxyui/src/app/exception-pages/access-denied/access-denied.component.ts
@@ -1,33 +1,19 @@
-import {
-    Component,
-    OnInit,
-    ViewEncapsulation
-} from '@angular/core';
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 
-import {
-    Router
-} from '@angular/router';
+import { Router } from '@angular/router';
 
-import {
-    EmptyStateConfig
-} from 'patternfly-ng/empty-state';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state';
 
-import {
-    Action,
-    ActionConfig
-} from 'patternfly-ng/action';
+import { Action, ActionConfig } from 'patternfly-ng/action';
 
 @Component({
     encapsulation: ViewEncapsulation.None,
     selector: 'app-access-denied',
     templateUrl: './access-denied.component.html',
-    styleUrls: ['./access-denied.component.less']
+    styleUrls: ['./access-denied.component.less'],
 })
 export class AccessDeniedComponent implements OnInit {
-
-    constructor(
-        private router: Router
-    ) {}
+    constructor(private router: Router) {}
 
     pageTitle = 'Access Denied';
     pageIcon = 'fa fa-exclamation-triangle';
@@ -36,19 +22,22 @@ export class AccessDeniedComponent implements OnInit {
 
     ngOnInit(): void {
         this.actionConfig = {
-            primaryActions: [{
-                id: 'home',
-                title: 'Home',
-                tooltip: 'View the home page'
-            }]
+            primaryActions: [
+                {
+                    id: 'home',
+                    title: 'Home',
+                    tooltip: 'View the home page',
+                },
+            ],
         } as ActionConfig;
 
         this.emptyStateConfig = {
             actions: this.actionConfig,
             iconStyleClass: 'fa fa-frown-o',
-            info: 'You do not have access to the requested page. Choose one of the navigation options on the left, ' +
+            info:
+                'You do not have access to the requested page. Choose one of the navigation options on the left, ' +
                 'or click the Home button below, to visit the home page',
-            title: 'Access Denied'
+            title: 'Access Denied',
         } as EmptyStateConfig;
     }
 

--- a/galaxyui/src/app/exception-pages/exception-pages.module.ts
+++ b/galaxyui/src/app/exception-pages/exception-pages.module.ts
@@ -1,25 +1,16 @@
 import { CommonModule } from '@angular/common';
-import { NgModule }     from '@angular/core';
+import { NgModule } from '@angular/core';
 
-import { ActionModule }     from 'patternfly-ng/action/action.module';
+import { ActionModule } from 'patternfly-ng/action/action.module';
 import { EmptyStateModule } from 'patternfly-ng/empty-state/empty-state.module';
 
-import { PageHeaderModule }            from '../page-header/page-header.module';
-import { AccessDeniedComponent }       from './access-denied/access-denied.component';
+import { PageHeaderModule } from '../page-header/page-header.module';
+import { AccessDeniedComponent } from './access-denied/access-denied.component';
 import { ExceptionPagesRoutingModule } from './exception-pages.routing.module';
-import { NotFoundComponent }           from './not-found/not-found.component';
+import { NotFoundComponent } from './not-found/not-found.component';
 
 @NgModule({
-    declarations: [
-        AccessDeniedComponent,
-        NotFoundComponent
-    ],
-    imports: [
-        ActionModule,
-        CommonModule,
-        PageHeaderModule,
-        ExceptionPagesRoutingModule,
-        EmptyStateModule,
-    ],
+    declarations: [AccessDeniedComponent, NotFoundComponent],
+    imports: [ActionModule, CommonModule, PageHeaderModule, ExceptionPagesRoutingModule, EmptyStateModule],
 })
 export class ExceptionPagesModule {}

--- a/galaxyui/src/app/exception-pages/exception-pages.routing.module.ts
+++ b/galaxyui/src/app/exception-pages/exception-pages.routing.module.ts
@@ -1,12 +1,9 @@
-import { NgModule }                 from '@angular/core';
+import { NgModule } from '@angular/core';
 
-import {
-    RouterModule,
-    Routes
-} from '@angular/router';
+import { RouterModule, Routes } from '@angular/router';
 
 import { AccessDeniedComponent } from './access-denied/access-denied.component';
-import { NotFoundComponent }     from './not-found/not-found.component';
+import { NotFoundComponent } from './not-found/not-found.component';
 
 const exceptionPagesRoutes: Routes = [
     {
@@ -15,16 +12,12 @@ const exceptionPagesRoutes: Routes = [
     },
     {
         path: 'not-found',
-        component: NotFoundComponent
-    }
+        component: NotFoundComponent,
+    },
 ];
 
 @NgModule({
-    imports: [
-        RouterModule.forChild(exceptionPagesRoutes)
-    ],
-    exports: [
-        RouterModule,
-    ]
+    imports: [RouterModule.forChild(exceptionPagesRoutes)],
+    exports: [RouterModule],
 })
 export class ExceptionPagesRoutingModule {}

--- a/galaxyui/src/app/exception-pages/not-found/not-found.component.ts
+++ b/galaxyui/src/app/exception-pages/not-found/not-found.component.ts
@@ -1,33 +1,19 @@
-import {
-    Component,
-    OnInit,
-    ViewEncapsulation
-} from '@angular/core';
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 
-import {
-    Router
-} from '@angular/router';
+import { Router } from '@angular/router';
 
-import {
-    EmptyStateConfig
-} from 'patternfly-ng/empty-state';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state';
 
-import {
-    Action,
-    ActionConfig
-} from 'patternfly-ng/action';
+import { Action, ActionConfig } from 'patternfly-ng/action';
 
 @Component({
     encapsulation: ViewEncapsulation.None,
     selector: 'app-not-found',
     templateUrl: './not-found.component.html',
-    styleUrls: ['./not-found.component.less']
+    styleUrls: ['./not-found.component.less'],
 })
 export class NotFoundComponent implements OnInit {
-
-    constructor(
-        private router: Router
-    ) {}
+    constructor(private router: Router) {}
 
     pageTitle = 'Page Not Found';
     pageIcon = 'fa fa-frown-o';
@@ -36,20 +22,23 @@ export class NotFoundComponent implements OnInit {
 
     ngOnInit(): void {
         this.actionConfig = {
-            primaryActions: [{
-                id: 'home',
-                title: 'Home',
-                tooltip: 'View the home page'
-            }]
+            primaryActions: [
+                {
+                    id: 'home',
+                    title: 'Home',
+                    tooltip: 'View the home page',
+                },
+            ],
         } as ActionConfig;
 
         this.emptyStateConfig = {
             actions: this.actionConfig,
             iconStyleClass: 'fa fa-frown-o',
-            info: 'Well this is embarrassing. The page you requested could not be found. ' +
+            info:
+                'Well this is embarrassing. The page you requested could not be found. ' +
                 'Choose one of the navigation options on the left, or click the Home button ' +
                 'below, to visit the home page',
-            title: 'Page Not Found'
+            title: 'Page Not Found',
         } as EmptyStateConfig;
     }
 

--- a/galaxyui/src/app/home/carousel/carousel.component.ts
+++ b/galaxyui/src/app/home/carousel/carousel.component.ts
@@ -1,22 +1,15 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
-import {
-    Router
-} from '@angular/router';
+import { Router } from '@angular/router';
 
 import { Namespace } from '../../resources/namespaces/namespace';
 
 @Component({
     selector: 'carousel-component',
     templateUrl: './carousel.component.html',
-    styleUrls: ['./carousel.component.less']
+    styleUrls: ['./carousel.component.less'],
 })
 export class CarouselComponent implements OnInit {
-
     @Input()
     set vendors(data: Namespace[]) {
         this._vendors = JSON.parse(JSON.stringify(data));
@@ -38,11 +31,9 @@ export class CarouselComponent implements OnInit {
 
     _vendors: Namespace[] = [];
 
-    constructor(
-        private router: Router
-    ) { }
+    constructor(private router: Router) {}
 
-    ngOnInit() { }
+    ngOnInit() {}
 
     handleLeftClick() {
         document.getElementById('slider-inner').scrollLeft += 260;
@@ -54,8 +45,8 @@ export class CarouselComponent implements OnInit {
 
     handleVendorClick(vendor: Namespace) {
         const params = {
-            'vendor': 'true',
-            'namespaces': vendor.name
+            vendor: 'true',
+            namespaces: vendor.name,
         };
         this.router.navigate(['/', 'search'], { queryParams: params });
     }

--- a/galaxyui/src/app/home/home.component.spec.ts
+++ b/galaxyui/src/app/home/home.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { HomeComponent } from './home.component';
 
 describe('HomeComponent', () => {
-  let component: HomeComponent;
-  let fixture: ComponentFixture<HomeComponent>;
+    let component: HomeComponent;
+    let fixture: ComponentFixture<HomeComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ HomeComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [HomeComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(HomeComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(HomeComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/home/home.component.ts
+++ b/galaxyui/src/app/home/home.component.ts
@@ -1,29 +1,19 @@
-import {
-    AfterViewInit,
-    Component,
-    OnInit
-} from '@angular/core';
+import { AfterViewInit, Component, OnInit } from '@angular/core';
 
-import {
-    ActivatedRoute,
-    Router
-} from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
-import {
-    CardConfig
-} from 'patternfly-ng/card/basic-card/card-config';
+import { CardConfig } from 'patternfly-ng/card/basic-card/card-config';
 
-import { Namespace }              from '../resources/namespaces/namespace';
+import { Namespace } from '../resources/namespaces/namespace';
 
 import * as $ from 'jquery';
 
 @Component({
-    selector:    'home',
+    selector: 'home',
     templateUrl: './home.component.html',
-    styleUrls:   ['./home.component.less']
+    styleUrls: ['./home.component.less'],
 })
 export class HomeComponent implements OnInit, AfterViewInit {
-
     downloadConfig: CardConfig;
     shareConfig: CardConfig;
     featureConfig: CardConfig;
@@ -37,13 +27,10 @@ export class HomeComponent implements OnInit, AfterViewInit {
     showCards = false;
     vendors: Namespace[] = [];
 
-    constructor(
-        private route: ActivatedRoute,
-        private router: Router
-    ) {}
+    constructor(private route: ActivatedRoute, private router: Router) {}
 
     ngOnInit() {
-        this.route.data.subscribe((data) => {
+        this.route.data.subscribe(data => {
             this.vendors = data['vendors']['results'];
             data['contentBlocks'].forEach(item => {
                 switch (item.name) {
@@ -61,15 +48,15 @@ export class HomeComponent implements OnInit, AfterViewInit {
         });
 
         this.downloadConfig = {
-            titleBorder: true
+            titleBorder: true,
         } as CardConfig;
 
         this.shareConfig = {
-            titleBorder: true
+            titleBorder: true,
         } as CardConfig;
 
         this.featureConfig = {
-            titleBorder: true
+            titleBorder: true,
         } as CardConfig;
     }
 
@@ -83,7 +70,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
     }
 
     searchContent(): void {
-        this.router.navigate(['/search'], {queryParams: {keywords: this.searchText}});
+        this.router.navigate(['/search'], { queryParams: { keywords: this.searchText } });
     }
 
     // private

--- a/galaxyui/src/app/home/home.module.ts
+++ b/galaxyui/src/app/home/home.module.ts
@@ -1,36 +1,22 @@
-import {
-    CUSTOM_ELEMENTS_SCHEMA,
-    NgModule
-} from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 
-import { CommonModule }         from '@angular/common';
-import { FormsModule }          from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 
-import { CarouselComponent }    from './carousel/carousel.component';
-import { HomeComponent }        from './home.component';
-import { HomeRoutingModule }    from './home.routing.module';
-import { PopularComponent }     from './popular/popular.component';
+import { CarouselComponent } from './carousel/carousel.component';
+import { HomeComponent } from './home.component';
+import { HomeRoutingModule } from './home.routing.module';
+import { PopularComponent } from './popular/popular.component';
 
-import { CardModule }           from 'patternfly-ng/card/basic-card/card.module';
+import { CardModule } from 'patternfly-ng/card/basic-card/card.module';
 
-import { PageHeaderModule }     from '../page-header/page-header.module';
-import { PageLoadingModule }    from '../page-loading/page-loading.module';
+import { PageHeaderModule } from '../page-header/page-header.module';
+import { PageLoadingModule } from '../page-loading/page-loading.module';
 
 @NgModule({
-    declarations: [
-        CarouselComponent,
-        PopularComponent,
-        HomeComponent
-    ],
-    imports: [
-        CardModule,
-        PageHeaderModule,
-        PageLoadingModule,
-        HomeRoutingModule,
-        FormsModule,
-        CommonModule
-    ],
+    declarations: [CarouselComponent, PopularComponent, HomeComponent],
+    imports: [CardModule, PageHeaderModule, PageLoadingModule, HomeRoutingModule, FormsModule, CommonModule],
     providers: [],
-    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
-export class HomeModule { }
+export class HomeModule {}

--- a/galaxyui/src/app/home/home.resolver.service.ts
+++ b/galaxyui/src/app/home/home.resolver.service.ts
@@ -1,35 +1,25 @@
-import {
-    Injectable
-} from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import {
-    ActivatedRouteSnapshot,
-    Resolve,
-    RouterStateSnapshot
-} from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
 
-import { Observable }            from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 
-import { ContentBlock }          from '../resources/content-blocks/content-block';
-import { ContentBlocksService }  from '../resources/content-blocks/content-blocks.service';
-import { NamespaceService }      from '../resources/namespaces/namespace.service';
-import { PagedResponse }         from '../resources/paged-response';
+import { ContentBlock } from '../resources/content-blocks/content-block';
+import { ContentBlocksService } from '../resources/content-blocks/content-blocks.service';
+import { NamespaceService } from '../resources/namespaces/namespace.service';
+import { PagedResponse } from '../resources/paged-response';
 
 @Injectable()
 export class VendorListResolver implements Resolve<PagedResponse> {
-    constructor(
-        private namespaceService: NamespaceService,
-    ) {}
+    constructor(private namespaceService: NamespaceService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<PagedResponse> {
-        return this.namespaceService.pagedQuery({is_vendor: 'true'});
+        return this.namespaceService.pagedQuery({ is_vendor: 'true' });
     }
 }
 
 @Injectable()
 export class ContentBlockResolver implements Resolve<ContentBlock[]> {
-    constructor(
-        private blockService: ContentBlocksService,
-    ) {}
+    constructor(private blockService: ContentBlocksService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<ContentBlock[]> {
         return this.blockService.query();
     }

--- a/galaxyui/src/app/home/home.routing.module.ts
+++ b/galaxyui/src/app/home/home.routing.module.ts
@@ -1,20 +1,10 @@
-import {
-    NgModule
-} from '@angular/core';
+import { NgModule } from '@angular/core';
 
-import {
-    RouterModule,
-    Routes
-} from '@angular/router';
+import { RouterModule, Routes } from '@angular/router';
 
-import {
-    HomeComponent
-} from './home.component';
+import { HomeComponent } from './home.component';
 
-import {
-    ContentBlockResolver,
-    VendorListResolver
-} from './home.resolver.service';
+import { ContentBlockResolver, VendorListResolver } from './home.resolver.service';
 
 const homeRoutes: Routes = [
     {
@@ -22,21 +12,14 @@ const homeRoutes: Routes = [
         component: HomeComponent,
         resolve: {
             vendors: VendorListResolver,
-            contentBlocks: ContentBlockResolver
-        }
-    }
+            contentBlocks: ContentBlockResolver,
+        },
+    },
 ];
 
 @NgModule({
-    imports: [
-        RouterModule.forChild(homeRoutes)
-    ],
-    exports: [
-        RouterModule,
-    ],
-    providers: [
-        VendorListResolver,
-        ContentBlockResolver
-    ]
+    imports: [RouterModule.forChild(homeRoutes)],
+    exports: [RouterModule],
+    providers: [VendorListResolver, ContentBlockResolver],
 })
-export class HomeRoutingModule { }
+export class HomeRoutingModule {}

--- a/galaxyui/src/app/home/popular/popular.component.ts
+++ b/galaxyui/src/app/home/popular/popular.component.ts
@@ -1,15 +1,8 @@
-import {
-    Component,
-    OnInit
-} from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
-import {
-    Router
-} from '@angular/router';
+import { Router } from '@angular/router';
 
-import {
-    ContentTypes
-} from '../../enums/content-types.enum';
+import { ContentTypes } from '../../enums/content-types.enum';
 
 class Category {
     name: string;
@@ -17,60 +10,57 @@ class Category {
 }
 
 @Component({
-    selector:    'popular-component',
+    selector: 'popular-component',
     templateUrl: './popular.component.html',
-    styleUrls:   ['./popular.component.less']
+    styleUrls: ['./popular.component.less'],
 })
 export class PopularComponent implements OnInit {
-
     categories: Category[] = [];
 
-    constructor(
-        private router: Router
-    ) {}
+    constructor(private router: Router) {}
 
     ngOnInit() {
         this.categories = [
             {
                 name: 'System',
-                iconClass: 'fa fa-desktop'
+                iconClass: 'fa fa-desktop',
             },
             {
                 name: 'Development',
-                iconClass: 'fa fa-code'
+                iconClass: 'fa fa-code',
             },
             {
                 name: 'Networking',
-                iconClass: 'fa fa-sitemap'
+                iconClass: 'fa fa-sitemap',
             },
             {
                 name: 'Cloud',
-                iconClass: 'fa fa-cloud-upload'
+                iconClass: 'fa fa-cloud-upload',
             },
             {
                 name: 'Database',
-                iconClass: 'fa fa-database'
+                iconClass: 'fa fa-database',
             },
             {
                 name: 'Monitoring',
-                iconClass: 'fa fa-bar-chart'
+                iconClass: 'fa fa-bar-chart',
             },
             {
                 name: 'Packaging',
-                iconClass: 'fa fa-cube'
+                iconClass: 'fa fa-cube',
             },
             {
                 name: 'Playbook Bundles',
-                iconClass: 'pficon-bundle'
+                iconClass: 'pficon-bundle',
             },
             {
                 name: 'Security',
-                iconClass: 'fa fa-lock'
+                iconClass: 'fa fa-lock',
             },
             {
                 name: 'Web',
-                iconClass: 'fa fa-globe'
-            }
+                iconClass: 'fa fa-globe',
+            },
         ] as Category[];
     }
 
@@ -81,7 +71,6 @@ export class PopularComponent implements OnInit {
         } else {
             params['tags'] = category.name.toLowerCase();
         }
-        this.router.navigate(['/', 'search'], {queryParams: params});
+        this.router.navigate(['/', 'search'], { queryParams: params });
     }
-
 }

--- a/galaxyui/src/app/login/login.component.spec.ts
+++ b/galaxyui/src/app/login/login.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { HomeComponent } from './home.component';
 
 describe('HomeComponent', () => {
-  let component: HomeComponent;
-  let fixture: ComponentFixture<HomeComponent>;
+    let component: HomeComponent;
+    let fixture: ComponentFixture<HomeComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ HomeComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [HomeComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(HomeComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(HomeComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/login/login.component.ts
+++ b/galaxyui/src/app/login/login.component.ts
@@ -16,19 +16,11 @@
  * along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
  */
 
-import {
-    Component,
-    OnInit
-} from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
-import {
-    ActivatedRoute,
-    ParamMap
-} from '@angular/router';
+import { ActivatedRoute, ParamMap } from '@angular/router';
 
-import {
-    CardConfig
-} from 'patternfly-ng/card/basic-card/card-config';
+import { CardConfig } from 'patternfly-ng/card/basic-card/card-config';
 
 import { Observable } from 'rxjs/Observable';
 
@@ -37,39 +29,34 @@ import 'rxjs/add/operator/switchMap';
 import { AuthService } from '../auth/auth.service';
 
 @Component({
-    selector:    'login',
+    selector: 'login',
     templateUrl: './login.component.html',
-    styleUrls:   ['./login.component.less']
+    styleUrls: ['./login.component.less'],
 })
 export class LoginComponent implements OnInit {
-
     config: CardConfig;
     msgText = 'Log into Galaxy by clicking on one of the above SCMs';
     connectingMsg = '';
     errorParam: Observable<boolean>;
     redirectUrl: string = null;
 
-    constructor(
-        private authService: AuthService,
-        private route: ActivatedRoute,
-    ) {}
+    constructor(private authService: AuthService, private route: ActivatedRoute) {}
 
     ngOnInit() {
         this.config = {
             noPadding: true,
-            topBorder: false
+            topBorder: false,
         } as CardConfig;
 
         this.redirectUrl = this.authService.redirectUrl;
 
-        this.errorParam = this.route.paramMap
-            .switchMap((params: ParamMap) => {
-                return new Observable<boolean>(observer => {
-                    return observer.next((params.get('error') === 'true') ? true : false);
-                });
+        this.errorParam = this.route.paramMap.switchMap((params: ParamMap) => {
+            return new Observable<boolean>(observer => {
+                return observer.next(params.get('error') === 'true' ? true : false);
             });
+        });
 
-        this.errorParam.subscribe((result) => {
+        this.errorParam.subscribe(result => {
             if (result) {
                 this.msgText = 'To view the selected page, you must first log into Galaxy by clicking on one of the above SCMs';
             } else {

--- a/galaxyui/src/app/login/login.module.ts
+++ b/galaxyui/src/app/login/login.module.ts
@@ -1,27 +1,14 @@
-import {
-    NgModule
-} from '@angular/core';
+import { NgModule } from '@angular/core';
 
-import {
-    LoginComponent
-} from './login.component';
+import { LoginComponent } from './login.component';
 
-import {
-    LoginRoutingModule
-} from './login.routing.module';
+import { LoginRoutingModule } from './login.routing.module';
 
-import {
-    CardModule
-} from 'patternfly-ng/card/basic-card/card.module';
+import { CardModule } from 'patternfly-ng/card/basic-card/card.module';
 
 @NgModule({
-    declarations: [
-        LoginComponent
-    ],
-    imports: [
-        CardModule,
-        LoginRoutingModule
-    ],
-    providers: []
+    declarations: [LoginComponent],
+    imports: [CardModule, LoginRoutingModule],
+    providers: [],
 })
-export class LoginModule { }
+export class LoginModule {}

--- a/galaxyui/src/app/login/login.routing.module.ts
+++ b/galaxyui/src/app/login/login.routing.module.ts
@@ -1,30 +1,19 @@
-import {
-    NgModule
-} from '@angular/core';
+import { NgModule } from '@angular/core';
 
-import {
-    RouterModule,
-    Routes
-} from '@angular/router';
+import { RouterModule, Routes } from '@angular/router';
 
-import {
-    LoginComponent
-} from './login.component';
+import { LoginComponent } from './login.component';
 
 const loginRoutes: Routes = [
     {
         path: 'login',
-        component: LoginComponent
-    }
+        component: LoginComponent,
+    },
 ];
 
 @NgModule({
-    imports: [
-        RouterModule.forChild(loginRoutes)
-    ],
-    exports: [
-        RouterModule,
-    ],
-    providers: []
+    imports: [RouterModule.forChild(loginRoutes)],
+    exports: [RouterModule],
+    providers: [],
 })
-export class LoginRoutingModule { }
+export class LoginRoutingModule {}

--- a/galaxyui/src/app/my-content/add-repository-modal/add-repository-modal.component.spec.ts
+++ b/galaxyui/src/app/my-content/add-repository-modal/add-repository-modal.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { AddRepositoryModalComponent } from './add-repository-modal.component';
 
 describe('AddRepositoryModalComponent', () => {
-  let component: AddRepositoryModalComponent;
-  let fixture: ComponentFixture<AddRepositoryModalComponent>;
+    let component: AddRepositoryModalComponent;
+    let fixture: ComponentFixture<AddRepositoryModalComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ AddRepositoryModalComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [AddRepositoryModalComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AddRepositoryModalComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(AddRepositoryModalComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/my-content/add-repository-modal/add-repository-modal.component.ts
+++ b/galaxyui/src/app/my-content/add-repository-modal/add-repository-modal.component.ts
@@ -1,22 +1,19 @@
-import {
-    Component,
-    OnInit
-} from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
-import { EmptyStateConfig }        from 'patternfly-ng/empty-state/empty-state-config';
-import { ListConfig }              from 'patternfly-ng/list/basic-list/list-config';
-import { ListEvent }               from 'patternfly-ng/list/list-event';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state/empty-state-config';
+import { ListConfig } from 'patternfly-ng/list/basic-list/list-config';
+import { ListEvent } from 'patternfly-ng/list/list-event';
 
-import { cloneDeep }               from 'lodash';
-import { BsModalRef }              from 'ngx-bootstrap';
+import { cloneDeep } from 'lodash';
+import { BsModalRef } from 'ngx-bootstrap';
 
-import { Observable }              from 'rxjs/Observable';
-import { forkJoin }                from 'rxjs/observable/forkJoin';
+import { Observable } from 'rxjs/Observable';
+import { forkJoin } from 'rxjs/observable/forkJoin';
 
-import { Namespace }               from '../../resources/namespaces/namespace';
-import { ProviderSourceService }   from '../../resources/provider-namespaces/provider-source.service';
-import { Repository }              from '../../resources/repositories/repository';
-import { RepositoryService }       from '../../resources/repositories/repository.service';
+import { Namespace } from '../../resources/namespaces/namespace';
+import { ProviderSourceService } from '../../resources/provider-namespaces/provider-source.service';
+import { Repository } from '../../resources/repositories/repository';
+import { RepositoryService } from '../../resources/repositories/repository.service';
 
 class RepositorySource {
     name: string;
@@ -53,10 +50,9 @@ class ProviderNamespace {
 @Component({
     selector: 'add-repository-modal',
     templateUrl: './add-repository-modal.component.html',
-    styleUrls: ['./add-repository-modal.component.less']
+    styleUrls: ['./add-repository-modal.component.less'],
 })
 export class AddRepositoryModalComponent implements OnInit {
-
     emptyStateConfig: EmptyStateConfig = {} as EmptyStateConfig;
     namespace: Namespace;
     selectedPNS: ProviderNamespace;
@@ -71,7 +67,7 @@ export class AddRepositoryModalComponent implements OnInit {
     constructor(
         public bsModalRef: BsModalRef,
         private repositoryService: RepositoryService,
-        private providerSourceService: ProviderSourceService
+        private providerSourceService: ProviderSourceService,
     ) {}
 
     ngOnInit() {
@@ -93,7 +89,7 @@ export class AddRepositoryModalComponent implements OnInit {
             showCheckbox: true,
             showRadioButton: false,
             useExpandItems: false,
-            emptyStateConfig: this.emptyStateConfig
+            emptyStateConfig: this.emptyStateConfig,
         } as ListConfig;
 
         this.getRepoSources();
@@ -107,8 +103,9 @@ export class AddRepositoryModalComponent implements OnInit {
     filterRepos(filterValue: string) {
         if (filterValue) {
             this.filterValue = filterValue;
-            this.selectedPNS.filteredSources = this.selectedPNS.repoSources.filter(
-                repo => repo.name.toLowerCase().match(filterValue.toLowerCase()));
+            this.selectedPNS.filteredSources = this.selectedPNS.repoSources.filter(repo =>
+                repo.name.toLowerCase().match(filterValue.toLowerCase()),
+            );
         } else {
             this.filterValue = '';
             this.selectedPNS.filteredSources = this.selectedPNS.repoSources;
@@ -138,8 +135,7 @@ export class AddRepositoryModalComponent implements OnInit {
         this.repositoriesAdded = true;
         this.saveInProgress = true;
         const saveRequests: Observable<Repository>[] = [];
-        const selected: RepositorySource[] = this.selectedPNS.repoSources
-            .filter((repoSource) => repoSource.isSelected);
+        const selected: RepositorySource[] = this.selectedPNS.repoSources.filter(repoSource => repoSource.isSelected);
 
         if (!selected.length) {
             // nothing was selected
@@ -150,14 +146,14 @@ export class AddRepositoryModalComponent implements OnInit {
         }
 
         selected.forEach(repoSource => {
-                const newRepo = new Repository();
-                newRepo.name = repoSource.name;
-                newRepo.original_name = repoSource.name;
-                newRepo.description = repoSource.description ? repoSource.description : repoSource.name;
-                newRepo.provider_namespace = this.selectedPNS.id;
-                newRepo.is_enabled = true;
-                saveRequests.push(this.repositoryService.save(newRepo));
-            });
+            const newRepo = new Repository();
+            newRepo.name = repoSource.name;
+            newRepo.original_name = repoSource.name;
+            newRepo.description = repoSource.description ? repoSource.description : repoSource.name;
+            newRepo.provider_namespace = this.selectedPNS.id;
+            newRepo.is_enabled = true;
+            saveRequests.push(this.repositoryService.save(newRepo));
+        });
 
         forkJoin(saveRequests).subscribe((results: Repository[]) => {
             this.saveInProgress = false;
@@ -184,18 +180,20 @@ export class AddRepositoryModalComponent implements OnInit {
             this.setLoadingStateConfig();
             this.selectedPNS.repoSources = [];
             this.selectedPNS.filteredSources = [];
-            this.providerSourceService.getRepoSources({
-                providerName: this.selectedPNS.provider_name,
-                name: this.selectedPNS.name
-            }).subscribe(repoSources => {
-                repoSources.forEach(repoSource => {
-                    if (!repoSource.summary_fields.repository) {
-                        this.selectedPNS.repoSources.push(repoSource as RepositorySource);
-                    }
+            this.providerSourceService
+                .getRepoSources({
+                    providerName: this.selectedPNS.provider_name,
+                    name: this.selectedPNS.name,
+                })
+                .subscribe(repoSources => {
+                    repoSources.forEach(repoSource => {
+                        if (!repoSource.summary_fields.repository) {
+                            this.selectedPNS.repoSources.push(repoSource as RepositorySource);
+                        }
+                    });
+                    this.filterRepos(this.filterValue);
+                    this.setEmptyStateConfig();
                 });
-                this.filterRepos(this.filterValue);
-                this.setEmptyStateConfig();
-            });
         } else {
             this.filterRepos(this.filterValue);
             this.setEmptyStateConfig();

--- a/galaxyui/src/app/my-content/my-content.module.ts
+++ b/galaxyui/src/app/my-content/my-content.module.ts
@@ -1,57 +1,46 @@
 import { CommonModule } from '@angular/common';
-import { NgModule }     from '@angular/core';
+import { NgModule } from '@angular/core';
 
-import {
-    FormsModule,
-    ReactiveFormsModule
-} from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { MyContentRoutingModule } from './my-content.routing.module';
 
-import {
-    BsDropdownConfig,
-    BsDropdownModule
-} from 'ngx-bootstrap';
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap';
 
-import { TooltipModule }    from 'ngx-bootstrap/tooltip';
-import { ModalModule }      from 'patternfly-ng';
-import { ActionModule }     from 'patternfly-ng/action/action.module';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ModalModule } from 'patternfly-ng';
+import { ActionModule } from 'patternfly-ng/action/action.module';
 import { EmptyStateModule } from 'patternfly-ng/empty-state/empty-state.module';
-import { FilterModule }     from 'patternfly-ng/filter/filter.module';
-import { ListModule }       from 'patternfly-ng/list/basic-list/list.module';
+import { FilterModule } from 'patternfly-ng/filter/filter.module';
+import { ListModule } from 'patternfly-ng/list/basic-list/list.module';
 import { PaginationModule } from 'patternfly-ng/pagination/pagination.module';
-import { ToolbarModule }    from 'patternfly-ng/toolbar/toolbar.module';
+import { ToolbarModule } from 'patternfly-ng/toolbar/toolbar.module';
 
-import { NamespaceDetailComponent }           from './namespace-detail/namespace-detail.component';
-import { OwnersContentComponent }             from './namespace-list/content/owners-content/owners-content.component';
-import { RepositoriesContentComponent }       from './namespace-list/content/repositories-content/repositories-content.component';
-import { NamespaceListComponent }             from './namespace-list/namespace-list.component';
+import { NamespaceDetailComponent } from './namespace-detail/namespace-detail.component';
+import { OwnersContentComponent } from './namespace-list/content/owners-content/owners-content.component';
+import { RepositoriesContentComponent } from './namespace-list/content/repositories-content/repositories-content.component';
+import { NamespaceListComponent } from './namespace-list/namespace-list.component';
 
+// prettier-ignore
 import {
     ProviderNamespacesContentComponent
 } from './namespace-list/content/provider-namespaces-content/provider-namespaces-content.component';
 
-import {
-    AddRepositoryModalComponent
-} from './add-repository-modal/add-repository-modal.component';
+import { AddRepositoryModalComponent } from './add-repository-modal/add-repository-modal.component';
 
+// prettier-ignore
 import {
     AlternateNameModalComponent
 } from './namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component';
 
-import { PageHeaderModule }                   from '../page-header/page-header.module';
-import { PageLoadingModule }                  from '../page-loading/page-loading.module';
-import { NamespaceActionComponent }           from './namespace-list/action/action.component';
+import { PageHeaderModule } from '../page-header/page-header.module';
+import { PageLoadingModule } from '../page-loading/page-loading.module';
+import { NamespaceActionComponent } from './namespace-list/action/action.component';
 
-import {
-    NamespaceRepositoryActionComponent
-} from './namespace-list/content/repositories-content/action/action.component';
+import { NamespaceRepositoryActionComponent } from './namespace-list/content/repositories-content/action/action.component';
 
 @NgModule({
-    entryComponents: [
-        AddRepositoryModalComponent,
-        AlternateNameModalComponent,
-    ],
+    entryComponents: [AddRepositoryModalComponent, AlternateNameModalComponent],
     declarations: [
         NamespaceListComponent,
         NamespaceDetailComponent,
@@ -61,7 +50,7 @@ import {
         AddRepositoryModalComponent,
         AlternateNameModalComponent,
         NamespaceActionComponent,
-        NamespaceRepositoryActionComponent
+        NamespaceRepositoryActionComponent,
     ],
     imports: [
         ActionModule,
@@ -78,11 +67,8 @@ import {
         PaginationModule,
         PageHeaderModule,
         PageLoadingModule,
-        MyContentRoutingModule
+        MyContentRoutingModule,
     ],
-    providers: [
-        BsDropdownConfig
-    ]
+    providers: [BsDropdownConfig],
 })
-export class MyContentModule {
-}
+export class MyContentModule {}

--- a/galaxyui/src/app/my-content/my-content.routing.module.ts
+++ b/galaxyui/src/app/my-content/my-content.routing.module.ts
@@ -1,27 +1,21 @@
-import { NgModule }                 from '@angular/core';
+import { NgModule } from '@angular/core';
 
-import {
-    RouterModule,
-    Routes
-} from '@angular/router';
+import { RouterModule, Routes } from '@angular/router';
 
-import { AuthService }              from '../auth/auth.service';
+import { AuthService } from '../auth/auth.service';
 import { NamespaceDetailComponent } from './namespace-detail/namespace-detail.component';
 
-import {
-    MeResolver,
-    NamespaceDetailResolver
-}  from './namespace-detail/namespace-detail.resolver.service';
+import { MeResolver, NamespaceDetailResolver } from './namespace-detail/namespace-detail.resolver.service';
 
-import { NamespaceListResolver }    from './namespace-list/namespace-list-resolver.service';
-import { NamespaceListComponent }   from './namespace-list/namespace-list.component';
+import { NamespaceListResolver } from './namespace-list/namespace-list-resolver.service';
+import { NamespaceListComponent } from './namespace-list/namespace-list.component';
 
 const myContentRoutes: Routes = [
     {
         path: '',
         redirectTo: 'namespaces',
         pathMatch: 'full',
-        canActivate: [AuthService]
+        canActivate: [AuthService],
     },
     {
         path: 'namespaces/new',
@@ -31,9 +25,9 @@ const myContentRoutes: Routes = [
             namespace: NamespaceDetailResolver,
         },
         data: {
-            expectedRole: 'isStaff'
+            expectedRole: 'isStaff',
         },
-        canActivate: [AuthService]
+        canActivate: [AuthService],
     },
     {
         path: 'namespaces/:id',
@@ -42,31 +36,22 @@ const myContentRoutes: Routes = [
             me: MeResolver,
             namespace: NamespaceDetailResolver,
         },
-        canActivate: [AuthService]
+        canActivate: [AuthService],
     },
     {
         path: 'namespaces',
         component: NamespaceListComponent,
         resolve: {
             me: MeResolver,
-            namespaces: NamespaceListResolver
+            namespaces: NamespaceListResolver,
         },
-        canActivate: [AuthService]
-    }
+        canActivate: [AuthService],
+    },
 ];
 
 @NgModule({
-    imports: [
-        RouterModule.forChild(myContentRoutes)
-    ],
-    exports: [
-        RouterModule,
-    ],
-    providers: [
-        NamespaceDetailResolver,
-        NamespaceListResolver,
-        MeResolver
-    ]
+    imports: [RouterModule.forChild(myContentRoutes)],
+    exports: [RouterModule],
+    providers: [NamespaceDetailResolver, NamespaceListResolver, MeResolver],
 })
-export class MyContentRoutingModule {
-}
+export class MyContentRoutingModule {}

--- a/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NamespaceDetailComponent } from './namespace-detail.component';
 
 describe('NamespaceDetailComponent', () => {
-  let component: NamespaceDetailComponent;
-  let fixture: ComponentFixture<NamespaceDetailComponent>;
+    let component: NamespaceDetailComponent;
+    let fixture: ComponentFixture<NamespaceDetailComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ NamespaceDetailComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [NamespaceDetailComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(NamespaceDetailComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(NamespaceDetailComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.ts
+++ b/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.ts
@@ -1,32 +1,24 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { cloneDeep } from 'lodash';
 
-import {
-    FormBuilder,
-    FormGroup,
-    Validators
-} from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
-import { FilterConfig }          from 'patternfly-ng/filter/filter-config';
-import { FilterEvent }           from 'patternfly-ng/filter/filter-event';
-import { FilterField }           from 'patternfly-ng/filter/filter-field';
-import { FilterType }            from 'patternfly-ng/filter/filter-type';
+import { FilterConfig } from 'patternfly-ng/filter/filter-config';
+import { FilterEvent } from 'patternfly-ng/filter/filter-event';
+import { FilterField } from 'patternfly-ng/filter/filter-field';
+import { FilterType } from 'patternfly-ng/filter/filter-type';
 
-import { IMe }                   from '../../auth/auth.service';
-import { Namespace }             from '../../resources/namespaces/namespace';
-import { NamespaceService }      from '../../resources/namespaces/namespace.service';
-import { ProviderNamespace }     from '../../resources/provider-namespaces/provider-namespace';
-import { ProviderSource }        from '../../resources/provider-namespaces/provider-source';
+import { IMe } from '../../auth/auth.service';
+import { Namespace } from '../../resources/namespaces/namespace';
+import { NamespaceService } from '../../resources/namespaces/namespace.service';
+import { ProviderNamespace } from '../../resources/provider-namespaces/provider-namespace';
+import { ProviderSource } from '../../resources/provider-namespaces/provider-source';
 import { ProviderSourceService } from '../../resources/provider-namespaces/provider-source.service';
-import { User }                  from '../../resources/users/user';
-import { UserService }           from '../../resources/users/user.service';
+import { User } from '../../resources/users/user';
+import { UserService } from '../../resources/users/user.service';
 
 class Owner {
     username: string;
@@ -53,10 +45,9 @@ class Source {
 @Component({
     selector: 'app-namespace-detail',
     templateUrl: './namespace-detail.component.html',
-    styleUrls: ['./namespace-detail.component.less']
+    styleUrls: ['./namespace-detail.component.less'],
 })
 export class NamespaceDetailComponent implements OnInit {
-
     @Input()
     set namespace(data: Namespace) {
         this._namespace = data;
@@ -91,64 +82,64 @@ export class NamespaceDetailComponent implements OnInit {
         private formBuilder: FormBuilder,
         private namespaceService: NamespaceService,
         private userService: UserService,
-        private providerSourceService: ProviderSourceService
+        private providerSourceService: ProviderSourceService,
     ) {}
 
     ngOnInit() {
-        this.route.data
-            .subscribe(data => {
-                this.me = data['me'];
-                this.namespace = new Namespace();
-                this.pageLoading = false;
-                if (data['namespace']) {
-                    this.namespace = data['namespace'];
-                    if (this.namespace && this.namespace['summary_fields']) {
-                        this.selectedUsers = this.namespace.summary_fields['owners'] as Owner[];
-                        this.selectedNamespaces = this.namespace.summary_fields['provider_namespaces'] as Source[];
-                        this.pageTitle = 'My Content;/my-content;Edit Namespace';
-                    } else {
-                        // Requested namespace not found
-                        this.router.navigate(['/not-found']);
-                    }
+        this.route.data.subscribe(data => {
+            this.me = data['me'];
+            this.namespace = new Namespace();
+            this.pageLoading = false;
+            if (data['namespace']) {
+                this.namespace = data['namespace'];
+                if (this.namespace && this.namespace['summary_fields']) {
+                    this.selectedUsers = this.namespace.summary_fields['owners'] as Owner[];
+                    this.selectedNamespaces = this.namespace.summary_fields['provider_namespaces'] as Source[];
+                    this.pageTitle = 'My Content;/my-content;Edit Namespace';
+                } else {
+                    // Requested namespace not found
+                    this.router.navigate(['/not-found']);
                 }
-                this.createForm();
-                this.getUsers();
-                this.getProviderSources();
-            });
+            }
+            this.createForm();
+            this.getUsers();
+            this.getProviderSources();
+        });
 
         this.namespaceFilterConfig = {
-            fields: [{
-                id: 'name',
-                title: 'Name',
-                placeholder: 'Filter by Name',
-                type: FilterType.TEXT
-            }] as FilterField[],
+            fields: [
+                {
+                    id: 'name',
+                    title: 'Name',
+                    placeholder: 'Filter by Name',
+                    type: FilterType.TEXT,
+                },
+            ] as FilterField[],
             resultsCount: 0,
-            appliedFilters: []
+            appliedFilters: [],
         } as FilterConfig;
 
         this.userFilterConfig = {
-            fields: [{
-                id: 'name',
-                title: 'Name',
-                placeholder: 'Filter by Name',
-                type: FilterType.TEXT
-            }] as FilterField[],
+            fields: [
+                {
+                    id: 'name',
+                    title: 'Name',
+                    placeholder: 'Filter by Name',
+                    type: FilterType.TEXT,
+                },
+            ] as FilterField[],
             resultsCount: 0,
-            appliedFilters: []
+            appliedFilters: [],
         } as FilterConfig;
     }
 
     saveNamespace($event) {
         const namespace: Namespace = this.prepareSaveNamespace();
-        this.namespaceService.save(namespace)
-            .subscribe(
-                result => {
-                    if (!this.namespaceService.encounteredErrors) {
-                        this.router.navigate(['/my-content']);
-                    }
-                }
-            );
+        this.namespaceService.save(namespace).subscribe(result => {
+            if (!this.namespaceService.encounteredErrors) {
+                this.router.navigate(['/my-content']);
+            }
+        });
     }
 
     toggleUser(id: number): void {
@@ -267,7 +258,7 @@ export class NamespaceDetailComponent implements OnInit {
             avatar_url: [this.namespace.avatar_url],
             email: [this.namespace.email],
             html_url: [this.namespace.html_url],
-            namespaceType: (this.namespace.is_vendor) ? ['vendor'] : ['community']
+            namespaceType: this.namespace.is_vendor ? ['vendor'] : ['community'],
         });
         if (!this.me.staff) {
             this.namespaceForm.controls['namespaceType'].disable();
@@ -277,26 +268,20 @@ export class NamespaceDetailComponent implements OnInit {
 
     private getUsers(params?: any): void {
         this.usersLoading = true;
-        this.userService.query(params)
-            .subscribe(
-                users => {
-                    this.users = this.prepUsersForList(users);
-                    this.userFilterConfig.resultsCount = this.users.length;
-                    this.usersLoading = false;
-                }
-            );
+        this.userService.query(params).subscribe(users => {
+            this.users = this.prepUsersForList(users);
+            this.userFilterConfig.resultsCount = this.users.length;
+            this.usersLoading = false;
+        });
     }
 
     private getProviderSources(): void {
         this.namespacesLoading = true;
-        this.providerSourceService.query()
-            .subscribe(
-                providerSources => {
-                    this.providerSources = this.prepProviderSourcesForList(providerSources);
-                    this.providerSourcesFiltered = this.providerSources;
-                    this.namespacesLoading = false;
-                }
-            );
+        this.providerSourceService.query().subscribe(providerSources => {
+            this.providerSources = this.prepProviderSourcesForList(providerSources);
+            this.providerSourcesFiltered = this.providerSources;
+            this.namespacesLoading = false;
+        });
     }
 
     private prepUsersForList(users: User[]): User[] {
@@ -346,7 +331,7 @@ export class NamespaceDetailComponent implements OnInit {
         ns.email = formModel.email as string;
         ns.html_url = formModel.html_url as string;
         ns.active = true;
-        ns.is_vendor = (formModel.namespaceType === 'vendor') ? true : false;
+        ns.is_vendor = formModel.namespaceType === 'vendor' ? true : false;
 
         const owners: User[] = [];
         const pns: ProviderNamespace[] = [];

--- a/galaxyui/src/app/my-content/namespace-detail/namespace-detail.resolver.service.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-detail/namespace-detail.resolver.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { NamespaceDetailResolver } from './namespace-detail-resolver.service';
 
 describe('NamespaceDetailResolver', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [NamespaceDetailResolver]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [NamespaceDetailResolver],
+        });
     });
-  });
 
-  it('should be created', inject([NamespaceDetailResolver], (service: NamespaceDetailResolver) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([NamespaceDetailResolver], (service: NamespaceDetailResolver) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/my-content/namespace-detail/namespace-detail.resolver.service.ts
+++ b/galaxyui/src/app/my-content/namespace-detail/namespace-detail.resolver.service.ts
@@ -1,29 +1,19 @@
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/take';
 
-import { Injectable }        from '@angular/core';
-import { Observable }        from 'rxjs/Observable';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
 
-import {
-    ActivatedRouteSnapshot,
-    Resolve,
-    Router,
-    RouterStateSnapshot
-} from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve, Router, RouterStateSnapshot } from '@angular/router';
 
-import { Namespace }         from '../../resources/namespaces/namespace';
-import { NamespaceService }  from '../../resources/namespaces/namespace.service';
+import { Namespace } from '../../resources/namespaces/namespace';
+import { NamespaceService } from '../../resources/namespaces/namespace.service';
 
-import {
-    AuthService,
-    IMe
-} from '../../auth/auth.service';
+import { AuthService, IMe } from '../../auth/auth.service';
 
 @Injectable()
 export class NamespaceDetailResolver implements Resolve<Namespace> {
-    constructor(
-        private namespaceService: NamespaceService,
-        private router: Router) {}
+    constructor(private namespaceService: NamespaceService, private router: Router) {}
 
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Namespace> {
         const id = route.paramMap.get('id');
@@ -32,22 +22,23 @@ export class NamespaceDetailResolver implements Resolve<Namespace> {
             return null;
         }
 
-        return this.namespaceService.get(Number(id)).take(1).map(namespace => {
-            if (namespace) {
-                return namespace;
-            } else {
-                this.router.navigate(['/my-content/namespaces/new']);
-                return null;
-            }
-        });
+        return this.namespaceService
+            .get(Number(id))
+            .take(1)
+            .map(namespace => {
+                if (namespace) {
+                    return namespace;
+                } else {
+                    this.router.navigate(['/my-content/namespaces/new']);
+                    return null;
+                }
+            });
     }
 }
 
 @Injectable()
 export class MeResolver implements Resolve<IMe> {
-    constructor(
-        private authService: AuthService,
-    ) {}
+    constructor(private authService: AuthService) {}
 
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<IMe> {
         return this.authService.me();

--- a/galaxyui/src/app/my-content/namespace-list/action/action.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/action/action.component.ts
@@ -1,29 +1,20 @@
-import {
-    Component,
-    EventEmitter,
-    Input,
-    OnInit,
-    Output,
-    TemplateRef,
-    ViewChild,
-    ViewEncapsulation
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
 
-import { Action }           from 'patternfly-ng/action/action';
-import { ActionConfig }     from 'patternfly-ng/action/action-config';
+import { Action } from 'patternfly-ng/action/action';
+import { ActionConfig } from 'patternfly-ng/action/action-config';
 
-import { AuthService }      from '../../../auth/auth.service';
-import { Namespace }        from '../../../resources/namespaces/namespace';
+import { AuthService } from '../../../auth/auth.service';
+import { Namespace } from '../../../resources/namespaces/namespace';
 
 @Component({
     encapsulation: ViewEncapsulation.None,
     selector: 'namespace-action',
     templateUrl: './action.component.html',
-    styleUrls: ['./action.component.less']
+    styleUrls: ['./action.component.less'],
 })
 export class NamespaceActionComponent implements OnInit {
-
-    @ViewChild('addContentButtonTemplate') public buttonTemplate: TemplateRef<any>;
+    @ViewChild('addContentButtonTemplate')
+    public buttonTemplate: TemplateRef<any>;
 
     @Input()
     set namespace(data: Namespace) {
@@ -34,68 +25,72 @@ export class NamespaceActionComponent implements OnInit {
         return this._namespace;
     }
 
-    @Output() handleAction = new EventEmitter<any>();
+    @Output()
+    handleAction = new EventEmitter<any>();
 
     _namespace: Namespace;
     actionConfig: ActionConfig;
 
-    constructor(
-        private authService: AuthService
-    ) {}
+    constructor(private authService: AuthService) {}
 
     ngOnInit(): void {
         const provider_namespaces = this.namespace['summary_fields']['provider_namespaces'];
 
         let primaryTooltip = 'Add yor Ansible content repositories';
         if (!this.namespace.active) {
-             primaryTooltip = 'Namespace is disabled';
+            primaryTooltip = 'Namespace is disabled';
         }
         if (!provider_namespaces.length) {
-             primaryTooltip = 'Missing provider namespaces';
+            primaryTooltip = 'Missing provider namespaces';
         }
 
         this.actionConfig = {
-            primaryActions: [{
-                id: 'addContent',
-                title: 'Add Content',
-                styleClass: 'btn-primary',
-                tooltip: primaryTooltip,
-                template: this.buttonTemplate,
-                disabled: !this.namespace.active || !provider_namespaces.length
-            }] as Action[],
-            moreActions: [{
-                id: 'enableNamespace',
-                title: 'Enable',
-                styleClass: 'btn-default',
-                tooltip: 'Enable namespace',
-                visible: !this.namespace.active
-            },
-            {
-                id: 'editNamespaceProps',
-                title: 'Edit Properties',
-                tooltip: 'Edit namespace properties'
-            },
-            {
-                id: 'disableNamespace',
-                title: 'Disable',
-                tooltip: 'Disable namespace',
-                visible: this.namespace.active
-            }, {
-                id: 'deleteNamespace',
-                title: 'Delete',
-                tooltip: 'Delete namespace',
-                visible: this.authService.meCache.staff
-            }] as Action[],
+            primaryActions: [
+                {
+                    id: 'addContent',
+                    title: 'Add Content',
+                    styleClass: 'btn-primary',
+                    tooltip: primaryTooltip,
+                    template: this.buttonTemplate,
+                    disabled: !this.namespace.active || !provider_namespaces.length,
+                },
+            ] as Action[],
+            moreActions: [
+                {
+                    id: 'enableNamespace',
+                    title: 'Enable',
+                    styleClass: 'btn-default',
+                    tooltip: 'Enable namespace',
+                    visible: !this.namespace.active,
+                },
+                {
+                    id: 'editNamespaceProps',
+                    title: 'Edit Properties',
+                    tooltip: 'Edit namespace properties',
+                },
+                {
+                    id: 'disableNamespace',
+                    title: 'Disable',
+                    tooltip: 'Disable namespace',
+                    visible: this.namespace.active,
+                },
+                {
+                    id: 'deleteNamespace',
+                    title: 'Delete',
+                    tooltip: 'Delete namespace',
+                    visible: this.authService.meCache.staff,
+                },
+            ] as Action[],
             moreActionsDisabled: false,
             moreActionsVisible: true,
-            moreActionsStyleClass: ''
+            moreActionsStyleClass: '',
         } as ActionConfig;
     }
 
     handleListAction($event: Action) {
         const event = {
             id: $event.id,
-            item: this.namespace
+            item: this.namespace,
         };
         this.handleAction.emit(event);
     }

--- a/galaxyui/src/app/my-content/namespace-list/content/owners-content/owners-content.component.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/owners-content/owners-content.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { OwnersContentComponent } from './owners-content.component';
 
 describe('OwnersContentComponent', () => {
-  let component: OwnersContentComponent;
-  let fixture: ComponentFixture<OwnersContentComponent>;
+    let component: OwnersContentComponent;
+    let fixture: ComponentFixture<OwnersContentComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ OwnersContentComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [OwnersContentComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(OwnersContentComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(OwnersContentComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/my-content/namespace-list/content/owners-content/owners-content.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/owners-content/owners-content.component.ts
@@ -1,19 +1,17 @@
 import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
-import { Namespace }                                   from '../../../../resources/namespaces/namespace';
+import { Namespace } from '../../../../resources/namespaces/namespace';
 
 @Component({
     encapsulation: ViewEncapsulation.None,
     selector: 'owners-content',
     templateUrl: './owners-content.component.html',
-    styleUrls: ['./owners-content.component.less']
+    styleUrls: ['./owners-content.component.less'],
 })
 export class OwnersContentComponent implements OnInit {
-    @Input() namespace: Namespace;
+    @Input()
+    namespace: Namespace;
 
-    constructor() {
-    }
+    constructor() {}
 
-    ngOnInit() {
-    }
-
+    ngOnInit() {}
 }

--- a/galaxyui/src/app/my-content/namespace-list/content/provider-namespaces-content/provider-namespaces-content.component.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/provider-namespaces-content/provider-namespaces-content.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProviderNamespacesContentComponent } from './provider-namespaces-content.component';
 
 describe('ProviderNamespacesContentComponent', () => {
-  let component: ProviderNamespacesContentComponent;
-  let fixture: ComponentFixture<ProviderNamespacesContentComponent>;
+    let component: ProviderNamespacesContentComponent;
+    let fixture: ComponentFixture<ProviderNamespacesContentComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ ProviderNamespacesContentComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [ProviderNamespacesContentComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ProviderNamespacesContentComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(ProviderNamespacesContentComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/my-content/namespace-list/content/provider-namespaces-content/provider-namespaces-content.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/provider-namespaces-content/provider-namespaces-content.component.ts
@@ -1,20 +1,18 @@
 import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 
-import { Namespace }                                   from '../../../../resources/namespaces/namespace';
+import { Namespace } from '../../../../resources/namespaces/namespace';
 
 @Component({
     encapsulation: ViewEncapsulation.None,
     selector: 'provider-namespaces-content',
     templateUrl: './provider-namespaces-content.component.html',
-    styleUrls: ['./provider-namespaces-content.component.less']
+    styleUrls: ['./provider-namespaces-content.component.less'],
 })
 export class ProviderNamespacesContentComponent implements OnInit {
-    @Input() namespace: Namespace;
+    @Input()
+    namespace: Namespace;
 
-    constructor() {
-    }
+    constructor() {}
 
-    ngOnInit() {
-    }
-
+    ngOnInit() {}
 }

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/action/action.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/action/action.component.ts
@@ -1,28 +1,19 @@
-import {
-    Component,
-    EventEmitter,
-    Input,
-    OnInit,
-    Output,
-    TemplateRef,
-    ViewChild,
-    ViewEncapsulation
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
 
-import { Action }           from 'patternfly-ng/action/action';
-import { ActionConfig }     from 'patternfly-ng/action/action-config';
+import { Action } from 'patternfly-ng/action/action';
+import { ActionConfig } from 'patternfly-ng/action/action-config';
 
-import { Repository }        from '../../../../../resources/repositories/repository';
+import { Repository } from '../../../../../resources/repositories/repository';
 
 @Component({
     encapsulation: ViewEncapsulation.None,
     selector: 'namespace-repository-action',
     templateUrl: './action.component.html',
-    styleUrls: ['./action.component.less']
+    styleUrls: ['./action.component.less'],
 })
 export class NamespaceRepositoryActionComponent implements OnInit {
-
-    @ViewChild('importButtonTemplate') public buttonTemplate: TemplateRef<any>;
+    @ViewChild('importButtonTemplate')
+    public buttonTemplate: TemplateRef<any>;
 
     @Input()
     set repository(data: Repository) {
@@ -33,43 +24,48 @@ export class NamespaceRepositoryActionComponent implements OnInit {
         return this._repository;
     }
 
-    @Output() handleAction = new EventEmitter<any>();
+    @Output()
+    handleAction = new EventEmitter<any>();
 
     _repository: Repository;
     actionConfig: ActionConfig;
 
-    constructor(
-    ) {}
+    constructor() {}
 
     ngOnInit(): void {
         let importing = false;
-        if (this.repository['latest_import'] &&
-            (this.repository['latest_import']['state'] === 'PENDING' ||
-                this.repository['latest_import']['state'] === 'RUNNING')) {
+        if (
+            this.repository['latest_import'] &&
+            (this.repository['latest_import']['state'] === 'PENDING' || this.repository['latest_import']['state'] === 'RUNNING')
+        ) {
             importing = true;
         }
         this.actionConfig = {
-            primaryActions: [{
-                id: 'import',
-                title: 'Import',
-                tooltip: 'Import Repository',
-                template: this.buttonTemplate,
-                disabled: importing
-            }],
-            moreActions: [{
-                id: 'delete',
-                title: 'Delete',
-                tooltip: 'Delete Repository'
-            }],
+            primaryActions: [
+                {
+                    id: 'import',
+                    title: 'Import',
+                    tooltip: 'Import Repository',
+                    template: this.buttonTemplate,
+                    disabled: importing,
+                },
+            ],
+            moreActions: [
+                {
+                    id: 'delete',
+                    title: 'Delete',
+                    tooltip: 'Delete Repository',
+                },
+            ],
             moreActionsDisabled: false,
-            moreActionsVisible: !importing
+            moreActionsVisible: !importing,
         } as ActionConfig;
     }
 
     handleListAction($event: Action) {
         const event = {
             id: $event.id,
-            item: this.repository
+            item: this.repository,
         };
         this.handleAction.emit(event);
     }

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.spec.ts
@@ -1,23 +1,22 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 describe('AlternateNameModalComponent', () => {
-  let component: AlternateNameModalComponent;
-  let fixture: ComponentFixture<AlternateNameModalComponent>;
+    let component: AlternateNameModalComponent;
+    let fixture: ComponentFixture<AlternateNameModalComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ AlternateNameModalComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [AlternateNameModalComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AlternateNameModalComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(AlternateNameModalComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.ts
@@ -1,26 +1,18 @@
-import {
-    Component,
-    OnInit
-    } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
-import {
-    AbstractControl,
-    FormControl,
-    ValidatorFn,
-    Validators
-    } from '@angular/forms';
+import { AbstractControl, FormControl, ValidatorFn, Validators } from '@angular/forms';
 
-import { BsModalRef }              from 'ngx-bootstrap';
+import { BsModalRef } from 'ngx-bootstrap';
 
-import { Repository }              from '../../../../../resources/repositories/repository';
-import { RepositoryService }       from '../../../../../resources/repositories/repository.service';
+import { Repository } from '../../../../../resources/repositories/repository';
+import { RepositoryService } from '../../../../../resources/repositories/repository.service';
 import { RepositoryImportService } from '../../../../../resources/repository-imports/repository-import.service';
 
 export function forbiddenCharValidator(): ValidatorFn {
     const charRE = new RegExp('[^0-9A-Za-z-_]');
     return (control: AbstractControl): { [key: string]: any } => {
         const forbidden = charRE.test(control.value);
-        return forbidden ? { 'forbiddenChar': { value: control.value } } : null;
+        return forbidden ? { forbiddenChar: { value: control.value } } : null;
     };
 }
 
@@ -28,7 +20,7 @@ export function forbiddenFirstCharValidator(): ValidatorFn {
     const charRE = new RegExp('^[A-Za-z0-9]');
     return (control: AbstractControl): { [key: string]: any } => {
         const forbidden = !charRE.test(control.value);
-        return forbidden ? { 'forbiddenFirstChar': { value: control.value } } : null;
+        return forbidden ? { forbiddenFirstChar: { value: control.value } } : null;
     };
 }
 
@@ -36,34 +28,33 @@ export function forbiddenLastCharValidator(): ValidatorFn {
     const charRE = new RegExp('[A-Za-z0-9]$');
     return (control: AbstractControl): { [key: string]: any } => {
         const forbidden = !charRE.test(control.value);
-        return forbidden ? { 'forbiddenLastChar': { value: control.value } } : null;
+        return forbidden ? { forbiddenLastChar: { value: control.value } } : null;
     };
 }
 
 @Component({
     selector: 'alternate-name-modale',
     templateUrl: './alternate-name-modal.component.html',
-    styleUrls: ['./alternate-name-modal.component.less']
+    styleUrls: ['./alternate-name-modal.component.less'],
 })
 export class AlternateNameModalComponent implements OnInit {
-
     saveInProgress = false;
     repository: Repository;
     startedImport = false;
 
-    name: FormControl = new FormControl(
-        '', [
+    name: FormControl = new FormControl('', [
         Validators.required,
         Validators.minLength(3),
         forbiddenCharValidator(),
         forbiddenFirstCharValidator(),
-        forbiddenLastCharValidator()
-        ]);
+        forbiddenLastCharValidator(),
+    ]);
 
     constructor(
         public bsModalRef: BsModalRef,
         private repositoryService: RepositoryService,
-        private repositoryImportService: RepositoryImportService) {}
+        private repositoryImportService: RepositoryImportService,
+    ) {}
 
     ngOnInit() {
         this.name.setValue(this.repository.name);
@@ -84,13 +75,12 @@ export class AlternateNameModalComponent implements OnInit {
             repo.import_branch = this.repository.import_branch;
             repo.is_enabled = this.repository.is_enabled;
             this.repositoryService.save(repo).subscribe(saveResult => {
-                this.repositoryImportService
-                    .save({'repository_id': this.repository.id}).subscribe(importResult => {
-                        console.log(`Started import for ${this.repository.name}`);
-                        this.saveInProgress = true;
-                        this.startedImport = true;
-                        this.bsModalRef.hide();
-                    });
+                this.repositoryImportService.save({ repository_id: this.repository.id }).subscribe(importResult => {
+                    console.log(`Started import for ${this.repository.name}`);
+                    this.saveInProgress = true;
+                    this.startedImport = true;
+                    this.bsModalRef.hide();
+                });
             });
         }
     }

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RepositoriesContentComponent } from './repositories-content.component';
 
 describe('RepositoriesContentComponent', () => {
-  let component: RepositoriesContentComponent;
-  let fixture: ComponentFixture<RepositoriesContentComponent>;
+    let component: RepositoriesContentComponent;
+    let fixture: ComponentFixture<RepositoriesContentComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ RepositoriesContentComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [RepositoriesContentComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(RepositoriesContentComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(RepositoriesContentComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.ts
@@ -1,53 +1,43 @@
-import {
-    Component,
-    Input,
-    OnDestroy,
-    OnInit,
-    ViewEncapsulation,
-} from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 
-import { ActionConfig }      from 'patternfly-ng/action/action-config';
-import { EmptyStateConfig }  from 'patternfly-ng/empty-state/empty-state-config';
-import { ListConfig }        from 'patternfly-ng/list/basic-list/list-config';
+import { ActionConfig } from 'patternfly-ng/action/action-config';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state/empty-state-config';
+import { ListConfig } from 'patternfly-ng/list/basic-list/list-config';
 
-import {
-    BsModalRef,
-    BsModalService
-} from 'ngx-bootstrap';
+import { BsModalRef, BsModalService } from 'ngx-bootstrap';
 
-import { FilterConfig }                from 'patternfly-ng/filter/filter-config';
-import { FilterField }                 from 'patternfly-ng/filter/filter-field';
-import { FilterType }                  from 'patternfly-ng/filter/filter-type';
+import { FilterConfig } from 'patternfly-ng/filter/filter-config';
+import { FilterField } from 'patternfly-ng/filter/filter-field';
+import { FilterType } from 'patternfly-ng/filter/filter-type';
 
-import { PaginationConfig }            from 'patternfly-ng/pagination/pagination-config';
-import { PaginationEvent }             from 'patternfly-ng/pagination/pagination-event';
-import { ToolbarConfig }               from 'patternfly-ng/toolbar/toolbar-config';
+import { PaginationConfig } from 'patternfly-ng/pagination/pagination-config';
+import { PaginationEvent } from 'patternfly-ng/pagination/pagination-event';
+import { ToolbarConfig } from 'patternfly-ng/toolbar/toolbar-config';
 
-import { Namespace }               from '../../../../resources/namespaces/namespace';
-import { PagedResponse }           from '../../../../resources/paged-response';
-import { ProviderNamespace }       from '../../../../resources/provider-namespaces/provider-namespace';
-import { Repository }              from '../../../../resources/repositories/repository';
-import { RepositoryService }       from '../../../../resources/repositories/repository.service';
+import { Namespace } from '../../../../resources/namespaces/namespace';
+import { PagedResponse } from '../../../../resources/paged-response';
+import { ProviderNamespace } from '../../../../resources/provider-namespaces/provider-namespace';
+import { Repository } from '../../../../resources/repositories/repository';
+import { RepositoryService } from '../../../../resources/repositories/repository.service';
 import { RepositoryImportService } from '../../../../resources/repository-imports/repository-import.service';
 
-import {
-    AlternateNameModalComponent
-} from './alternate-name-modal/alternate-name-modal.component';
+import { AlternateNameModalComponent } from './alternate-name-modal/alternate-name-modal.component';
 
 import 'rxjs/add/observable/interval';
-import { Observable }              from 'rxjs/Observable';
-import { forkJoin }                from 'rxjs/observable/forkJoin';
+import { Observable } from 'rxjs/Observable';
+import { forkJoin } from 'rxjs/observable/forkJoin';
 
-import * as moment                 from 'moment';
+import * as moment from 'moment';
 
 @Component({
     encapsulation: ViewEncapsulation.None,
     selector: 'repositories-content',
     templateUrl: './repositories-content.component.html',
-    styleUrls: ['./repositories-content.component.less']
+    styleUrls: ['./repositories-content.component.less'],
 })
 export class RepositoriesContentComponent implements OnInit, OnDestroy {
-    @Input() namespace: Namespace;
+    @Input()
+    namespace: Namespace;
 
     @Input()
     set contentAdded(state: number) {
@@ -90,7 +80,7 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
     constructor(
         private repositoryService: RepositoryService,
         private repositoryImportService: RepositoryImportService,
-        private modalService: BsModalService
+        private modalService: BsModalService,
     ) {
         this.modalService.onHidden.subscribe(_ => {
             if (this.bsModalRef && this.bsModalRef.content.startedImport) {
@@ -110,44 +100,44 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
                     id: 'name',
                     title: 'Name',
                     placeholder: 'Filter by Name...',
-                    type: FilterType.TEXT
+                    type: FilterType.TEXT,
                 },
             ] as FilterField[],
             resultsCount: this.items.length,
-            appliedFilters: []
+            appliedFilters: [],
         } as FilterConfig;
 
         this.toolbarConfig = {
             filterConfig: this.filterConfig,
-            views: []
+            views: [],
         } as ToolbarConfig;
 
         this.emptyStateConfig = {
             actions: {
                 primaryActions: [],
-                moreActions: []
+                moreActions: [],
             } as ActionConfig,
             iconStyleClass: 'pficon-warning-triangle-o',
             title: 'No Repositories',
-            info: 'Add repositories by clicking the \'Add Content\' button above.',
-            helpLink: {}
+            info: 'Add repositories by clicking the "Add Content" button above.',
+            helpLink: {},
         } as EmptyStateConfig;
 
         this.nonEmptyStateConfig = {
             actions: {
                 primaryActions: [],
-                moreActions: []
+                moreActions: [],
             } as ActionConfig,
             iconStyleClass: '',
             title: '',
             info: '',
-            helpLink: {}
+            helpLink: {},
         } as EmptyStateConfig;
 
         this.disabledStateConfig = {
             iconStyleClass: 'pficon-warning-triangle-o',
             info: `The Namespace ${this.namespace.name} is disabled. You'll need to re-enable it before viewing and modifying its content.`,
-            title: 'Namespace Disabled'
+            title: 'Namespace Disabled',
         } as EmptyStateConfig;
 
         this.listConfig = {
@@ -157,7 +147,7 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
             selectItems: false,
             selectionMatchProp: 'name',
             showCheckbox: false,
-            useExpandItems: false
+            useExpandItems: false,
         } as ListConfig;
 
         if (this.namespace.active && provider_namespaces.length) {
@@ -207,10 +197,9 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
 
     private getRepositories() {
         this.loading = true;
-        this.polling = Observable.interval(10000)
-            .subscribe(pollingResult => {
-                this.refreshRepositories();
-            });
+        this.polling = Observable.interval(10000).subscribe(pollingResult => {
+            this.refreshRepositories();
+        });
     }
 
     private getDetailUrl(item: Repository) {
@@ -248,9 +237,9 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
         const queries: Observable<PagedResponse>[] = [];
         this.namespace.summary_fields.provider_namespaces.forEach((pns: ProviderNamespace) => {
             const query = {
-                'provider_namespace__id': pns.id,
-                'page_size': this.paginationConfig.pageSize,
-                'page': this.paginationConfig.pageNumber,
+                provider_namespace__id: pns.id,
+                page_size: this.paginationConfig.pageSize,
+                page: this.paginationConfig.pageNumber,
             };
 
             if (this.filterConfig) {
@@ -268,7 +257,7 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
             let resultCount = 0;
 
             for (const response of results) {
-                repositories =  repositories.concat(response.results as Repository[]);
+                repositories = repositories.concat(response.results as Repository[]);
                 resultCount += response.count;
             }
 
@@ -310,15 +299,14 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
         // Start an import
         repository['latest_import']['state'] = 'PENDING';
         repository['latest_import']['as_of_dt'] = '';
-        this.repositoryImportService.save({'repository_id': repository.id})
-            .subscribe(response => {
-                console.log(`Started import for repository ${repository.id}`);
-            });
+        this.repositoryImportService.save({ repository_id: repository.id }).subscribe(response => {
+            console.log(`Started import for repository ${repository.id}`);
+        });
     }
 
     private deleteRepository(repository: Repository) {
         this.loading = true;
-        this.repositoryService.destroy(repository).subscribe( _ => {
+        this.repositoryService.destroy(repository).subscribe(_ => {
             this.items.forEach((item: Repository, idx: number) => {
                 if (item.id === repository.id) {
                     this.items.splice(idx, 1);
@@ -331,9 +319,12 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
 
     private changeRepositoryName(repository: Repository) {
         const initialState = {
-            repository: repository
+            repository: repository,
         };
-        this.bsModalRef = this.modalService.show(AlternateNameModalComponent,
-            { initialState: initialState, keyboard: true, animated: true });
+        this.bsModalRef = this.modalService.show(AlternateNameModalComponent, {
+            initialState: initialState,
+            keyboard: true,
+            animated: true,
+        });
     }
 }

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list-resolver.service.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list-resolver.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { NamespaceListResolver } from './namespace-list-resolver.service';
 
 describe('NamespaceListResolver', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [NamespaceListResolver]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [NamespaceListResolver],
+        });
     });
-  });
 
-  it('should be created', inject([NamespaceListResolver], (service: NamespaceListResolver) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([NamespaceListResolver], (service: NamespaceListResolver) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list-resolver.service.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list-resolver.service.ts
@@ -1,29 +1,21 @@
-import { Injectable }                                                   from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import {
-    ActivatedRouteSnapshot,
-    Resolve,
-    RouterStateSnapshot
-} from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
 
-import { Observable }            from 'rxjs/Observable';
-import { AuthService }           from '../../auth/auth.service';
-import { NamespaceService }      from '../../resources/namespaces/namespace.service';
-import { PagedResponse }         from '../../resources/paged-response';
+import { Observable } from 'rxjs/Observable';
+import { AuthService } from '../../auth/auth.service';
+import { NamespaceService } from '../../resources/namespaces/namespace.service';
+import { PagedResponse } from '../../resources/paged-response';
 
 @Injectable()
 export class NamespaceListResolver implements Resolve<PagedResponse> {
-
-    constructor(
-        private namespaceService: NamespaceService,
-        private authService: AuthService
-    ) {}
+    constructor(private namespaceService: NamespaceService, private authService: AuthService) {}
 
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<PagedResponse> {
         if (this.authService.meCache.staff) {
             // staff can view and update all namespaces
             return this.namespaceService.pagedQuery({});
         }
-        return this.namespaceService.pagedQuery({'owners__username': this.authService.meCache.username});
+        return this.namespaceService.pagedQuery({ owners__username: this.authService.meCache.username });
     }
 }

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NamespaceListComponent } from './namespace-list.component';
 
 describe('NamespaceListComponent', () => {
-  let component: NamespaceListComponent;
-  let fixture: ComponentFixture<NamespaceListComponent>;
+    let component: NamespaceListComponent;
+    let fixture: ComponentFixture<NamespaceListComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ NamespaceListComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [NamespaceListComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(NamespaceListComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(NamespaceListComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
@@ -1,43 +1,36 @@
-import {
-    Component,
-    OnInit,
-    ViewEncapsulation
-} from '@angular/core';
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 
-import {
-    ActivatedRoute,
-    Router
-} from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
-import { cloneDeep }    from 'lodash';
+import { cloneDeep } from 'lodash';
 
 import { ActionConfig } from 'patternfly-ng/action/action-config';
-import { ListConfig }   from 'patternfly-ng/list/basic-list/list-config';
+import { ListConfig } from 'patternfly-ng/list/basic-list/list-config';
 
-import { PaginationConfig }   from 'patternfly-ng/pagination/pagination-config';
-import { PaginationEvent }    from 'patternfly-ng/pagination/pagination-event';
+import { PaginationConfig } from 'patternfly-ng/pagination/pagination-config';
+import { PaginationEvent } from 'patternfly-ng/pagination/pagination-event';
 
-import { BsModalRef, BsModalService }  from 'ngx-bootstrap';
-import { FilterConfig }                from 'patternfly-ng/filter/filter-config';
-import { FilterField }                 from 'patternfly-ng/filter/filter-field';
-import { FilterType }                  from 'patternfly-ng/filter/filter-type';
-import { SortConfig }                  from 'patternfly-ng/sort/sort-config';
-import { SortEvent }                   from 'patternfly-ng/sort/sort-event';
-import { SortField }                   from 'patternfly-ng/sort/sort-field';
-import { ToolbarConfig }               from 'patternfly-ng/toolbar/toolbar-config';
-import { ToolbarView }                 from 'patternfly-ng/toolbar/toolbar-view';
-import { IMe }                         from '../../auth/auth.service';
-import { AuthService }                 from '../../auth/auth.service';
-import { Namespace }                   from '../../resources/namespaces/namespace';
-import { NamespaceService }            from '../../resources/namespaces/namespace.service';
-import { PagedResponse }               from '../../resources/paged-response';
+import { BsModalRef, BsModalService } from 'ngx-bootstrap';
+import { FilterConfig } from 'patternfly-ng/filter/filter-config';
+import { FilterField } from 'patternfly-ng/filter/filter-field';
+import { FilterType } from 'patternfly-ng/filter/filter-type';
+import { SortConfig } from 'patternfly-ng/sort/sort-config';
+import { SortEvent } from 'patternfly-ng/sort/sort-event';
+import { SortField } from 'patternfly-ng/sort/sort-field';
+import { ToolbarConfig } from 'patternfly-ng/toolbar/toolbar-config';
+import { ToolbarView } from 'patternfly-ng/toolbar/toolbar-view';
+import { IMe } from '../../auth/auth.service';
+import { AuthService } from '../../auth/auth.service';
+import { Namespace } from '../../resources/namespaces/namespace';
+import { NamespaceService } from '../../resources/namespaces/namespace.service';
+import { PagedResponse } from '../../resources/paged-response';
 import { AddRepositoryModalComponent } from '../add-repository-modal/add-repository-modal.component';
 
 @Component({
     encapsulation: ViewEncapsulation.None,
     selector: 'namespace-list',
     templateUrl: './namespace-list.component.html',
-    styleUrls: ['./namespace-list.component.less']
+    styleUrls: ['./namespace-list.component.less'],
 })
 export class NamespaceListComponent implements OnInit {
     items: Namespace[] = [];
@@ -74,7 +67,7 @@ export class NamespaceListComponent implements OnInit {
         private router: Router,
         private modalService: BsModalService,
         private namespaceService: NamespaceService,
-        private authService: AuthService
+        private authService: AuthService,
     ) {
         this.modalService.onHidden.subscribe(_ => {
             if (this.bsModalRef && this.bsModalRef.content.repositoriesAdded) {
@@ -95,17 +88,17 @@ export class NamespaceListComponent implements OnInit {
                     id: 'name',
                     title: 'Name',
                     placeholder: 'Filter by Name...',
-                    type: FilterType.TEXT
+                    type: FilterType.TEXT,
                 },
                 {
                     id: 'description',
                     title: 'Description',
                     placeholder: 'Filter by Description...',
-                    type: FilterType.TEXT
-                }
+                    type: FilterType.TEXT,
+                },
             ] as FilterField[],
             resultsCount: this.items.length,
-            appliedFilters: []
+            appliedFilters: [],
         } as FilterConfig;
 
         this.sortConfig = {
@@ -113,27 +106,27 @@ export class NamespaceListComponent implements OnInit {
                 {
                     id: 'name',
                     title: 'Name',
-                    sortType: 'alpha'
+                    sortType: 'alpha',
                 },
                 {
                     id: 'description',
                     title: 'Description',
-                    sortType: 'alpha'
-                }
+                    sortType: 'alpha',
+                },
             ],
-            isAscending: this.isAscendingSort
+            isAscending: this.isAscendingSort,
         } as SortConfig;
 
         this.toolbarActionConfig = {
             primaryActions: [],
-            moreActions: []
+            moreActions: [],
         } as ActionConfig;
 
         this.toolbarConfig = {
             actionConfig: this.toolbarActionConfig,
             filterConfig: this.filterConfig,
             sortConfig: this.sortConfig,
-            views: []
+            views: [],
         } as ToolbarConfig;
 
         this.listConfig = {
@@ -142,24 +135,23 @@ export class NamespaceListComponent implements OnInit {
             selectItems: false,
             selectionMatchProp: 'name',
             showCheckbox: false,
-            useExpandItems: true
+            useExpandItems: true,
         } as ListConfig;
 
         this.paginationConfig = {
             pageSize: 10,
             pageNumber: 1,
-            totalItems: 0
+            totalItems: 0,
         } as PaginationConfig;
 
-        this.route.data
-            .subscribe(data => {
-                const results = data['namespaces'] as PagedResponse;
-                this.me = data['me'];
-                this.items = this.prepForList(results.results as Namespace[]);
-                this.filterConfig.resultsCount = results.count;
-                this.paginationConfig.totalItems = results.count;
-                this.pageLoading = false;
-            });
+        this.route.data.subscribe(data => {
+            const results = data['namespaces'] as PagedResponse;
+            this.me = data['me'];
+            this.items = this.prepForList(results.results as Namespace[]);
+            this.filterConfig.resultsCount = results.count;
+            this.paginationConfig.totalItems = results.count;
+            this.pageLoading = false;
+        });
     }
 
     handleListAction($event: any): void {
@@ -214,7 +206,7 @@ export class NamespaceListComponent implements OnInit {
     // View
 
     viewSelected(currentView: ToolbarView): void {
-        this.sortConfig.visible = (currentView.id === 'tableView' ? false : true);
+        this.sortConfig.visible = currentView.id === 'tableView' ? false : true;
     }
 
     handlePageSizeChange($event: PaginationEvent) {
@@ -244,15 +236,20 @@ export class NamespaceListComponent implements OnInit {
 
     private addContent(namespace: Namespace) {
         const initialState = {
-            namespace: namespace
+            namespace: namespace,
         };
-        this.bsModalRef = this.modalService.show(AddRepositoryModalComponent, {initialState: initialState, keyboard: true, animated: true});
+        this.bsModalRef = this.modalService.show(AddRepositoryModalComponent, {
+            initialState: initialState,
+            keyboard: true,
+            animated: true,
+        });
     }
 
     private enableDisableNamespace(namespace: Namespace) {
         namespace.active = !namespace.active;
-        this.namespaceService.save(namespace)
-            .subscribe(_ => { this.searchNamespaces(); });
+        this.namespaceService.save(namespace).subscribe(_ => {
+            this.searchNamespaces();
+        });
     }
 
     private searchNamespaces() {

--- a/galaxyui/src/app/my-imports/import-detail/import-detail.component.spec.ts
+++ b/galaxyui/src/app/my-imports/import-detail/import-detail.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ImportDetailComponent } from './import-detail.component';
 
 describe('ImportDetailComponent', () => {
-  let component: ImportDetailComponent;
-  let fixture: ComponentFixture<ImportDetailComponent>;
+    let component: ImportDetailComponent;
+    let fixture: ComponentFixture<ImportDetailComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ ImportDetailComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [ImportDetailComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ImportDetailComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(ImportDetailComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/my-imports/import-detail/import-detail.component.ts
+++ b/galaxyui/src/app/my-imports/import-detail/import-detail.component.ts
@@ -1,30 +1,22 @@
-import {
-    AfterViewInit,
-    Component,
-    EventEmitter,
-    Input,
-    OnInit,
-    Output
-} from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
-import { ImportState }             from '../../enums/import-state.enum';
-import { Import }                  from '../../resources/imports/import';
+import { ImportState } from '../../enums/import-state.enum';
+import { Import } from '../../resources/imports/import';
 
 import { RepositoryImportService } from '../../resources/repository-imports/repository-import.service';
 
-import { NamespaceService }        from '../../resources/namespaces/namespace.service';
+import { NamespaceService } from '../../resources/namespaces/namespace.service';
 
-import { AuthService }             from '../../auth/auth.service';
+import { AuthService } from '../../auth/auth.service';
 
-import * as $       from 'jquery';
+import * as $ from 'jquery';
 
 @Component({
-  selector: 'app-import-detail',
-  templateUrl: './import-detail.component.html',
-  styleUrls: ['./import-detail.component.less']
+    selector: 'app-import-detail',
+    templateUrl: './import-detail.component.html',
+    styleUrls: ['./import-detail.component.less'],
 })
 export class ImportDetailComponent implements OnInit, AfterViewInit {
-
     private _importTask: Import;
     private _refreshing: boolean;
     private canImport: boolean;
@@ -38,24 +30,20 @@ export class ImportDetailComponent implements OnInit, AfterViewInit {
         this.canImport = false;
 
         if (data) {
-            this.authService.me().subscribe(
-                (me) => {
-                    if (me.staff) {
-                        this.canImport = true;
-                    } else {
-                        this.namespaceService.get(data.summary_fields.namespace.id).subscribe(
-                            (namespace) => {
-                                for (const owner of namespace.summary_fields.owners) {
-                                    if (me.username === owner.username) {
-                                        this.canImport = true;
-                                        break;
-                                    }
-                                }
+            this.authService.me().subscribe(me => {
+                if (me.staff) {
+                    this.canImport = true;
+                } else {
+                    this.namespaceService.get(data.summary_fields.namespace.id).subscribe(namespace => {
+                        for (const owner of namespace.summary_fields.owners) {
+                            if (me.username === owner.username) {
+                                this.canImport = true;
+                                break;
                             }
-                        );
-                    }
+                        }
+                    });
                 }
-            );
+            });
         }
 
         if (this._importTask && this.importTask.id !== data.id) {
@@ -81,13 +69,15 @@ export class ImportDetailComponent implements OnInit, AfterViewInit {
         return this._refreshing;
     }
 
-    @Output() startedImport = new EventEmitter<boolean>();
-    @Output() scrollToggled = new EventEmitter<boolean>();
+    @Output()
+    startedImport = new EventEmitter<boolean>();
+    @Output()
+    scrollToggled = new EventEmitter<boolean>();
 
     constructor(
         private repositoryImportService: RepositoryImportService,
         private authService: AuthService,
-        private namespaceService: NamespaceService
+        private namespaceService: NamespaceService,
     ) {}
 
     ngOnInit() {}
@@ -95,13 +85,10 @@ export class ImportDetailComponent implements OnInit, AfterViewInit {
     ngAfterViewInit() {}
 
     startImport(): void {
-        this.repositoryImportService.save({'repository_id': this.importTask.summary_fields.repository.id})
-            .subscribe(response => {
-                console.log(
-                  `Started import for repository ${this.importTask.summary_fields.repository.id}`
-                );
-                this.startedImport.emit(true);
-            });
+        this.repositoryImportService.save({ repository_id: this.importTask.summary_fields.repository.id }).subscribe(response => {
+            console.log(`Started import for repository ${this.importTask.summary_fields.repository.id}`);
+            this.startedImport.emit(true);
+        });
     }
 
     affix(): void {

--- a/galaxyui/src/app/my-imports/import-list/import-list.component.spec.ts
+++ b/galaxyui/src/app/my-imports/import-list/import-list.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ImportListComponent } from './import-list.component';
 
 describe('ImportListComponent', () => {
-  let component: ImportListComponent;
-  let fixture: ComponentFixture<ImportListComponent>;
+    let component: ImportListComponent;
+    let fixture: ComponentFixture<ImportListComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ ImportListComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [ImportListComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ImportListComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(ImportListComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/my-imports/import-list/import-list.component.ts
+++ b/galaxyui/src/app/my-imports/import-list/import-list.component.ts
@@ -1,57 +1,45 @@
-import {
-    AfterViewInit,
-    Component,
-    OnDestroy,
-    OnInit,
-    ViewChild,
-} from '@angular/core';
+import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 
-import {
-    ActivatedRoute,
-} from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 
-import {
-    Location
-} from '@angular/common';
+import { Location } from '@angular/common';
 
-import {
-    ImportsService
-} from '../../resources/imports/imports.service';
+import { ImportsService } from '../../resources/imports/imports.service';
 
 import 'rxjs/add/observable/interval';
-import { Observable }    from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 
-import { Import }        from '../../resources/imports/import';
-import { ImportLatest }  from '../../resources/imports/import-latest';
+import { Import } from '../../resources/imports/import';
+import { ImportLatest } from '../../resources/imports/import-latest';
 
-import { ImportState }   from '../../enums/import-state.enum';
+import { ImportState } from '../../enums/import-state.enum';
 import { PagedResponse } from '../../resources/paged-response';
 
-import { Filter }        from 'patternfly-ng/filter/filter';
-import { FilterConfig }  from 'patternfly-ng/filter/filter-config';
-import { FilterEvent }   from 'patternfly-ng/filter/filter-event';
-import { FilterField }   from 'patternfly-ng/filter/filter-field';
-import { FilterQuery }   from 'patternfly-ng/filter/filter-query';
-import { FilterType }    from 'patternfly-ng/filter/filter-type';
-import { ListConfig }    from 'patternfly-ng/list/basic-list/list-config';
+import { Filter } from 'patternfly-ng/filter/filter';
+import { FilterConfig } from 'patternfly-ng/filter/filter-config';
+import { FilterEvent } from 'patternfly-ng/filter/filter-event';
+import { FilterField } from 'patternfly-ng/filter/filter-field';
+import { FilterQuery } from 'patternfly-ng/filter/filter-query';
+import { FilterType } from 'patternfly-ng/filter/filter-type';
+import { ListConfig } from 'patternfly-ng/list/basic-list/list-config';
 import { ListComponent } from 'patternfly-ng/list/basic-list/list.component';
 
-import { PaginationConfig }  from 'patternfly-ng/pagination/pagination-config';
-import { PaginationEvent }   from 'patternfly-ng/pagination/pagination-event';
+import { PaginationConfig } from 'patternfly-ng/pagination/pagination-config';
+import { PaginationEvent } from 'patternfly-ng/pagination/pagination-event';
 
-import { AuthService }   from '../../auth/auth.service';
+import { AuthService } from '../../auth/auth.service';
 
-import * as $            from 'jquery';
-import * as moment       from 'moment';
+import * as $ from 'jquery';
+import * as moment from 'moment';
 
 @Component({
     selector: 'import-list',
     templateUrl: './import-list.component.html',
-    styleUrls: ['./import-list.component.less']
+    styleUrls: ['./import-list.component.less'],
 })
 export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
-
-    @ViewChild(ListComponent) pfList: ListComponent;
+    @ViewChild(ListComponent)
+    pfList: ListComponent;
 
     listConfig: ListConfig;
     filterConfig: FilterConfig;
@@ -79,39 +67,41 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
         private route: ActivatedRoute,
         private importsService: ImportsService,
         private location: Location,
-        private authService: AuthService
+        private authService: AuthService,
     ) {}
 
     ngOnInit() {
-
         this.listConfig = {
             dblClick: false,
             multiSelect: false,
             selectItems: true,
             showCheckbox: false,
-            useExpandItems: false
+            useExpandItems: false,
         } as ListConfig;
 
         this.filterConfig = {
-            fields: [{
-                id: 'repository_name',
-                title: 'Repository Name',
-                placeholder: 'Filter by Repository Name...',
-                type: FilterType.TEXT,
-            }, {
-                id: 'namespace',
-                title: 'Namespace',
-                placeholder: 'Filter by Namespace...',
-                type: FilterType.TEXT,
-            }] as FilterField[],
+            fields: [
+                {
+                    id: 'repository_name',
+                    title: 'Repository Name',
+                    placeholder: 'Filter by Repository Name...',
+                    type: FilterType.TEXT,
+                },
+                {
+                    id: 'namespace',
+                    title: 'Namespace',
+                    placeholder: 'Filter by Namespace...',
+                    type: FilterType.TEXT,
+                },
+            ] as FilterField[],
             resultsCount: 0,
-            appliedFilters: []
+            appliedFilters: [],
         } as FilterConfig;
 
         this.paginationConfig = {
             pageSize: 10,
             pageNumber: 1,
-            totalItems: 0
+            totalItems: 0,
         } as PaginationConfig;
 
         this.route.queryParams.subscribe(params => {
@@ -119,24 +109,22 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
             this.setAppliedFilters(params);
             this.setQuery();
 
-            this.route.data.subscribe(
-                (data) => {
-                    const imports: PagedResponse = data['imports'] as PagedResponse;
-                    this.items = imports.results;
-                    this.filterConfig.resultsCount = this.items.length;
-                    this.paginationConfig.totalItems = imports.count;
-                    this.prepareImports(this.items);
-                    if (this.items.length) {
-                        if (params['selected']) {
-                            this.getImport(Number(params['selected']), true);
-                        } else {
-                            this.getImport(this.items[0].id, true);
-                        }
+            this.route.data.subscribe(data => {
+                const imports: PagedResponse = data['imports'] as PagedResponse;
+                this.items = imports.results;
+                this.filterConfig.resultsCount = this.items.length;
+                this.paginationConfig.totalItems = imports.count;
+                this.prepareImports(this.items);
+                if (this.items.length) {
+                    if (params['selected']) {
+                        this.getImport(Number(params['selected']), true);
                     } else {
-                        this.cancelPageLoading();
+                        this.getImport(this.items[0].id, true);
                     }
+                } else {
+                    this.cancelPageLoading();
                 }
-            );
+            });
             this.cancelPageLoading();
         });
     }
@@ -206,23 +194,20 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
         if (this.polling) {
             this.polling.unsubscribe();
         }
-        this.importsService.get(id).subscribe(
-            result => {
-                this.prepareImport(result);
-                this.selected = result;
-                this.selectedId = result.id;
-                this.setQuery();
-                if (this.pfList) {
-                    this.selectItem(this.selected.id, deselectId);
-                }
-                this.cancelPageLoading();
-                if (this.selected.state === ImportState.running ||
-                    this.selected.state === ImportState.pending) {
-                        // monitor the state of a running import
-                        this.polling = Observable.interval(5000)
-                            .subscribe(_ => this.refreshImport());
-                }
-            });
+        this.importsService.get(id).subscribe(result => {
+            this.prepareImport(result);
+            this.selected = result;
+            this.selectedId = result.id;
+            this.setQuery();
+            if (this.pfList) {
+                this.selectItem(this.selected.id, deselectId);
+            }
+            this.cancelPageLoading();
+            if (this.selected.state === ImportState.running || this.selected.state === ImportState.pending) {
+                // monitor the state of a running import
+                this.polling = Observable.interval(5000).subscribe(_ => this.refreshImport());
+            }
+        });
     }
 
     applyFilters($event: FilterEvent): void {
@@ -257,8 +242,7 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
 
     startedImport($event): void {
         this.refreshImport();
-        this.polling = Observable.interval(5000)
-            .subscribe(_ => this.refreshImport());
+        this.polling = Observable.interval(5000).subscribe(_ => this.refreshImport());
     }
 
     toggleScroll($event): void {
@@ -271,7 +255,7 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
     // private
 
     private scrollDetails() {
-        $('#import-details-container').animate({scrollTop: $('#import-details-container')[0].scrollHeight}, 1000);
+        $('#import-details-container').animate({ scrollTop: $('#import-details-container')[0].scrollHeight }, 1000);
     }
 
     private setPageSize(params: any) {
@@ -280,10 +264,10 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
             this.pageSize = params['page_size'];
             this.pageNumber = 1;
         }
-           if (params['page']) {
-               this.paginationConfig.pageNumber = params['page'];
-               this.pageNumber = params['page'];
-           }
+        if (params['page']) {
+            this.paginationConfig.pageNumber = params['page'];
+            this.pageNumber = params['page'];
+        }
     }
 
     private prepareImport(data: Import): void {
@@ -299,8 +283,7 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
         } else if (data.state === ImportState.running) {
             data.last_run = 'Running...';
         } else if (data.state === ImportState.failed || data.state === ImportState.success) {
-            const state = data.state.charAt(0).toUpperCase() +
-                data.state.slice(1).toLowerCase();
+            const state = data.state.charAt(0).toUpperCase() + data.state.slice(1).toLowerCase();
             data.last_run = state + ' ' + moment(data.finished).fromNow();
         }
     }
@@ -339,7 +322,7 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
                 if (!field) {
                     continue;
                 }
-                const values = (typeof params[key] === 'object') ? params[key] : [params[key]];
+                const values = typeof params[key] === 'object' ? params[key] : [params[key]];
                 values.forEach(value => {
                     if (filterParams !== '') {
                         filterParams += '&';
@@ -355,7 +338,7 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
                     const ffield: Filter = {} as Filter;
                     ffield.field = field;
                     if (field.type === FilterType.TEXT) {
-                          ffield.value = value;
+                        ffield.value = value;
                     } else if (field.type === FilterType.TYPEAHEAD) {
                         field.queries.forEach((query: FilterQuery) => {
                             if (query.id === value) {
@@ -384,8 +367,8 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
             paging += '&page=' + this.pageNumber;
         }
 
-        const query = (this.filterParams + paging).replace(/^&/, '');  // remove leading &
-        const selected = (this.selectedId) ? `&selected=${this.selectedId}` : '';
+        const query = (this.filterParams + paging).replace(/^&/, ''); // remove leading &
+        const selected = this.selectedId ? `&selected=${this.selectedId}` : '';
 
         // Refresh params on location URL
         const location = (this.locationParams + selected + paging).replace(/^&/, ''); // remove leading &
@@ -419,42 +402,39 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
             const selectedId = this.selected.id;
             this.refreshing = true;
             const params: any = {
-                'repository__id': this.selected.summary_fields.repository.id,
-                'order_by': '-id'
+                repository__id: this.selected.summary_fields.repository.id,
+                order_by: '-id',
             };
-            this.importsService.query(params).subscribe(
-                result => {
-                    if (result.length) {
-                        const import_result: Import = result[0];
-                        this.prepareImport(import_result);
-                        this.items.forEach((item: ImportLatest) => {
-                            if (item.repository_id === import_result.summary_fields.repository.id) {
-                                item.finished = moment(import_result.modified).fromNow();
-                                item.state = import_result.state.charAt(0).toUpperCase() +
-                                    import_result.state.slice(1).toLowerCase();
-                            }
-                        });
-                        if (this.selected.id === selectedId) {
-                            // If the selected item has not changed,
-                            //   copy result property values -> this.selected
-                            const keys = Object.keys(import_result);
-                            for (const key of keys) {
-                                this.selected[key] = import_result[key];
-                            }
-                            if (this.selected.state === ImportState.failed ||
-                                this.selected.state === ImportState.success) {
-                                // The import finished
-                                if (this.polling) {
-                                    this.polling.unsubscribe();
-                                }
+            this.importsService.query(params).subscribe(result => {
+                if (result.length) {
+                    const import_result: Import = result[0];
+                    this.prepareImport(import_result);
+                    this.items.forEach((item: ImportLatest) => {
+                        if (item.repository_id === import_result.summary_fields.repository.id) {
+                            item.finished = moment(import_result.modified).fromNow();
+                            item.state = import_result.state.charAt(0).toUpperCase() + import_result.state.slice(1).toLowerCase();
+                        }
+                    });
+                    if (this.selected.id === selectedId) {
+                        // If the selected item has not changed,
+                        //   copy result property values -> this.selected
+                        const keys = Object.keys(import_result);
+                        for (const key of keys) {
+                            this.selected[key] = import_result[key];
+                        }
+                        if (this.selected.state === ImportState.failed || this.selected.state === ImportState.success) {
+                            // The import finished
+                            if (this.polling) {
+                                this.polling.unsubscribe();
                             }
                         }
                     }
-                    this.refreshing = false;
-                    if (this.scroll) {
-                        this.scrollDetails();
-                    }
-                });
+                }
+                this.refreshing = false;
+                if (this.scroll) {
+                    this.scrollDetails();
+                }
+            });
         }
     }
 

--- a/galaxyui/src/app/my-imports/import-list/import-list.resolver.service.ts
+++ b/galaxyui/src/app/my-imports/import-list/import-list.resolver.service.ts
@@ -1,32 +1,21 @@
-import {
-    Injectable
-} from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import {
-    ActivatedRouteSnapshot,
-    Resolve,
-} from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 
-import { Observable }            from 'rxjs/Observable';
-import { AuthService }           from '../../auth/auth.service';
-import { ImportsService }        from '../../resources/imports/imports.service';
-import { PagedResponse }         from '../../resources/paged-response';
+import { Observable } from 'rxjs/Observable';
+import { AuthService } from '../../auth/auth.service';
+import { ImportsService } from '../../resources/imports/imports.service';
+import { PagedResponse } from '../../resources/paged-response';
 
 @Injectable()
 export class ImportListResolver implements Resolve<PagedResponse> {
+    constructor(private importsService: ImportsService, private authService: AuthService) {}
 
-    constructor(
-        private importsService: ImportsService,
-        private authService: AuthService
-    ) {}
-
-    resolve(
-        route: ActivatedRouteSnapshot,
-    ): Observable<PagedResponse> {
+    resolve(route: ActivatedRouteSnapshot): Observable<PagedResponse> {
         let params = '';
         for (const key in route.queryParams) {
             if (route.queryParams.hasOwnProperty(key)) {
-                const values = (typeof route.queryParams[key] === 'object') ? route.queryParams[key] : [route.queryParams[key]];
+                const values = typeof route.queryParams[key] === 'object' ? route.queryParams[key] : [route.queryParams[key]];
                 values.forEach(value => {
                     if (params !== '') {
                         params += '&';

--- a/galaxyui/src/app/my-imports/my-imports.module.ts
+++ b/galaxyui/src/app/my-imports/my-imports.module.ts
@@ -1,20 +1,20 @@
-import { CommonModule }              from '@angular/common';
-import { NgModule }                  from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
-import { ActionModule }              from 'patternfly-ng/action/action.module';
-import { EmptyStateModule }          from 'patternfly-ng/empty-state/empty-state.module';
-import { FilterModule }              from 'patternfly-ng/filter/filter.module';
-import { ListModule }                from 'patternfly-ng/list/basic-list/list.module';
-import { PaginationModule }          from 'patternfly-ng/pagination/pagination.module';
-import { ToolbarModule }             from 'patternfly-ng/toolbar/toolbar.module';
+import { ActionModule } from 'patternfly-ng/action/action.module';
+import { EmptyStateModule } from 'patternfly-ng/empty-state/empty-state.module';
+import { FilterModule } from 'patternfly-ng/filter/filter.module';
+import { ListModule } from 'patternfly-ng/list/basic-list/list.module';
+import { PaginationModule } from 'patternfly-ng/pagination/pagination.module';
+import { ToolbarModule } from 'patternfly-ng/toolbar/toolbar.module';
 
-import { TooltipModule }             from 'ngx-bootstrap/tooltip';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
-import { PageHeaderModule }          from '../page-header/page-header.module';
-import { PageLoadingModule }         from '../page-loading/page-loading.module';
-import { ImportDetailComponent }     from './import-detail/import-detail.component';
-import { ImportListComponent }       from './import-list/import-list.component';
-import { MyImportsRoutingModule }    from './my-imports.routing.module';
+import { PageHeaderModule } from '../page-header/page-header.module';
+import { PageLoadingModule } from '../page-loading/page-loading.module';
+import { ImportDetailComponent } from './import-detail/import-detail.component';
+import { ImportListComponent } from './import-list/import-list.component';
+import { MyImportsRoutingModule } from './my-imports.routing.module';
 
 @NgModule({
     imports: [
@@ -28,14 +28,9 @@ import { MyImportsRoutingModule }    from './my-imports.routing.module';
         PageHeaderModule,
         PageLoadingModule,
         PaginationModule,
-        MyImportsRoutingModule
+        MyImportsRoutingModule,
     ],
-    declarations: [
-        ImportListComponent,
-        ImportDetailComponent
-    ],
-    exports: [
-        ImportDetailComponent
-    ]
+    declarations: [ImportListComponent, ImportDetailComponent],
+    exports: [ImportDetailComponent],
 })
 export class MyImportsModule {}

--- a/galaxyui/src/app/my-imports/my-imports.routing.module.ts
+++ b/galaxyui/src/app/my-imports/my-imports.routing.module.ts
@@ -16,37 +16,28 @@
  * along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
  */
 
-import { NgModule }                 from '@angular/core';
+import { NgModule } from '@angular/core';
 
-import {
-    RouterModule,
-    Routes
-} from '@angular/router';
+import { RouterModule, Routes } from '@angular/router';
 
-import { AuthService }              from '../auth/auth.service';
-import { ImportListComponent }      from './import-list/import-list.component';
-import { ImportListResolver }       from './import-list/import-list.resolver.service';
+import { AuthService } from '../auth/auth.service';
+import { ImportListComponent } from './import-list/import-list.component';
+import { ImportListResolver } from './import-list/import-list.resolver.service';
 
 const myImportRoutes: Routes = [
     {
         path: '',
         component: ImportListComponent,
         resolve: {
-            imports: ImportListResolver
+            imports: ImportListResolver,
         },
-        canActivate: [AuthService]
-    }
+        canActivate: [AuthService],
+    },
 ];
 
 @NgModule({
-    imports: [
-        RouterModule.forChild(myImportRoutes)
-    ],
-    exports: [
-        RouterModule,
-    ],
-    providers: [
-        ImportListResolver
-    ]
+    imports: [RouterModule.forChild(myImportRoutes)],
+    exports: [RouterModule],
+    providers: [ImportListResolver],
 })
 export class MyImportsRoutingModule {}

--- a/galaxyui/src/app/page-header/page-header.component.spec.ts
+++ b/galaxyui/src/app/page-header/page-header.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { PageHeaderComponent } from './page-header.component';
 
 describe('PageHeaderComponent', () => {
-  let component: PageHeaderComponent;
-  let fixture: ComponentFixture<PageHeaderComponent>;
+    let component: PageHeaderComponent;
+    let fixture: ComponentFixture<PageHeaderComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ PageHeaderComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [PageHeaderComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(PageHeaderComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(PageHeaderComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/page-header/page-header.component.ts
+++ b/galaxyui/src/app/page-header/page-header.component.ts
@@ -1,8 +1,4 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 class Title {
     name: string;
@@ -10,18 +6,16 @@ class Title {
 }
 
 @Component({
-  selector: 'app-page-header',
-  templateUrl: './page-header.component.html',
-  styleUrls: ['./page-header.component.less']
+    selector: 'app-page-header',
+    templateUrl: './page-header.component.html',
+    styleUrls: ['./page-header.component.less'],
 })
 export class PageHeaderComponent implements OnInit {
-
     _headerTitle: Title[];
     _headerIcon: string;
 
     @Input()
     set headerTitle(headerTitle: string) {
-
         // Set headerTitle to a string. For sub pages, where you want a breadcrumb trail,
         // pass a list of page names and paths separated by ';'. For example:
         // 'page_name;/path;page_name;/path/foo;page_name'.
@@ -50,5 +44,4 @@ export class PageHeaderComponent implements OnInit {
     constructor() {}
 
     ngOnInit() {}
-
 }

--- a/galaxyui/src/app/page-header/page-header.module.ts
+++ b/galaxyui/src/app/page-header/page-header.module.ts
@@ -1,19 +1,12 @@
-import { CommonModule }        from '@angular/common';
-import { NgModule }            from '@angular/core';
-import { RouterModule }        from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 import { PageHeaderComponent } from './page-header.component';
 
 @NgModule({
-  imports: [
-      RouterModule,
-      CommonModule
-  ],
-  declarations: [
-      PageHeaderComponent
-  ],
-  exports: [
-      PageHeaderComponent
-  ]
+    imports: [RouterModule, CommonModule],
+    declarations: [PageHeaderComponent],
+    exports: [PageHeaderComponent],
 })
 export class PageHeaderModule {}

--- a/galaxyui/src/app/page-loading/page-loading.component.spec.ts
+++ b/galaxyui/src/app/page-loading/page-loading.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { PageLoadingComponent } from './page-loading.component';
 
 describe('PageLoadingComponent', () => {
-  let component: PageLoadingComponent;
-  let fixture: ComponentFixture<PageLoadingComponent>;
+    let component: PageLoadingComponent;
+    let fixture: ComponentFixture<PageLoadingComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ PageLoadingComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [PageLoadingComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(PageLoadingComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(PageLoadingComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/page-loading/page-loading.component.ts
+++ b/galaxyui/src/app/page-loading/page-loading.component.ts
@@ -1,18 +1,15 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 @Component({
     selector: 'app-page-loading',
     templateUrl: './page-loading.component.html',
-    styleUrls: ['./page-loading.component.less']
+    styleUrls: ['./page-loading.component.less'],
 })
 export class PageLoadingComponent implements OnInit {
-    @Input() loading: boolean;
+    @Input()
+    loading: boolean;
 
-    constructor() { }
+    constructor() {}
 
     ngOnInit() {}
 }

--- a/galaxyui/src/app/page-loading/page-loading.module.ts
+++ b/galaxyui/src/app/page-loading/page-loading.module.ts
@@ -3,14 +3,8 @@ import { NgModule } from '@angular/core';
 import { PageLoadingComponent } from './page-loading.component';
 
 @NgModule({
-  imports: [
-      CommonModule
-  ],
-  declarations: [
-      PageLoadingComponent
-  ],
-  exports: [
-      PageLoadingComponent
-  ]
+    imports: [CommonModule],
+    declarations: [PageLoadingComponent],
+    exports: [PageLoadingComponent],
 })
-export class PageLoadingModule { }
+export class PageLoadingModule {}

--- a/galaxyui/src/app/resources/api-root/api-root.service.spec.ts
+++ b/galaxyui/src/app/resources/api-root/api-root.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { ApiRootService } from './api-root.service';
 
 describe('ContentSearchService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [ApiRootService]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [ApiRootService],
+        });
     });
-  });
 
-  it('should be created', inject([ApiRootService], (service: ApiRootService) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([ApiRootService], (service: ApiRootService) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/resources/api-root/api-root.service.ts
+++ b/galaxyui/src/app/resources/api-root/api-root.service.ts
@@ -1,33 +1,29 @@
-import { HttpClient }           from '@angular/common/http';
-import { Injectable }           from '@angular/core';
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
-import { Observable }           from 'rxjs/Observable';
-import { of }                   from 'rxjs/observable/of';
-import { catchError, tap }      from 'rxjs/operators';
-import { ApiRoot }              from './api-root';
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
+import { catchError, tap } from 'rxjs/operators';
+import { ApiRoot } from './api-root';
 
 @Injectable()
 export class ApiRootService {
-
     private url = '/api/';
 
-    constructor(
-        private http: HttpClient,
-        private notificationService: NotificationService) { }
+    constructor(private http: HttpClient, private notificationService: NotificationService) {}
 
     get(): Observable<ApiRoot> {
-        return this.http.get<ApiRoot>(this.url)
-            .pipe(
-                tap(_ => this.log('fetched api information')),
-                catchError(this.handleError<ApiRoot>(`get api root`))
-            );
+        return this.http.get<ApiRoot>(this.url).pipe(
+            tap(_ => this.log('fetched api information')),
+            catchError(this.handleError<ApiRoot>(`get api root`)),
+        );
     }
 
     private handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} user error: ${error.message}`);
-            this.notificationService.httpError(`${operation} user failed:`, {data: error});
+            this.notificationService.httpError(`${operation} user failed:`, { data: error });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/api-root/api-root.ts
+++ b/galaxyui/src/app/resources/api-root/api-root.ts
@@ -3,5 +3,5 @@ export class ApiRoot {
     current_version: string;
     server_version: string;
     version_name: string;
-    team_members: string [];
+    team_members: string[];
 }

--- a/galaxyui/src/app/resources/cloud-platforms/cloud-platform.service.spec.ts
+++ b/galaxyui/src/app/resources/cloud-platforms/cloud-platform.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { CloudPlatformService } from './cloud-platform.service';
 
 describe('CloudPlatformService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [CloudPlatformService]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [CloudPlatformService],
+        });
     });
-  });
 
-  it('should be created', inject([CloudPlatformService], (service: CloudPlatformService) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([CloudPlatformService], (service: CloudPlatformService) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/resources/cloud-platforms/cloud-platform.service.ts
+++ b/galaxyui/src/app/resources/cloud-platforms/cloud-platform.service.ts
@@ -1,50 +1,43 @@
-import { Injectable }              from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import {
-    HttpClient,
-} from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 
-import { Observable }           from 'rxjs/Observable';
-import { of }                   from 'rxjs/observable/of';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 import { catchError, map, tap } from 'rxjs/operators';
 
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
-import { PagedResponse }        from '../paged-response';
-import { CloudPlatform }          from './cloud-platform';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
+import { PagedResponse } from '../paged-response';
+import { CloudPlatform } from './cloud-platform';
 
 @Injectable()
 export class CloudPlatformService {
-
     private url = '/api/v1/cloud_platforms';
     private searchUrl = '/api/v1/search/cloud_platforms';
 
-    constructor(private http: HttpClient,
-                private notificationService: NotificationService) {
-    }
+    constructor(private http: HttpClient, private notificationService: NotificationService) {}
 
     query(params?: any): Observable<CloudPlatform[]> {
-        return this.http.get<PagedResponse>(this.url + '/', {params: params})
-            .pipe(
-                map(response => response.results),
-                tap(_ => this.log('fetched content types')),
-                catchError(this.handleError('Query', [] as CloudPlatform[]))
-            );
+        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
+            map(response => response.results),
+            tap(_ => this.log('fetched content types')),
+            catchError(this.handleError('Query', [] as CloudPlatform[])),
+        );
     }
 
     search(params?: any): Observable<CloudPlatform[]> {
-        return this.http.get<PagedResponse>(this.searchUrl + '/', {params: params})
-            .pipe(
-                map(response => response.results),
-                tap(_ => this.log('fetched content types')),
-                catchError(this.handleError('Query', [] as CloudPlatform[]))
-            );
+        return this.http.get<PagedResponse>(this.searchUrl + '/', { params: params }).pipe(
+            map(response => response.results),
+            tap(_ => this.log('fetched content types')),
+            catchError(this.handleError('Query', [] as CloudPlatform[])),
+        );
     }
 
     private handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} repository error: ${error.message}`);
-            this.notificationService.httpError(`${operation} repository failed:`, {data: error});
+            this.notificationService.httpError(`${operation} repository failed:`, { data: error });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);
@@ -54,5 +47,4 @@ export class CloudPlatformService {
     private log(message: string) {
         console.log('CloudPlatformService: ' + message);
     }
-
 }

--- a/galaxyui/src/app/resources/content-blocks/content-blocks.service.spec.ts
+++ b/galaxyui/src/app/resources/content-blocks/content-blocks.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { UserService } from './user.service';
 
 describe('UserService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [UserService]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [UserService],
+        });
     });
-  });
 
-  it('should be created', inject([UserService], (service: UserService) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([UserService], (service: UserService) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/resources/content-blocks/content-blocks.service.ts
+++ b/galaxyui/src/app/resources/content-blocks/content-blocks.service.ts
@@ -1,44 +1,39 @@
-import { HttpClient }           from '@angular/common/http';
-import { Injectable }           from '@angular/core';
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
-import { Observable }           from 'rxjs/Observable';
-import { of }                   from 'rxjs/observable/of';
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 import { catchError, map, tap } from 'rxjs/operators';
-import { PagedResponse }        from '../paged-response';
-import { ContentBlock }         from './content-block';
+import { PagedResponse } from '../paged-response';
+import { ContentBlock } from './content-block';
 
 @Injectable()
 export class ContentBlocksService {
-
     private url = '/api/v1/content_blocks/';
 
-    constructor(
-        private http: HttpClient,
-        private notificationService: NotificationService) { }
+    constructor(private http: HttpClient, private notificationService: NotificationService) {}
 
     query(): Observable<ContentBlock[]> {
-        return this.http.get<PagedResponse>(this.url)
-            .pipe(
-                map(response => response.results as ContentBlock[]),
-                tap(_ => this.log('fetched content blocks')),
-                catchError(this.handleError<ContentBlock[]>('Query', []))
-            );
+        return this.http.get<PagedResponse>(this.url).pipe(
+            map(response => response.results as ContentBlock[]),
+            tap(_ => this.log('fetched content blocks')),
+            catchError(this.handleError<ContentBlock[]>('Query', [])),
+        );
     }
 
     get(name: string): Observable<ContentBlock> {
         const url = `${this.url}${name}/`;
-        return this.http.get<ContentBlock>(url)
-            .pipe(
-                tap(_ => this.log('fetched content block')),
-                catchError(this.handleError<ContentBlock>(`Get content block ${name}`))
-            );
+        return this.http.get<ContentBlock>(url).pipe(
+            tap(_ => this.log('fetched content block')),
+            catchError(this.handleError<ContentBlock>(`Get content block ${name}`)),
+        );
     }
 
     private handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} user error: ${error.message}`);
-            this.notificationService.httpError(`${operation} user failed:`, {data: error});
+            this.notificationService.httpError(`${operation} user failed:`, { data: error });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/content-search/content-search.service.spec.ts
+++ b/galaxyui/src/app/resources/content-search/content-search.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { ContentSearchService } from './content-search.service';
 
 describe('ContentSearchService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [ContentSearchService]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [ContentSearchService],
+        });
     });
-  });
 
-  it('should be created', inject([ContentSearchService], (service: ContentSearchService) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([ContentSearchService], (service: ContentSearchService) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/resources/content-search/content-search.service.ts
+++ b/galaxyui/src/app/resources/content-search/content-search.service.ts
@@ -1,25 +1,17 @@
-import { Injectable }           from '@angular/core';
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
+import { Injectable } from '@angular/core';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
 import { catchError, tap } from 'rxjs/operators';
 
-import {
-    HttpClient,
-} from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 
-import { Observable }    from 'rxjs/Observable';
-import { of }            from 'rxjs/observable/of';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 
-import {
-    ContentResponse
-} from './content';
+import { ContentResponse } from './content';
 
 @Injectable()
 export class ContentSearchService {
-
-    constructor(
-        private http: HttpClient,
-        private notificationService: NotificationService
-    ) { }
+    constructor(private http: HttpClient, private notificationService: NotificationService) {}
 
     private url = '/api/v1/search/content/';
 
@@ -28,19 +20,17 @@ export class ContentSearchService {
         if (query) {
             requestUrl += `?${query}`;
         }
-        return this.http.get<ContentResponse>(requestUrl)
-            .pipe(
-                 tap(_ => this.log('fetched content')),
-                 catchError(this.handleError('Query', {} as ContentResponse))
-            );
+        return this.http.get<ContentResponse>(requestUrl).pipe(
+            tap(_ => this.log('fetched content')),
+            catchError(this.handleError('Query', {} as ContentResponse)),
+        );
     }
 
     get(id: number): Observable<any> {
-        return this.http.get<any>(`${this.url}${id.toString()}/`)
-            .pipe(
-                tap(_ => this.log('fetched import')),
-                catchError(this.handleError('Get', []))
-            );
+        return this.http.get<any>(`${this.url}${id.toString()}/`).pipe(
+            tap(_ => this.log('fetched import')),
+            catchError(this.handleError('Get', [])),
+        );
     }
 
     private handleError<T>(operation = '', result?: T) {

--- a/galaxyui/src/app/resources/content-types/content-type.service.spec.ts
+++ b/galaxyui/src/app/resources/content-types/content-type.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { PlatformService } from './platform.service';
 
 describe('PlatformService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [PlatformService]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [PlatformService],
+        });
     });
-  });
 
-  it('should be created', inject([PlatformService], (service: PlatformService) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([PlatformService], (service: PlatformService) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/resources/content-types/content-type.service.ts
+++ b/galaxyui/src/app/resources/content-types/content-type.service.ts
@@ -1,40 +1,34 @@
-import { Injectable }              from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import {
-    HttpClient,
-} from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 
-import { Observable }           from 'rxjs/Observable';
-import { of }                   from 'rxjs/observable/of';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 import { catchError, map, tap } from 'rxjs/operators';
 
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
-import { PagedResponse }        from '../paged-response';
-import { ContentType }          from './content-type';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
+import { PagedResponse } from '../paged-response';
+import { ContentType } from './content-type';
 
 @Injectable()
 export class ContentTypeService {
-
     private url = '/api/v1/content_types';
 
-    constructor(private http: HttpClient,
-                private notificationService: NotificationService) {
-    }
+    constructor(private http: HttpClient, private notificationService: NotificationService) {}
 
     query(params?: any): Observable<ContentType[]> {
-        return this.http.get<PagedResponse>(this.url + '/', {params: params})
-            .pipe(
-                map(response => response.results),
-                tap(_ => this.log('fetched content types')),
-                catchError(this.handleError('Query', [] as ContentType[]))
-            );
+        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
+            map(response => response.results),
+            tap(_ => this.log('fetched content types')),
+            catchError(this.handleError('Query', [] as ContentType[])),
+        );
     }
 
     private handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} repository error: ${error.message}`);
-            this.notificationService.httpError(`${operation} repository failed:`, {data: error});
+            this.notificationService.httpError(`${operation} repository failed:`, { data: error });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);
@@ -44,5 +38,4 @@ export class ContentTypeService {
     private log(message: string) {
         console.log('ContentTypeService: ' + message);
     }
-
 }

--- a/galaxyui/src/app/resources/content/content.service.spec.ts
+++ b/galaxyui/src/app/resources/content/content.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { ContentService } from './content.service';
 
 describe('ContentSearchService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [ContentService]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [ContentService],
+        });
     });
-  });
 
-  it('should be created', inject([ContentService], (service: ContentService) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([ContentService], (service: ContentService) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/resources/content/content.service.ts
+++ b/galaxyui/src/app/resources/content/content.service.ts
@@ -1,64 +1,53 @@
-import { Injectable }           from '@angular/core';
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
+import { Injectable } from '@angular/core';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
 import { catchError, map, tap } from 'rxjs/operators';
 
-import {
-    HttpClient,
-} from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 
-import { Observable }    from 'rxjs/Observable';
-import { of }            from 'rxjs/observable/of';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 import { PagedResponse } from '../paged-response';
 
-import { Content }       from './content';
+import { Content } from './content';
 
 @Injectable()
 export class ContentService {
-
-    constructor(
-        private http: HttpClient,
-        private notificationService: NotificationService
-    ) { }
+    constructor(private http: HttpClient, private notificationService: NotificationService) {}
 
     private url = '/api/v1/content/';
 
     query(params?: any): Observable<Content[]> {
-        return this.http.get<PagedResponse>(this.url, {params: params})
-            .pipe(
-                map(result => result.results as Content[]),
-                 tap(_ => this.log('fetched content')),
-                 catchError(this.handleError('Query', [] as Content[]))
-            );
+        return this.http.get<PagedResponse>(this.url, { params: params }).pipe(
+            map(result => result.results as Content[]),
+            tap(_ => this.log('fetched content')),
+            catchError(this.handleError('Query', [] as Content[])),
+        );
     }
 
     pagedQuery(params?: any): Observable<PagedResponse> {
         if (params && typeof params === 'object') {
-            return this.http.get<PagedResponse>(this.url, {params: params})
-                .pipe(
-                    tap(_ => this.log('fetched paged content')),
-                     catchError(this.handleError('Query', {} as PagedResponse))
-                );
+            return this.http.get<PagedResponse>(this.url, { params: params }).pipe(
+                tap(_ => this.log('fetched paged content')),
+                catchError(this.handleError('Query', {} as PagedResponse)),
+            );
         }
         if (params && typeof params === 'string') {
-            return this.http.get<PagedResponse>(this.url + params)
-                .pipe(
-                    tap(_ => this.log('fetched paged content')),
-                     catchError(this.handleError('Query', {} as PagedResponse))
-                );
-        }
-        return this.http.get<PagedResponse>(this.url)
-            .pipe(
+            return this.http.get<PagedResponse>(this.url + params).pipe(
                 tap(_ => this.log('fetched paged content')),
-                 catchError(this.handleError('Query', {} as PagedResponse))
+                catchError(this.handleError('Query', {} as PagedResponse)),
             );
+        }
+        return this.http.get<PagedResponse>(this.url).pipe(
+            tap(_ => this.log('fetched paged content')),
+            catchError(this.handleError('Query', {} as PagedResponse)),
+        );
     }
 
     get(id: number): Observable<Content> {
-        return this.http.get<Content>(`${this.url}${id.toString()}/`)
-            .pipe(
-                tap(_ => this.log('fetched content')),
-                catchError(this.handleError('Get', {} as Content))
-            );
+        return this.http.get<Content>(`${this.url}${id.toString()}/`).pipe(
+            tap(_ => this.log('fetched content')),
+            catchError(this.handleError('Get', {} as Content)),
+        );
     }
 
     private handleError<T>(operation = '', result?: T) {

--- a/galaxyui/src/app/resources/imports/imports.service.spec.ts
+++ b/galaxyui/src/app/resources/imports/imports.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { ImportsService } from './imports.service';
 
 describe('ImportsService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [ImportsService]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [ImportsService],
+        });
     });
-  });
 
-  it('should be created', inject([ImportsService], (service: ImportsService) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([ImportsService], (service: ImportsService) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/resources/imports/imports.service.ts
+++ b/galaxyui/src/app/resources/imports/imports.service.ts
@@ -17,18 +17,15 @@
  */
 
 import { Injectable } from '@angular/core';
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
 import { catchError, map, tap } from 'rxjs/operators';
 
-import {
-    HttpClient,
-    HttpHeaders,
-} from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 
-import { Observable }           from 'rxjs/Observable';
-import { of }                   from 'rxjs/observable/of';
-import { PagedResponse }        from '../paged-response';
-import { Import }               from './import';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
+import { PagedResponse } from '../paged-response';
+import { Import } from './import';
 
 export class SaveParams {
     github_user: string;
@@ -37,47 +34,40 @@ export class SaveParams {
 
 const httpOptions = {
     headers: new HttpHeaders({
-        'Content-Type': 'application/json'
-    })
+        'Content-Type': 'application/json',
+    }),
 };
 
 @Injectable()
 export class ImportsService {
+    constructor(private http: HttpClient, private notificationService: NotificationService) {}
 
-    constructor(
-        private http: HttpClient,
-        private notificationService: NotificationService
-    ) {}
-
-    private url  = '/api/v1/imports';
+    private url = '/api/v1/imports';
 
     latest(query?: string): Observable<PagedResponse> {
         let requestUrl = `${this.url}/latest/`;
         if (query) {
             requestUrl += `?${query}`;
         }
-        return this.http.get<PagedResponse>(requestUrl)
-            .pipe(
-                tap(_ => this.log('fetched latest imports')),
-                catchError(this.handleError('Latest', {} as PagedResponse))
-            );
+        return this.http.get<PagedResponse>(requestUrl).pipe(
+            tap(_ => this.log('fetched latest imports')),
+            catchError(this.handleError('Latest', {} as PagedResponse)),
+        );
     }
 
     query(params?: any): Observable<Import[]> {
-        return this.http.get<PagedResponse>(this.url + '/', {params: params})
-            .pipe(
-                map(response => response.results),
-                tap(_ => this.log('fetched imports')),
-                catchError(this.handleError('Query', [] as Import[]))
-            );
+        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
+            map(response => response.results),
+            tap(_ => this.log('fetched imports')),
+            catchError(this.handleError('Query', [] as Import[])),
+        );
     }
 
     get(id: number): Observable<Import> {
-        return this.http.get<any>(`${this.url}/${id.toString()}/`)
-            .pipe(
-                tap(_ => this.log('fetched import')),
-                catchError(this.handleError('Get', {} as Import))
-            );
+        return this.http.get<any>(`${this.url}/${id.toString()}/`).pipe(
+            tap(_ => this.log('fetched import')),
+            catchError(this.handleError('Get', {} as Import)),
+        );
     }
 
     save(params: SaveParams): Observable<Import> {
@@ -85,7 +75,7 @@ export class ImportsService {
         httpResult = this.http.post<Import>(this.url, params, httpOptions);
         return httpResult.pipe(
             tap((newImport: Import) => this.log(`Saved import w/ id=${newImport.id}`)),
-            catchError(this.handleError<Import>('Save'))
+            catchError(this.handleError<Import>('Save')),
         );
     }
 
@@ -93,7 +83,7 @@ export class ImportsService {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} provider source error: ${error.message}`);
-            this.notificationService.httpError(`${operation} user failed:`, {data: error});
+            this.notificationService.httpError(`${operation} user failed:`, { data: error });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/namespaces/namespace.service.spec.ts
+++ b/galaxyui/src/app/resources/namespaces/namespace.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { NamespaceService } from './namespace.service';
 
 describe('NamespaceService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [NamespaceService]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [NamespaceService],
+        });
     });
-  });
 
-  it('should be created', inject([NamespaceService], (service: NamespaceService) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([NamespaceService], (service: NamespaceService) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/resources/namespaces/namespace.service.ts
+++ b/galaxyui/src/app/resources/namespaces/namespace.service.ts
@@ -12,56 +12,50 @@ import { PagedResponse } from '../paged-response';
 
 const httpOptions = {
     headers: new HttpHeaders({
-        'Content-Type': 'application/json'
-    })
+        'Content-Type': 'application/json',
+    }),
 };
 
 @Injectable()
 export class NamespaceService {
     private url = '/api/v1/namespaces';
 
-    constructor(private http: HttpClient,
-        private notificationService: NotificationService) {
-    }
+    constructor(private http: HttpClient, private notificationService: NotificationService) {}
 
     encounteredErrors = false;
 
     query(params?: any): Observable<Namespace[]> {
-        return this.http.get<PagedResponse>(this.url + '/', { params: params })
-            .pipe(
-                map(response => response.results),
-                tap(_ => this.log('fetched namespaces')),
-                catchError(this.handleError('Query', []))
-            );
+        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
+            map(response => response.results),
+            tap(_ => this.log('fetched namespaces')),
+            catchError(this.handleError('Query', [])),
+        );
     }
 
     pagedQuery(params: any): Observable<PagedResponse> {
         if (params && typeof params === 'object') {
-            return this.http.get<PagedResponse>(this.url + '/', { params: params })
-                .pipe(
-                    tap(_ => this.log('fetched paged content')),
-                    catchError(this.handleError('Query', {} as PagedResponse))
-                );
+            return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
+                tap(_ => this.log('fetched paged content')),
+                catchError(this.handleError('Query', {} as PagedResponse)),
+            );
         }
         if (params && typeof params === 'string') {
-            return this.http.get<PagedResponse>(this.url + '/' + params)
-                .pipe(
-                    tap(_ => this.log('fetched paged content')),
-                    catchError(this.handleError('Query', {} as PagedResponse))
-                );
-        }
-        return this.http.get<PagedResponse>(this.url + '/')
-            .pipe(
+            return this.http.get<PagedResponse>(this.url + '/' + params).pipe(
                 tap(_ => this.log('fetched paged content')),
-                catchError(this.handleError('Query', {} as PagedResponse))
+                catchError(this.handleError('Query', {} as PagedResponse)),
             );
+        }
+        return this.http.get<PagedResponse>(this.url + '/').pipe(
+            tap(_ => this.log('fetched paged content')),
+            catchError(this.handleError('Query', {} as PagedResponse)),
+        );
     }
 
     get(id: number): Observable<Namespace> {
         const url = `${this.url}/${id}/`;
         return this.http.get<Namespace>(url).pipe(
             tap(_ => this.log(`fetched namespace id=${id}`)),
-            catchError(this.handleError<Namespace>(`Get id=${id}`))
+            catchError(this.handleError<Namespace>(`Get id=${id}`)),
         );
     }
 
@@ -74,7 +68,7 @@ export class NamespaceService {
         }
         return httpResult.pipe(
             tap((newNamespace: Namespace) => this.log(`Saved namespace w/ id=${newNamespace.id}`)),
-            catchError(this.handleError<Namespace>('Save', namespace))
+            catchError(this.handleError<Namespace>('Save', namespace)),
         );
     }
 
@@ -84,7 +78,7 @@ export class NamespaceService {
 
         return this.http.delete<any>(url, httpOptions).pipe(
             tap(_ => this.log(`deleted namespace id=${id}`)),
-            catchError(this.handleError<any>('Delete'))
+            catchError(this.handleError<any>('Delete')),
         );
     }
 
@@ -93,8 +87,7 @@ export class NamespaceService {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} namespace error: ${error.message}`);
-            if (typeof error === 'object' && 'error' in error && typeof error['error'] === 'object' &&
-                result !== undefined) {
+            if (typeof error === 'object' && 'error' in error && typeof error['error'] === 'object' && result !== undefined) {
                 // Unpack error messages, sending each to the notification service
                 for (const fld in error['error']) {
                     if (error['error'].hasOwnProperty(fld)) {

--- a/galaxyui/src/app/resources/namespaces/namespace.ts
+++ b/galaxyui/src/app/resources/namespaces/namespace.ts
@@ -1,6 +1,6 @@
 import { ProviderNamespace } from '../provider-namespaces/provider-namespace';
-import { Repository }        from '../repositories/repository';
-import { User }              from '../users/user';
+import { Repository } from '../repositories/repository';
+import { User } from '../users/user';
 
 export class Namespace {
     id: number;

--- a/galaxyui/src/app/resources/pf-body/pf-body.service.ts
+++ b/galaxyui/src/app/resources/pf-body/pf-body.service.ts
@@ -2,34 +2,32 @@ import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
 
 @Injectable()
-
 export class BodyCommand {
     propertyName: string;
     propertyValue: number;
 }
 
 export class PFBodyService {
+    private messageSource = new Subject();
+    currentMessage = this.messageSource.asObservable();
 
-  private messageSource = new Subject();
-  currentMessage = this.messageSource.asObservable();
+    constructor() {}
 
-  constructor() { }
+    scrollToTop() {
+        const top = {
+            propertyName: 'scrollTop',
+            propertyValue: 0,
+        } as BodyCommand;
 
-  scrollToTop() {
-    const top = {
-        propertyName: 'scrollTop',
-        propertyValue: 0,
-    } as BodyCommand;
+        this.messageSource.next(top);
+    }
 
-    this.messageSource.next(top);
-  }
+    scrollTo(xCoord: number) {
+        const location = {
+            propertyName: 'scrollTop',
+            propertyValue: xCoord,
+        };
 
-  scrollTo(xCoord: number) {
-      const location = {
-          propertyName: 'scrollTop',
-          propertyValue: xCoord,
-      };
-
-      this.messageSource.next(location);
-  }
+        this.messageSource.next(location);
+    }
 }

--- a/galaxyui/src/app/resources/platforms/platform.service.spec.ts
+++ b/galaxyui/src/app/resources/platforms/platform.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { PlatformService } from './platform.service';
 
 describe('PlatformService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [PlatformService]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [PlatformService],
+        });
     });
-  });
 
-  it('should be created', inject([PlatformService], (service: PlatformService) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([PlatformService], (service: PlatformService) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/resources/platforms/platform.service.ts
+++ b/galaxyui/src/app/resources/platforms/platform.service.ts
@@ -1,47 +1,42 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable }              from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import { Observable }           from 'rxjs/Observable';
-import { of }                   from 'rxjs/observable/of';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 import { catchError, map, tap } from 'rxjs/operators';
 
 import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
-import { PagedResponse }       from '../paged-response';
-import { Platform }            from './platform';
+import { PagedResponse } from '../paged-response';
+import { Platform } from './platform';
 
 @Injectable()
 export class PlatformService {
-
     private url = '/api/v1/platforms';
     private searchUrl = '/api/v1/search/platforms';
 
-    constructor(private http: HttpClient,
-                private notificationService: NotificationService) {
+    constructor(private http: HttpClient, private notificationService: NotificationService) {}
+
+    query(params?: any): Observable<Platform[]> {
+        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
+            map(response => response.results),
+            tap(_ => this.log('fetched repositories')),
+            catchError(this.handleError('Query', [] as Platform[])),
+        );
     }
 
-    query(params?: any ): Observable<Platform[]> {
-        return this.http.get<PagedResponse>(this.url + '/', {params: params})
-            .pipe(
-                map(response => response.results),
-               tap(_ => this.log('fetched repositories')),
-               catchError(this.handleError('Query', [] as Platform[]))
-            );
-    }
-
-    search(params?: any ): Observable<Platform[]> {
-        return this.http.get<PagedResponse>(this.searchUrl + '/', {params: params})
-            .pipe(
-                map(response => response.results),
-               tap(_ => this.log('fetched repositories')),
-               catchError(this.handleError('Query', [] as Platform[]))
-            );
+    search(params?: any): Observable<Platform[]> {
+        return this.http.get<PagedResponse>(this.searchUrl + '/', { params: params }).pipe(
+            map(response => response.results),
+            tap(_ => this.log('fetched repositories')),
+            catchError(this.handleError('Query', [] as Platform[])),
+        );
     }
 
     private handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} repository error: ${error.message}`);
-            this.notificationService.httpError(`${operation} repository failed:`, {data: error});
+            this.notificationService.httpError(`${operation} repository failed:`, { data: error });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);
@@ -51,5 +46,4 @@ export class PlatformService {
     private log(message: string) {
         console.log('PlatformService: ' + message);
     }
-
 }

--- a/galaxyui/src/app/resources/provider-namespaces/provider-source.service.spec.ts
+++ b/galaxyui/src/app/resources/provider-namespaces/provider-source.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { ProviderSourceService } from './provider-source.service';
 
 describe('ProviderSourceService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [ProviderSourceService]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [ProviderSourceService],
+        });
     });
-  });
 
-  it('should be created', inject([ProviderSourceService], (service: ProviderSourceService) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([ProviderSourceService], (service: ProviderSourceService) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/resources/provider-namespaces/provider-source.service.ts
+++ b/galaxyui/src/app/resources/provider-namespaces/provider-source.service.ts
@@ -1,34 +1,29 @@
-import { HttpClient }           from '@angular/common/http';
-import { Injectable }           from '@angular/core';
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
-import { Observable }           from 'rxjs/Observable';
-import { of }                   from 'rxjs/observable/of';
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 import { catchError, tap } from 'rxjs/operators';
-import { RepositorySource }     from '../repositories/repository-source';
-import { ProviderSource }       from './provider-source';
+import { RepositorySource } from '../repositories/repository-source';
+import { ProviderSource } from './provider-source';
 
 @Injectable()
 export class ProviderSourceService {
-
     private url = '/api/v1/providers/sources';
 
-    constructor(
-        private http: HttpClient,
-        private notificationService: NotificationService) {}
+    constructor(private http: HttpClient, private notificationService: NotificationService) {}
 
     query(): Observable<ProviderSource[]> {
-        return this.http.get<ProviderSource[]>(this.url + '/')
-            .pipe(
-                tap(providerNamespaces => this.log('fetched provider sources')),
-                catchError(this.handleError('Query', []))
-            );
+        return this.http.get<ProviderSource[]>(this.url + '/').pipe(
+            tap(providerNamespaces => this.log('fetched provider sources')),
+            catchError(this.handleError('Query', [])),
+        );
     }
 
-    getRepoSources(params):  Observable<RepositorySource[]> {
-        return this.http.get<RepositorySource[]>(`${this.url}/${params.providerName}/${params.name}/`)
-        .pipe(
+    getRepoSources(params): Observable<RepositorySource[]> {
+        return this.http.get<RepositorySource[]>(`${this.url}/${params.providerName}/${params.name}/`).pipe(
             tap(providerNamespaces => this.log('fetched source repositories')),
-        catchError(this.handleError('Query', []))
+            catchError(this.handleError('Query', [])),
         );
     }
 
@@ -36,7 +31,7 @@ export class ProviderSourceService {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} provider source error: ${error.message}`);
-            this.notificationService.httpError(`${operation} user failed:`, {data: error});
+            this.notificationService.httpError(`${operation} user failed:`, { data: error });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/repositories/repository.service.spec.ts
+++ b/galaxyui/src/app/resources/repositories/repository.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { RepositoryService } from './repository.service';
 
 describe('RepositoryService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [RepositoryService]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [RepositoryService],
+        });
     });
-  });
 
-  it('should be created', inject([RepositoryService], (service: RepositoryService) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([RepositoryService], (service: RepositoryService) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/resources/repositories/repository.service.ts
+++ b/galaxyui/src/app/resources/repositories/repository.service.ts
@@ -11,56 +11,48 @@ import { Repository } from './repository';
 
 const httpOptions = {
     headers: new HttpHeaders({
-        'Content-Type': 'application/json'
-    })
+        'Content-Type': 'application/json',
+    }),
 };
 
 @Injectable()
 export class RepositoryService {
-
     private url = '/api/v1/repositories';
 
-    constructor(private http: HttpClient,
-        private notificationService: NotificationService) {
-    }
+    constructor(private http: HttpClient, private notificationService: NotificationService) {}
 
     query(params?: any): Observable<Repository[]> {
-        return this.http.get<PagedResponse>(this.url + '/', { params: params })
-            .pipe(
-                map(response => response.results as Repository[]),
-                tap(_ => this.log('fetched repositories')),
-                catchError(this.handleError('Query', [] as Repository[]))
-            );
+        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
+            map(response => response.results as Repository[]),
+            tap(_ => this.log('fetched repositories')),
+            catchError(this.handleError('Query', [] as Repository[])),
+        );
     }
 
     pagedQuery(params?: any): Observable<PagedResponse> {
         if (params && typeof params === 'object') {
-            return this.http.get<PagedResponse>(this.url + '/', { params: params })
-                .pipe(
-                    tap(_ => this.log('fetched repositories')),
-                    catchError(this.handleError('Query', {} as PagedResponse))
-                );
+            return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
+                tap(_ => this.log('fetched repositories')),
+                catchError(this.handleError('Query', {} as PagedResponse)),
+            );
         }
         if (params && typeof params === 'string') {
-            return this.http.get<PagedResponse>(this.url + '/' + params)
-                .pipe(
-                    tap(_ => this.log('fetched repositories')),
-                    catchError(this.handleError('Query', {} as PagedResponse))
-                );
-        }
-        return this.http.get<PagedResponse>(this.url + '/')
-            .pipe(
+            return this.http.get<PagedResponse>(this.url + '/' + params).pipe(
                 tap(_ => this.log('fetched repositories')),
-                catchError(this.handleError('Query', {} as PagedResponse))
+                catchError(this.handleError('Query', {} as PagedResponse)),
             );
+        }
+        return this.http.get<PagedResponse>(this.url + '/').pipe(
+            tap(_ => this.log('fetched repositories')),
+            catchError(this.handleError('Query', {} as PagedResponse)),
+        );
     }
 
     get(id: number): Observable<Repository> {
-        return this.http.get<Repository>(`${this.url}/${id.toString()}/`)
-            .pipe(
-                tap(_ => this.log('Fetched repository')),
-                catchError(this.handleError('Get', {} as Repository))
-            );
+        return this.http.get<Repository>(`${this.url}/${id.toString()}/`).pipe(
+            tap(_ => this.log('Fetched repository')),
+            catchError(this.handleError('Get', {} as Repository)),
+        );
     }
 
     save(repository: Repository): Observable<Repository> {
@@ -73,16 +65,15 @@ export class RepositoryService {
 
         return httpResult.pipe(
             tap((newRepo: Repository) => this.log(`Saved repository w/ id=${newRepo.id}`)),
-            catchError(this.handleError<Repository>('Save'))
+            catchError(this.handleError<Repository>('Save')),
         );
     }
 
     destroy(repository: Repository): Observable<any> {
-        return this.http.delete<any>(`${this.url}/${repository.id}/`)
-            .pipe(
-                tap(_ => this.log(`Deleted repository w/ id=${repository.id}`)),
-                catchError(this.handleError<any>('Save'))
-            );
+        return this.http.delete<any>(`${this.url}/${repository.id}/`).pipe(
+            tap(_ => this.log(`Deleted repository w/ id=${repository.id}`)),
+            catchError(this.handleError<any>('Save')),
+        );
     }
 
     private handleError<T>(operation = '', result?: T) {
@@ -112,5 +103,4 @@ export class RepositoryService {
     private log(message: string) {
         console.log('RepositoryService: ' + message);
     }
-
 }

--- a/galaxyui/src/app/resources/repository-imports/repository-import.service.spec.ts
+++ b/galaxyui/src/app/resources/repository-imports/repository-import.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { RepositoryImportService } from './repository-import.service';
 
 describe('RepositoryImportService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [RepositoryImportService]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [RepositoryImportService],
+        });
     });
-  });
 
-  it('should be created', inject([RepositoryImportService], (service: RepositoryImportService) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([RepositoryImportService], (service: RepositoryImportService) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/resources/repository-imports/repository-import.service.ts
+++ b/galaxyui/src/app/resources/repository-imports/repository-import.service.ts
@@ -1,49 +1,44 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Injectable }              from '@angular/core';
-import { NotificationService }     from 'patternfly-ng/notification/notification-service/notification.service';
-import { Observable }              from 'rxjs/Observable';
-import { of }                      from 'rxjs/observable/of';
-import { catchError, map, tap }    from 'rxjs/operators';
-import { PagedResponse }           from '../paged-response';
-import { RepositoryImport }        from './repository-import';
+import { Injectable } from '@angular/core';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
+import { catchError, map, tap } from 'rxjs/operators';
+import { PagedResponse } from '../paged-response';
+import { RepositoryImport } from './repository-import';
 
 const httpOptions = {
     headers: new HttpHeaders({
-        'Content-Type': 'application/json'
-    })
+        'Content-Type': 'application/json',
+    }),
 };
 
 @Injectable()
 export class RepositoryImportService {
-
     private url = '/api/v1/imports';
 
-    constructor(private http: HttpClient,
-                private notificationService: NotificationService) {
-    }
+    constructor(private http: HttpClient, private notificationService: NotificationService) {}
 
     query(params): Observable<RepositoryImport[]> {
-        return this.http.get<PagedResponse>(this.url, {params: params})
-            .pipe(
-                map(response => response.results),
-                tap(_ => this.log('fetched repository imports')),
-                catchError(this.handleError('Query', []))
-            );
+        return this.http.get<PagedResponse>(this.url, { params: params }).pipe(
+            map(response => response.results),
+            tap(_ => this.log('fetched repository imports')),
+            catchError(this.handleError('Query', [])),
+        );
     }
 
     save(params: any): Observable<RepositoryImport> {
-        return this.http.post<RepositoryImport>(`${this.url}/`, params, httpOptions)
-            .pipe(
-                tap((newImport: RepositoryImport) => this.log(`Saved repository import`)),
-                catchError(this.handleError<RepositoryImport>('Save'))
-            );
+        return this.http.post<RepositoryImport>(`${this.url}/`, params, httpOptions).pipe(
+            tap((newImport: RepositoryImport) => this.log(`Saved repository import`)),
+            catchError(this.handleError<RepositoryImport>('Save')),
+        );
     }
 
     private handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} repository import error: ${error.message}`);
-            this.notificationService.httpError(`${operation} repository import failed:`, {data: error});
+            this.notificationService.httpError(`${operation} repository import failed:`, { data: error });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);
@@ -53,5 +48,4 @@ export class RepositoryImportService {
     private log(message: string) {
         console.log('RepositoryImportService: ' + message);
     }
-
 }

--- a/galaxyui/src/app/resources/tags/tags.service.spec.ts
+++ b/galaxyui/src/app/resources/tags/tags.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { TagsService } from './tags.service';
 
 describe('TagsService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [TagsService]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [TagsService],
+        });
     });
-  });
 
-  it('should be created', inject([TagsService], (service: TagsService) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([TagsService], (service: TagsService) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/resources/tags/tags.service.ts
+++ b/galaxyui/src/app/resources/tags/tags.service.ts
@@ -1,50 +1,43 @@
-import { Injectable }              from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import {
-    HttpClient
-} from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
-import { Observable }           from 'rxjs/Observable';
-import { of }                   from 'rxjs/observable/of';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 import { catchError, map, tap } from 'rxjs/operators';
 
-import { PagedResponse }        from '../paged-response';
-import { Tag }                  from './tag';
+import { PagedResponse } from '../paged-response';
+import { Tag } from './tag';
 
 @Injectable()
 export class TagsService {
-
     private url = '/api/v1/tags';
     private searchUrl = '/api/v1/search/tags';
 
-    constructor(private http: HttpClient,
-                private notificationService: NotificationService) {
-    }
+    constructor(private http: HttpClient, private notificationService: NotificationService) {}
 
     query(params?: any): Observable<Tag[]> {
-        return this.http.get<PagedResponse>(this.url + '/', {params: params})
-            .pipe(
-                map(response => response.results),
-                tap(_ => this.log('fetched content types')),
-                catchError(this.handleError('Query', [] as Tag[]))
-            );
+        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
+            map(response => response.results),
+            tap(_ => this.log('fetched content types')),
+            catchError(this.handleError('Query', [] as Tag[])),
+        );
     }
 
     search(params?: any): Observable<Tag[]> {
-        return this.http.get<PagedResponse>(this.searchUrl + '/', {params: params})
-            .pipe(
-                map(response => response.results),
-                tap(_ => this.log('fetched content types')),
-                catchError(this.handleError('Query', [] as Tag[]))
-            );
+        return this.http.get<PagedResponse>(this.searchUrl + '/', { params: params }).pipe(
+            map(response => response.results),
+            tap(_ => this.log('fetched content types')),
+            catchError(this.handleError('Query', [] as Tag[])),
+        );
     }
 
     private handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} repository error: ${error.message}`);
-            this.notificationService.httpError(`${operation} repository failed:`, {data: error});
+            this.notificationService.httpError(`${operation} repository failed:`, { data: error });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/users/user.service.spec.ts
+++ b/galaxyui/src/app/resources/users/user.service.spec.ts
@@ -3,13 +3,13 @@ import { inject, TestBed } from '@angular/core/testing';
 import { UserService } from './user.service';
 
 describe('UserService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [UserService]
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [UserService],
+        });
     });
-  });
 
-  it('should be created', inject([UserService], (service: UserService) => {
-    expect(service).toBeTruthy();
-  }));
+    it('should be created', inject([UserService], (service: UserService) => {
+        expect(service).toBeTruthy();
+    }));
 });

--- a/galaxyui/src/app/resources/users/user.service.ts
+++ b/galaxyui/src/app/resources/users/user.service.ts
@@ -1,20 +1,17 @@
-import { HttpClient }           from '@angular/common/http';
-import { Injectable }           from '@angular/core';
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
-import { Observable }           from 'rxjs/Observable';
-import { of }                   from 'rxjs/observable/of';
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 import { catchError, map, tap } from 'rxjs/operators';
-import { PagedResponse }        from '../paged-response';
-import { User }                 from './user';
+import { PagedResponse } from '../paged-response';
+import { User } from './user';
 
 @Injectable()
 export class UserService {
-
     private url = '/api/v1/users/';
 
-    constructor(private http: HttpClient,
-                private notificationService: NotificationService) {
-    }
+    constructor(private http: HttpClient, private notificationService: NotificationService) {}
 
     query(params?: any): Observable<User[]> {
         let userUrl = this.url;
@@ -26,19 +23,18 @@ export class UserService {
                 userParams = params;
             }
         }
-        return this.http.get<PagedResponse>(userUrl, {'params':  userParams})
-            .pipe(
-                map(response => response.results as User[]),
-                tap(_ => this.log('fetched users')),
-                catchError(this.handleError('Query', []))
-            );
+        return this.http.get<PagedResponse>(userUrl, { params: userParams }).pipe(
+            map(response => response.results as User[]),
+            tap(_ => this.log('fetched users')),
+            catchError(this.handleError('Query', [])),
+        );
     }
 
     private handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} user error: ${error.message}`);
-            this.notificationService.httpError(`${operation} user failed:`, {data: error});
+            this.notificationService.httpError(`${operation} user failed:`, { data: error });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/search/popular/popular.component.spec.ts
+++ b/galaxyui/src/app/search/popular/popular.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { SearchComponent } from './search.component';
 
 describe('SearchComponent', () => {
-  let component: SearchComponent;
-  let fixture: ComponentFixture<SearchComponent>;
+    let component: SearchComponent;
+    let fixture: ComponentFixture<SearchComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ SearchComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [SearchComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(SearchComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(SearchComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/search/popular/popular.component.ts
+++ b/galaxyui/src/app/search/popular/popular.component.ts
@@ -1,22 +1,14 @@
-import {
-    Component,
-    EventEmitter,
-    Input,
-    OnInit,
-    Output
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
-import {
-    ActivatedRoute,
-} from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 
-import { ListConfig }     from 'patternfly-ng/list/basic-list/list-config';
+import { ListConfig } from 'patternfly-ng/list/basic-list/list-config';
 
-import { Tag }              from '../../resources/tags/tag';
+import { Tag } from '../../resources/tags/tag';
 
-import { Platform }         from '../../resources/platforms/platform';
+import { Platform } from '../../resources/platforms/platform';
 
-import { CloudPlatform }        from '../../resources/cloud-platforms/cloud-platform';
+import { CloudPlatform } from '../../resources/cloud-platforms/cloud-platform';
 
 class PopularData {
     tags: Tag[];
@@ -32,21 +24,21 @@ export class PopularEvent {
 @Component({
     selector: 'popular-widget',
     templateUrl: './popular.component.html',
-    styleUrls: ['./popular.component.less']
+    styleUrls: ['./popular.component.less'],
 })
 export class PopularComponent implements OnInit {
-
-    @Input() popularType: string;
-    @Input() popularTitle: string;
-    @Output() click = new EventEmitter<PopularEvent>();
+    @Input()
+    popularType: string;
+    @Input()
+    popularTitle: string;
+    @Output()
+    click = new EventEmitter<PopularEvent>();
 
     data: PopularData;
     listConfig: ListConfig;
     items: any;
 
-    constructor(
-        private route: ActivatedRoute
-    ) {}
+    constructor(private route: ActivatedRoute) {}
 
     handleClick($event) {
         // User clicked on an item

--- a/galaxyui/src/app/search/search-routing.module.ts
+++ b/galaxyui/src/app/search/search-routing.module.ts
@@ -1,9 +1,6 @@
 import { NgModule } from '@angular/core';
 
-import {
-    RouterModule,
-    Routes
-} from '@angular/router';
+import { RouterModule, Routes } from '@angular/router';
 
 import { SearchComponent } from './search.component';
 
@@ -14,8 +11,8 @@ import {
     SearchCloudPlatformResolver,
     SearchContentResolver,
     SearchContentTypeResolver,
-    SearchPlatformResolver
-}  from './search.resolver.service';
+    SearchPlatformResolver,
+} from './search.resolver.service';
 
 const routes: Routes = [
     {
@@ -29,26 +26,22 @@ const routes: Routes = [
             platforms: SearchPlatformResolver,
             popularTags: PopularTagsResolver,
             popularCloudPlatforms: PopularCloudPlatformsResolver,
-            popularPlatforms: PopularPlatformsResolver
+            popularPlatforms: PopularPlatformsResolver,
         },
-    }
+    },
 ];
 
 @NgModule({
-    imports: [
-        RouterModule.forChild(routes)
-    ],
-    exports: [
-          RouterModule
-      ],
-      providers: [
-          SearchCloudPlatformResolver,
+    imports: [RouterModule.forChild(routes)],
+    exports: [RouterModule],
+    providers: [
+        SearchCloudPlatformResolver,
         SearchContentResolver,
         SearchContentTypeResolver,
         SearchPlatformResolver,
         PopularTagsResolver,
         PopularPlatformsResolver,
-        PopularCloudPlatformsResolver
-      ]
+        PopularCloudPlatformsResolver,
+    ],
 })
-export class SearchRoutingModule { }
+export class SearchRoutingModule {}

--- a/galaxyui/src/app/search/search.component.spec.ts
+++ b/galaxyui/src/app/search/search.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { SearchComponent } from './search.component';
 
 describe('SearchComponent', () => {
-  let component: SearchComponent;
-  let fixture: ComponentFixture<SearchComponent>;
+    let component: SearchComponent;
+    let fixture: ComponentFixture<SearchComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ SearchComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [SearchComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(SearchComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(SearchComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/search/search.component.ts
+++ b/galaxyui/src/app/search/search.component.ts
@@ -1,73 +1,55 @@
-import {
-    AfterViewInit,
-    Component,
-    OnInit
-} from '@angular/core';
+import { AfterViewInit, Component, OnInit } from '@angular/core';
 
-import {
-    ActivatedRoute,
-} from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 
-import {
-    Location
-} from '@angular/common';
+import { Location } from '@angular/common';
 
-import { ListConfig }     from 'patternfly-ng/list/basic-list/list-config';
-import { ToolbarConfig }  from 'patternfly-ng/toolbar/toolbar-config';
+import { ListConfig } from 'patternfly-ng/list/basic-list/list-config';
+import { ToolbarConfig } from 'patternfly-ng/toolbar/toolbar-config';
 
-import { Filter }         from 'patternfly-ng/filter/filter';
-import { FilterConfig }   from 'patternfly-ng/filter/filter-config';
-import { FilterEvent }    from 'patternfly-ng/filter/filter-event';
-import { FilterField }    from 'patternfly-ng/filter/filter-field';
-import { FilterQuery }    from 'patternfly-ng/filter/filter-query';
-import { FilterType }     from 'patternfly-ng/filter/filter-type';
+import { Filter } from 'patternfly-ng/filter/filter';
+import { FilterConfig } from 'patternfly-ng/filter/filter-config';
+import { FilterEvent } from 'patternfly-ng/filter/filter-event';
+import { FilterField } from 'patternfly-ng/filter/filter-field';
+import { FilterQuery } from 'patternfly-ng/filter/filter-query';
+import { FilterType } from 'patternfly-ng/filter/filter-type';
 
-import { SortConfig }     from 'patternfly-ng/sort/sort-config';
-import { SortEvent }      from 'patternfly-ng/sort/sort-event';
-import { SortField }      from 'patternfly-ng/sort/sort-field';
+import { SortConfig } from 'patternfly-ng/sort/sort-config';
+import { SortEvent } from 'patternfly-ng/sort/sort-event';
+import { SortField } from 'patternfly-ng/sort/sort-field';
 
-import { EmptyStateConfig }     from 'patternfly-ng/empty-state/empty-state-config';
-import { PaginationConfig }     from 'patternfly-ng/pagination/pagination-config';
-import { PaginationEvent }      from 'patternfly-ng/pagination/pagination-event';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state/empty-state-config';
+import { PaginationConfig } from 'patternfly-ng/pagination/pagination-config';
+import { PaginationEvent } from 'patternfly-ng/pagination/pagination-event';
 
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
-import { NotificationType }     from 'patternfly-ng/notification/notification-type';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
+import { NotificationType } from 'patternfly-ng/notification/notification-type';
 
-import { ContentTypes }         from '../enums/content-types.enum';
-import { CloudPlatform }        from '../resources/cloud-platforms/cloud-platform';
+import { ContentTypes } from '../enums/content-types.enum';
+import { CloudPlatform } from '../resources/cloud-platforms/cloud-platform';
 import { ContentSearchService } from '../resources/content-search/content-search.service';
-import { ContentType }          from '../resources/content-types/content-type';
-import { PFBodyService }        from '../resources/pf-body/pf-body.service';
-import { Platform }             from '../resources/platforms/platform';
+import { ContentType } from '../resources/content-types/content-type';
+import { PFBodyService } from '../resources/pf-body/pf-body.service';
+import { Platform } from '../resources/platforms/platform';
 
-import {
-    ContentTypesIconClasses
-} from '../enums/content-types.enum';
+import { ContentTypesIconClasses } from '../enums/content-types.enum';
 
-import {
-    RepoFormats
-} from '../enums/repo-types.enum';
+import { RepoFormats } from '../enums/repo-types.enum';
 
-import {
-    ContributorTypes,
-    ContributorTypesIconClasses
-} from '../enums/contributor-types.enum';
+import { ContributorTypes, ContributorTypesIconClasses } from '../enums/contributor-types.enum';
 
-import { PopularEvent }     from './popular/popular.component';
+import { PopularEvent } from './popular/popular.component';
 
-import {
-    Content,
-} from '../resources/content-search/content';
+import { Content } from '../resources/content-search/content';
 
-import * as moment        from 'moment';
+import * as moment from 'moment';
 
 @Component({
     selector: 'app-search',
     templateUrl: './search.component.html',
-    styleUrls: ['./search.component.less']
+    styleUrls: ['./search.component.less'],
 })
 export class SearchComponent implements OnInit, AfterViewInit {
-
     pageTitle = 'Search';
     pageIcon = 'fa fa-search';
     toolbarConfig: ToolbarConfig;
@@ -108,138 +90,132 @@ export class SearchComponent implements OnInit, AfterViewInit {
                     id: 'keywords',
                     title: 'Keyword',
                     placeholder: 'Keyword',
-                    type: FilterType.TEXT
+                    type: FilterType.TEXT,
                 },
                 {
                     id: 'cloud_platforms',
                     title: 'Cloud Platform',
                     placeholder: 'Cloud Platform',
                     type: FilterType.TYPEAHEAD,
-                    queries: []
+                    queries: [],
                 },
                 {
                     id: 'namespaces',
                     title: 'Contributor',
                     placeholder: 'Name',
-                    type: FilterType.TEXT
+                    type: FilterType.TEXT,
                 },
                 {
                     id: 'contributor_type',
                     title: 'Contributor Type',
                     placeholder: 'Contributur Type',
                     type: FilterType.TYPEAHEAD,
-                    queries: [{
-                        id: ContributorTypes.community,
-                        value: ContributorTypes.community,
-                        iconStyleClass: ContributorTypesIconClasses.community
-                    }, {
-                        id: ContributorTypes.vendor,
-                        value: ContributorTypes.vendor,
-                        iconStyleClass: ContributorTypesIconClasses.vendor
-                    }]
+                    queries: [
+                        {
+                            id: ContributorTypes.community,
+                            value: ContributorTypes.community,
+                            iconStyleClass: ContributorTypesIconClasses.community,
+                        },
+                        {
+                            id: ContributorTypes.vendor,
+                            value: ContributorTypes.vendor,
+                            iconStyleClass: ContributorTypesIconClasses.vendor,
+                        },
+                    ],
                 },
                 {
                     id: 'content_type',
                     title: 'Content Type',
                     placeholder: 'Content Type',
                     type: FilterType.TYPEAHEAD,
-                    queries: []
+                    queries: [],
                 },
                 {
                     id: 'platforms',
                     title: 'Platform',
                     placeholder: 'Platform',
                     type: FilterType.TYPEAHEAD,
-                    queries: []
+                    queries: [],
                 },
                 {
                     id: 'tags',
                     title: 'Tag',
                     placeholder: 'Tag',
-                    type: FilterType.TEXT
-                }
+                    type: FilterType.TEXT,
+                },
             ] as FilterField[],
             resultsCount: 0,
             totalCount: 0,
-            appliedFilters: []
+            appliedFilters: [],
         } as FilterConfig;
 
         this.sortConfig = {
             fields: [] as SortField[],
-              isAscending: true
+            isAscending: true,
         } as SortConfig;
 
         this.emptyStateConfig = {
             info: '',
             title: this.noResultsState,
-            iconStyleClass: 'pficon pficon-filter'
+            iconStyleClass: 'pficon pficon-filter',
         } as EmptyStateConfig;
 
         this.toolbarConfig = {
             filterConfig: this.filterConfig,
-            sortConfig: this.sortConfig
+            sortConfig: this.sortConfig,
         } as ToolbarConfig;
 
         this.listConfig = {
-            emptyStateConfig: this.emptyStateConfig
+            emptyStateConfig: this.emptyStateConfig,
         } as ListConfig;
 
         this.paginationConfig = {
             pageSize: 10,
             pageNumber: 1,
-            totalItems: 0
+            totalItems: 0,
         } as PaginationConfig;
 
         this.route.queryParams.subscribe(params => {
-            this.route.data.subscribe(
-                (data) => {
-                    // This function is called each time the route updates, so
-                    // the default values have to be reset
-                    this.appliedFilters = [];
-                    this.paginationConfig.pageNumber = 1;
-                    this.pageNumber = 1;
-                    this.sortParams = '&order_by=-relevance';
-                    this.setSortConfig(this.sortParams);
+            this.route.data.subscribe(data => {
+                // This function is called each time the route updates, so
+                // the default values have to be reset
+                this.appliedFilters = [];
+                this.paginationConfig.pageNumber = 1;
+                this.pageNumber = 1;
+                this.sortParams = '&order_by=-relevance';
+                this.setSortConfig(this.sortParams);
 
-                    this.preparePlatforms(data.platforms);
-                    this.prepareContentTypes(data.contentTypes);
-                    this.prepareCloudPlatforms(data.cloudPlatforms);
+                this.preparePlatforms(data.platforms);
+                this.prepareContentTypes(data.contentTypes);
+                this.prepareCloudPlatforms(data.cloudPlatforms);
 
-                    // If there is an error on the search API, the content search services
-                    // returns nothing, so we have to check if results actually exist.
-                    if (data.content.results) {
-                        if (!data.content.results.length && !Object.keys(params).length) {
-                            // No vendors exists
-                            const default_params = {vendor: false};
-                            this.setSortConfig();
-                            this.setAppliedFilters(default_params);
-                            this.searchContent();
-                        } else {
-                            this.setSortConfig(params['order_by']);
-                            this.setPageSize(params);
-                            this.setAppliedFilters(params);
-                            this.prepareContent(data.content.results, data.content.count);
-                            this.setQuery();
-                            this.pageLoading = false;
-                        }
+                // If there is an error on the search API, the content search services
+                // returns nothing, so we have to check if results actually exist.
+                if (data.content.results) {
+                    if (!data.content.results.length && !Object.keys(params).length) {
+                        // No vendors exists
+                        const default_params = { vendor: false };
+                        this.setSortConfig();
+                        this.setAppliedFilters(default_params);
+                        this.searchContent();
                     } else {
-                        this.notificationService.message(
-                            NotificationType.WARNING,
-                            'Error',
-                            'Invalid search query',
-                            false,
-                            null,
-                            null,
-                        );
-
                         this.setSortConfig(params['order_by']);
                         this.setPageSize(params);
                         this.setAppliedFilters(params);
-
+                        this.prepareContent(data.content.results, data.content.count);
+                        this.setQuery();
                         this.pageLoading = false;
                     }
+                } else {
+                    this.notificationService.message(NotificationType.WARNING, 'Error', 'Invalid search query', false, null, null);
 
-                });
+                    this.setSortConfig(params['order_by']);
+                    this.setPageSize(params);
+                    this.setAppliedFilters(params);
+
+                    this.pageLoading = false;
+                }
+            });
         });
     }
 
@@ -335,7 +311,7 @@ export class SearchComponent implements OnInit, AfterViewInit {
                 ffield = this.getFilterField('tags');
                 filter = {
                     field: ffield,
-                    value: $event.item['name']
+                    value: $event.item['name'],
                 } as Filter;
                 break;
             case 'cloudPlatforms':
@@ -344,7 +320,7 @@ export class SearchComponent implements OnInit, AfterViewInit {
                 filter = {
                     field: ffield,
                     query: query,
-                    value: $event.item['name']
+                    value: $event.item['name'],
                 } as Filter;
                 break;
             case 'platforms':
@@ -353,7 +329,7 @@ export class SearchComponent implements OnInit, AfterViewInit {
                 filter = {
                     field: ffield,
                     query: query,
-                    value: $event.item['name']
+                    value: $event.item['name'],
                 } as Filter;
                 break;
         }
@@ -385,16 +361,16 @@ export class SearchComponent implements OnInit, AfterViewInit {
             this.paginationConfig.pageSize = pageSize;
             this.pageSize = pageSize;
         }
-       if (params['page']) {
-           let pageNumber = Number(params['page']);
+        if (params['page']) {
+            let pageNumber = Number(params['page']);
 
-           if (Number.isNaN(pageNumber)) {
-               pageNumber = 1;
-           }
+            if (Number.isNaN(pageNumber)) {
+                pageNumber = 1;
+            }
 
-           this.paginationConfig.pageNumber = pageNumber;
-           this.pageNumber = pageNumber;
-       }
+            this.paginationConfig.pageNumber = pageNumber;
+            this.pageNumber = pageNumber;
+        }
     }
 
     private setAppliedFilters(queryParams: any) {
@@ -446,7 +422,7 @@ export class SearchComponent implements OnInit, AfterViewInit {
                         const ffield: Filter = {} as Filter;
                         ffield.field = field;
                         if (field.type === FilterType.TEXT) {
-                              ffield.value = v;
+                            ffield.value = v;
                         } else if (field.type === FilterType.TYPEAHEAD) {
                             field.queries.forEach((query: FilterQuery) => {
                                 if (query.id === v) {
@@ -491,7 +467,7 @@ export class SearchComponent implements OnInit, AfterViewInit {
 
     private addToFilter(filter: Filter) {
         let filterExists = false;
-        this.appliedFilters.forEach( (item: Filter) => {
+        this.appliedFilters.forEach((item: Filter) => {
             if (item.field.id === filter.field.id && item.value === filter.value) {
                 filterExists = true;
             }
@@ -506,19 +482,18 @@ export class SearchComponent implements OnInit, AfterViewInit {
         if (this.pageNumber > 1) {
             paging += `&page=${this.pageNumber}`;
         }
-        const query = (this.filterParams + this.sortParams + paging).replace(/^&/, '');  // remove leading &
-        this.location.replaceState(this.getBasePath(), query);   // update browser URL
+        const query = (this.filterParams + this.sortParams + paging).replace(/^&/, ''); // remove leading &
+        this.location.replaceState(this.getBasePath(), query); // update browser URL
         return query;
     }
 
     private searchContent() {
         this.pageLoading = true;
         const query = this.setQuery();
-        this.contentSearch.query(query)
-            .subscribe(result => {
-                this.prepareContent(result.results, result.count);
-                this.pageLoading = false;
-            });
+        this.contentSearch.query(query).subscribe(result => {
+            this.prepareContent(result.results, result.count);
+            this.pageLoading = false;
+        });
     }
 
     private prepareContent(data: Content[], count: number) {
@@ -536,7 +511,7 @@ export class SearchComponent implements OnInit, AfterViewInit {
                 item['namespace_name'] = item.summary_fields['namespace']['name'];
             } else {
                 // for vendors, assume name is in logo
-                item['namespace_name'] = (item.summary_fields['namespace']['avatar_url']) ? '' : item.summary_fields['namespace']['name'];
+                item['namespace_name'] = item.summary_fields['namespace']['avatar_url'] ? '' : item.summary_fields['namespace']['name'];
             }
             item['displayNamespace'] = item.summary_fields['namespace']['name'];
             if (item.summary_fields['content_type']['name'].indexOf('plugin') > -1) {
@@ -584,7 +559,7 @@ export class SearchComponent implements OnInit, AfterViewInit {
                 if (platformMap.hasOwnProperty(key)) {
                     this.toolbarConfig.filterConfig.fields[idx].queries.push({
                         id: key,
-                        value: key
+                        value: key,
                     });
                 }
             }
@@ -612,7 +587,7 @@ export class SearchComponent implements OnInit, AfterViewInit {
                 if (contentTypeMap.hasOwnProperty(key)) {
                     this.toolbarConfig.filterConfig.fields[idx].queries.push({
                         id: key,
-                        value: contentTypeMap[key]
+                        value: contentTypeMap[key],
                     });
                 }
             }
@@ -632,7 +607,7 @@ export class SearchComponent implements OnInit, AfterViewInit {
                 if (cpMap.hasOwnProperty(key)) {
                     this.toolbarConfig.filterConfig.fields[idx].queries.push({
                         id: key,
-                        value: cpMap[key]
+                        value: cpMap[key],
                     });
                 }
             }
@@ -644,30 +619,33 @@ export class SearchComponent implements OnInit, AfterViewInit {
             {
                 id: 'relevance',
                 title: 'Best Match',
-                sortType: 'numeric'
-            }, {
+                sortType: 'numeric',
+            },
+            {
                 id: 'namespace__name,name',
                 title: 'Contributor Name',
-                sortType: 'alpha'
-            }, {
+                sortType: 'alpha',
+            },
+            {
                 id: 'repository__download_count',
                 title: 'Download Count',
-                sortType: 'numeric'
-
-            }, {
+                sortType: 'numeric',
+            },
+            {
                 id: 'repository__forks_count',
                 title: 'Forks',
-                sortType: 'numeric'
-            }
-            , {
+                sortType: 'numeric',
+            },
+            {
                 id: 'repository__stargazers_count',
                 title: 'Stars',
-                sortType: 'numeric'
-            }, {
+                sortType: 'numeric',
+            },
+            {
                 id: 'repository__watchers_count',
                 title: 'Watchers',
-                sortType: 'numeric'
-            }
+                sortType: 'numeric',
+            },
         ] as SortField[];
 
         this.sortParams = '&order_by=';

--- a/galaxyui/src/app/search/search.module.ts
+++ b/galaxyui/src/app/search/search.module.ts
@@ -1,23 +1,23 @@
-import { CommonModule }        from '@angular/common';
-import { NgModule }            from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
-import { BsDropdownModule }    from 'ngx-bootstrap';
+import { BsDropdownModule } from 'ngx-bootstrap';
 
-import { TooltipModule }               from 'ngx-bootstrap/tooltip';
-import { ActionModule }        from 'patternfly-ng/action/action.module';
-import { EmptyStateModule }    from 'patternfly-ng/empty-state/empty-state.module';
-import { FilterModule }        from 'patternfly-ng/filter/filter.module';
-import { ListModule }          from 'patternfly-ng/list/basic-list/list.module';
-import { PaginationModule }    from 'patternfly-ng/pagination/pagination.module';
-import { SortModule }          from 'patternfly-ng/sort/sort.module';
-import { ToolbarModule }       from 'patternfly-ng/toolbar/toolbar.module';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ActionModule } from 'patternfly-ng/action/action.module';
+import { EmptyStateModule } from 'patternfly-ng/empty-state/empty-state.module';
+import { FilterModule } from 'patternfly-ng/filter/filter.module';
+import { ListModule } from 'patternfly-ng/list/basic-list/list.module';
+import { PaginationModule } from 'patternfly-ng/pagination/pagination.module';
+import { SortModule } from 'patternfly-ng/sort/sort.module';
+import { ToolbarModule } from 'patternfly-ng/toolbar/toolbar.module';
 
-import { PopularComponent }    from './popular/popular.component';
+import { PopularComponent } from './popular/popular.component';
 import { SearchRoutingModule } from './search-routing.module';
-import { SearchComponent }     from './search.component';
+import { SearchComponent } from './search.component';
 
-import { PageHeaderModule }    from '../page-header/page-header.module';
-import { PageLoadingModule }   from '../page-loading/page-loading.module';
+import { PageHeaderModule } from '../page-header/page-header.module';
+import { PageLoadingModule } from '../page-loading/page-loading.module';
 
 @NgModule({
     imports: [
@@ -33,11 +33,8 @@ import { PageLoadingModule }   from '../page-loading/page-loading.module';
         PageHeaderModule,
         PageLoadingModule,
         PaginationModule,
-        BsDropdownModule.forRoot()
+        BsDropdownModule.forRoot(),
     ],
-    declarations: [
-        SearchComponent,
-        PopularComponent
-    ]
+    declarations: [SearchComponent, PopularComponent],
 })
-export class SearchModule { }
+export class SearchModule {}

--- a/galaxyui/src/app/search/search.resolver.service.ts
+++ b/galaxyui/src/app/search/search.resolver.service.ts
@@ -1,36 +1,28 @@
-import {
-    Injectable
-} from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import {
-    ActivatedRouteSnapshot,
-    Resolve,
-    RouterStateSnapshot
-} from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
 
-import { Observable }            from 'rxjs/Observable';
-import { ContentResponse }       from '../resources/content-search/content';
-import { ContentSearchService }  from '../resources/content-search/content-search.service';
+import { Observable } from 'rxjs/Observable';
+import { ContentResponse } from '../resources/content-search/content';
+import { ContentSearchService } from '../resources/content-search/content-search.service';
 
-import { Platform }              from '../resources/platforms/platform';
-import { PlatformService }       from '../resources/platforms/platform.service';
+import { Platform } from '../resources/platforms/platform';
+import { PlatformService } from '../resources/platforms/platform.service';
 
-import { ContentType }           from '../resources/content-types/content-type';
-import { ContentTypeService }    from '../resources/content-types/content-type.service';
+import { ContentType } from '../resources/content-types/content-type';
+import { ContentTypeService } from '../resources/content-types/content-type.service';
 
-import { CloudPlatform }         from '../resources/cloud-platforms/cloud-platform';
-import { CloudPlatformService }  from '../resources/cloud-platforms/cloud-platform.service';
+import { CloudPlatform } from '../resources/cloud-platforms/cloud-platform';
+import { CloudPlatformService } from '../resources/cloud-platforms/cloud-platform.service';
 
-import { Tag }                   from '../resources/tags/tag';
-import { TagsService }           from '../resources/tags/tags.service';
+import { Tag } from '../resources/tags/tag';
+import { TagsService } from '../resources/tags/tags.service';
 
-import { ContributorTypes }      from '../enums/contributor-types.enum';
+import { ContributorTypes } from '../enums/contributor-types.enum';
 
 @Injectable()
 export class SearchContentResolver implements Resolve<ContentResponse> {
-    constructor(
-        private contentService: ContentSearchService,
-    ) {}
+    constructor(private contentService: ContentSearchService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<ContentResponse> {
         let params = '';
         for (const key in route.queryParams) {
@@ -68,51 +60,41 @@ export class SearchContentResolver implements Resolve<ContentResponse> {
 
 @Injectable()
 export class SearchPlatformResolver implements Resolve<Platform[]> {
-    constructor(
-        private platformService: PlatformService,
-    ) {}
+    constructor(private platformService: PlatformService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Platform[]> {
-        return this.platformService.query({'page_size': 1000});
+        return this.platformService.query({ page_size: 1000 });
     }
 }
 
 @Injectable()
 export class SearchContentTypeResolver implements Resolve<ContentType[]> {
-    constructor(
-        private contentTypeService: ContentTypeService,
-    ) {}
+    constructor(private contentTypeService: ContentTypeService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<ContentType[]> {
-        return this.contentTypeService.query({'page_size': 1000, 'order': 'description'});
+        return this.contentTypeService.query({ page_size: 1000, order: 'description' });
     }
 }
 
 @Injectable()
 export class SearchCloudPlatformResolver implements Resolve<CloudPlatform[]> {
-    constructor(
-        private contentTypeService: CloudPlatformService,
-    ) {}
+    constructor(private contentTypeService: CloudPlatformService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<CloudPlatform[]> {
-        return this.contentTypeService.query({'page_size': 1000});
+        return this.contentTypeService.query({ page_size: 1000 });
     }
 }
 
 @Injectable()
 export class PopularTagsResolver implements Resolve<Tag[]> {
-    constructor(
-        private tagsService: TagsService,
-    ) {}
+    constructor(private tagsService: TagsService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Tag[]> {
-        return this.tagsService.search({'order_by': '-roles_count,name'});
+        return this.tagsService.search({ order_by: '-roles_count,name' });
     }
 }
 
 @Injectable()
 export class PopularPlatformsResolver implements Resolve<Platform[]> {
-    constructor(
-        private platformService: PlatformService,
-    ) {}
+    constructor(private platformService: PlatformService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Platform[]> {
-        return this.platformService.search({'page_size': 1000, 'order_by': '-roles_count,name'}).map(result => {
+        return this.platformService.search({ page_size: 1000, order_by: '-roles_count,name' }).map(result => {
             // Sum roles_count per platforms, sans release
             const summary = {};
             const platforms: Platform[] = [];
@@ -126,7 +108,7 @@ export class PopularPlatformsResolver implements Resolve<Platform[]> {
                 if (summary.hasOwnProperty(key)) {
                     platforms.push({
                         name: key,
-                        roles_count: summary[key]
+                        roles_count: summary[key],
                     } as Platform);
                 }
             }
@@ -137,10 +119,8 @@ export class PopularPlatformsResolver implements Resolve<Platform[]> {
 
 @Injectable()
 export class PopularCloudPlatformsResolver implements Resolve<CloudPlatform[]> {
-    constructor(
-        private cloudPlatformService: CloudPlatformService,
-    ) {}
+    constructor(private cloudPlatformService: CloudPlatformService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<CloudPlatform[]> {
-        return this.cloudPlatformService.search({'order_by': '-roles_count,name'});
+        return this.cloudPlatformService.search({ order_by: '-roles_count,name' });
     }
 }

--- a/galaxyui/src/app/user-notifications/user-notifications.component.spec.ts
+++ b/galaxyui/src/app/user-notifications/user-notifications.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { UserNotificationsComponent } from './user-notifications.component';
 
 describe('UserNotificationsComponent', () => {
-  let component: UserNotificationsComponent;
-  let fixture: ComponentFixture<UserNotificationsComponent>;
+    let component: UserNotificationsComponent;
+    let fixture: ComponentFixture<UserNotificationsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ UserNotificationsComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [UserNotificationsComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(UserNotificationsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(UserNotificationsComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/user-notifications/user-notifications.component.ts
+++ b/galaxyui/src/app/user-notifications/user-notifications.component.ts
@@ -1,25 +1,20 @@
-import {
-    Component,
-    OnInit,
-    ViewEncapsulation
-} from '@angular/core';
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 
-import { NotificationEvent }    from 'patternfly-ng';
-import { Notification }         from 'patternfly-ng/notification/notification';
-import { NotificationService }  from 'patternfly-ng/notification/notification-service/notification.service';
+import { NotificationEvent } from 'patternfly-ng';
+import { Notification } from 'patternfly-ng/notification/notification';
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
 
 @Component({
     encapsulation: ViewEncapsulation.None,
     selector: 'user-notifications',
     templateUrl: './user-notifications.component.html',
-    styleUrls: ['./user-notifications.component.less']
+    styleUrls: ['./user-notifications.component.less'],
 })
 export class UserNotificationsComponent implements OnInit {
     showClose = true;
     notifications: Notification[];
 
-    constructor(private notificationService: NotificationService) {
-    }
+    constructor(private notificationService: NotificationService) {}
 
     ngOnInit(): void {
         this.notifications = this.notificationService.getNotifications();

--- a/galaxyui/src/app/utilities/clipboard/clipboard.component.ts
+++ b/galaxyui/src/app/utilities/clipboard/clipboard.component.ts
@@ -1,16 +1,11 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 @Component({
     selector: 'copy-to-clipboard',
     templateUrl: './clipboard.component.html',
-    styleUrls: ['./clipboard.component.less']
+    styleUrls: ['./clipboard.component.less'],
 })
 export class ClipboardComponent implements OnInit {
-
     constructor() {}
 
     _copyText: string;
@@ -30,12 +25,12 @@ export class ClipboardComponent implements OnInit {
 
     s4(): string {
         return Math.floor((1 + Math.random()) * 0x10000)
-          .toString(16)
-          .substring(1);
+            .toString(16)
+            .substring(1);
     }
 
     calcGuid(): string {
-      return this.s4() + this.s4() + '-' + this.s4() + '-' + this.s4() + '-' + this.s4() + '-' + this.s4() + this.s4() + this.s4();
+        return this.s4() + this.s4() + '-' + this.s4() + '-' + this.s4() + '-' + this.s4() + '-' + this.s4() + this.s4() + this.s4();
     }
 
     copyToClipboard() {

--- a/galaxyui/src/app/utilities/utilities.module.ts
+++ b/galaxyui/src/app/utilities/utilities.module.ts
@@ -1,20 +1,13 @@
-import { CommonModule }    from '@angular/common';
-import { NgModule }        from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
-import { TooltipModule }       from 'ngx-bootstrap/tooltip';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
-import { ClipboardComponent }  from './clipboard/clipboard.component';
+import { ClipboardComponent } from './clipboard/clipboard.component';
 
 @NgModule({
-    imports: [
-        CommonModule,
-        TooltipModule
-    ],
-    declarations: [
-        ClipboardComponent
-    ],
-    exports: [
-        ClipboardComponent
-    ]
+    imports: [CommonModule, TooltipModule],
+    declarations: [ClipboardComponent],
+    exports: [ClipboardComponent],
 })
-export class UtilitiesModule { }
+export class UtilitiesModule {}

--- a/galaxyui/src/app/vendors/card/vendor-card.component.ts
+++ b/galaxyui/src/app/vendors/card/vendor-card.component.ts
@@ -1,25 +1,16 @@
-import {
-    Component,
-    Input,
-    OnInit
-} from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
-import {
-    Router
-} from '@angular/router';
+import { Router } from '@angular/router';
 
-import { Namespace }     from '../../resources/namespaces/namespace';
+import { Namespace } from '../../resources/namespaces/namespace';
 
 @Component({
     selector: 'vendor-card',
     templateUrl: './vendor-card.component.html',
-    styleUrls: ['./vendor-card.component.less']
+    styleUrls: ['./vendor-card.component.less'],
 })
 export class VendorCardComponent implements OnInit {
-
-    constructor(
-        private router: Router
-    ) {}
+    constructor(private router: Router) {}
 
     _vendor: Namespace;
 

--- a/galaxyui/src/app/vendors/vendors.component.ts
+++ b/galaxyui/src/app/vendors/vendors.component.ts
@@ -1,47 +1,32 @@
-import {
-    Component,
-    OnInit
-} from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
-import {
-    ActivatedRoute,
-    Router
-} from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
-import { ActionConfig }       from 'patternfly-ng/action/action-config';
-import { EmptyStateConfig }   from 'patternfly-ng/empty-state/empty-state-config';
-import { Filter }             from 'patternfly-ng/filter/filter';
-import { FilterConfig }       from 'patternfly-ng/filter/filter-config';
-import { FilterField }        from 'patternfly-ng/filter/filter-field';
-import { FilterType }         from 'patternfly-ng/filter/filter-type';
-import { ListEvent }          from 'patternfly-ng/list/list-event';
-import { PaginationConfig }   from 'patternfly-ng/pagination/pagination-config';
-import { PaginationEvent }    from 'patternfly-ng/pagination/pagination-event';
-import { SortConfig }         from 'patternfly-ng/sort/sort-config';
-import { SortEvent }          from 'patternfly-ng/sort/sort-event';
-import { ToolbarConfig }      from 'patternfly-ng/toolbar/toolbar-config';
+import { ActionConfig } from 'patternfly-ng/action/action-config';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state/empty-state-config';
+import { Filter } from 'patternfly-ng/filter/filter';
+import { FilterConfig } from 'patternfly-ng/filter/filter-config';
+import { FilterField } from 'patternfly-ng/filter/filter-field';
+import { FilterType } from 'patternfly-ng/filter/filter-type';
+import { ListEvent } from 'patternfly-ng/list/list-event';
+import { PaginationConfig } from 'patternfly-ng/pagination/pagination-config';
+import { PaginationEvent } from 'patternfly-ng/pagination/pagination-event';
+import { SortConfig } from 'patternfly-ng/sort/sort-config';
+import { SortEvent } from 'patternfly-ng/sort/sort-event';
+import { ToolbarConfig } from 'patternfly-ng/toolbar/toolbar-config';
 
-import { Namespace }          from '../resources/namespaces/namespace';
-import { NamespaceService }   from '../resources/namespaces/namespace.service';
+import { Namespace } from '../resources/namespaces/namespace';
+import { NamespaceService } from '../resources/namespaces/namespace.service';
 
-import {
-    ContentTypes,
-    ContentTypesIconClasses,
-    ContentTypesPluralChoices
-} from '../enums/content-types.enum';
+import { ContentTypes, ContentTypesIconClasses, ContentTypesPluralChoices } from '../enums/content-types.enum';
 
 @Component({
     selector: 'app-vendors',
     templateUrl: './vendors.component.html',
-    styleUrls: ['./vendors.component.less']
+    styleUrls: ['./vendors.component.less'],
 })
 export class VendorsComponent implements OnInit {
-
-    constructor(
-        private router: Router,
-          private route: ActivatedRoute,
-          private namespaceService: NamespaceService
-    ) {}
+    constructor(private router: Router, private route: ActivatedRoute, private namespaceService: NamespaceService) {}
 
     pageTitle = 'Partners';
     headerIcon = 'fa fa-star';
@@ -56,7 +41,7 @@ export class VendorsComponent implements OnInit {
     paginationConfig: PaginationConfig;
     sortBy = 'name';
     filterBy: any = {
-        'is_vendor': 'true'
+        is_vendor: 'true',
     };
     pageNumber = 1;
     pageSize = 10;
@@ -65,7 +50,7 @@ export class VendorsComponent implements OnInit {
         this.emptyStateConfig = {
             info: '',
             title: 'No partners match your search',
-            iconStyleClass: 'pficon pficon-filter'
+            iconStyleClass: 'pficon pficon-filter',
         } as EmptyStateConfig;
 
         this.filterConfig = {
@@ -74,17 +59,17 @@ export class VendorsComponent implements OnInit {
                     id: 'name',
                     title: 'Name',
                     placeholder: 'Filter by Name...',
-                    type: FilterType.TEXT
+                    type: FilterType.TEXT,
                 },
                 {
                     id: 'description',
                     title: 'Description',
                     placeholder: 'Filter by Description...',
-                    type: FilterType.TEXT
-                }
+                    type: FilterType.TEXT,
+                },
             ] as FilterField[],
             resultsCount: 0,
-            appliedFilters: [] as Filter[]
+            appliedFilters: [] as Filter[],
         } as FilterConfig;
 
         this.sortConfig = {
@@ -92,36 +77,36 @@ export class VendorsComponent implements OnInit {
                 {
                     id: 'name',
                     title: 'Name',
-                    sortType: 'alpha'
+                    sortType: 'alpha',
                 },
                 {
                     id: 'description',
                     title: 'Description',
-                    sortType: 'alpha'
-                }
+                    sortType: 'alpha',
+                },
             ],
-            isAscending: true
+            isAscending: true,
         } as SortConfig;
 
         this.toolbarActionConfig = {
             primaryActions: [],
-            moreActions: []
+            moreActions: [],
         } as ActionConfig;
 
         this.toolbarConfig = {
             actionConfig: this.toolbarActionConfig,
             filterConfig: this.filterConfig,
             sortConfig: this.sortConfig,
-            views: []
+            views: [],
         } as ToolbarConfig;
 
         this.paginationConfig = {
             pageSize: 10,
             pageNumber: 1,
-            totalItems: 0
+            totalItems: 0,
         } as PaginationConfig;
 
-        this.route.data.subscribe((data) => {
+        this.route.data.subscribe(data => {
             this.items = data['vendors']['results'];
             this.paginationConfig.totalItems = data['vendors']['count'];
             this.prepareNamespaces();
@@ -143,7 +128,7 @@ export class VendorsComponent implements OnInit {
             });
         } else {
             this.filterBy = {
-                'is_vendor': 'true'
+                is_vendor: 'true',
             };
         }
         this.pageNumber = 1;
@@ -223,13 +208,12 @@ export class VendorsComponent implements OnInit {
         this.filterBy['page_size'] = this.pageSize;
         this.filterBy['page'] = this.pageNumber;
         this.filterBy['order'] = this.sortBy;
-        this.namespaceService.pagedQuery(this.filterBy)
-            .subscribe(result => {
-                this.items = result.results as Namespace[];
-                this.prepareNamespaces();
-                this.filterConfig.resultsCount = result.count;
-                this.paginationConfig.totalItems = result.count;
-                this.pageLoading = false;
-            });
+        this.namespaceService.pagedQuery(this.filterBy).subscribe(result => {
+            this.items = result.results as Namespace[];
+            this.prepareNamespaces();
+            this.filterConfig.resultsCount = result.count;
+            this.paginationConfig.totalItems = result.count;
+            this.pageLoading = false;
+        });
     }
 }

--- a/galaxyui/src/app/vendors/vendors.module.ts
+++ b/galaxyui/src/app/vendors/vendors.module.ts
@@ -1,19 +1,19 @@
-import { CommonModule }    from '@angular/common';
-import { NgModule }        from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
-import { TooltipModule }           from 'ngx-bootstrap/tooltip';
-import { ActionModule }            from 'patternfly-ng/action/action.module';
-import { EmptyStateModule }        from 'patternfly-ng/empty-state/empty-state.module';
-import { FilterModule }            from 'patternfly-ng/filter/filter.module';
-import { ListModule }              from 'patternfly-ng/list/basic-list/list.module';
-import { PaginationModule }        from 'patternfly-ng/pagination/pagination.module';
-import { ToolbarModule }           from 'patternfly-ng/toolbar/toolbar.module';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ActionModule } from 'patternfly-ng/action/action.module';
+import { EmptyStateModule } from 'patternfly-ng/empty-state/empty-state.module';
+import { FilterModule } from 'patternfly-ng/filter/filter.module';
+import { ListModule } from 'patternfly-ng/list/basic-list/list.module';
+import { PaginationModule } from 'patternfly-ng/pagination/pagination.module';
+import { ToolbarModule } from 'patternfly-ng/toolbar/toolbar.module';
 
-import { PageHeaderModule }        from '../page-header/page-header.module';
-import { PageLoadingModule }       from '../page-loading/page-loading.module';
-import { VendorCardComponent }     from './card/vendor-card.component';
-import { VendorsComponent }        from './vendors.component';
-import { VendorsRoutingModule }    from './vendors.routing.module';
+import { PageHeaderModule } from '../page-header/page-header.module';
+import { PageLoadingModule } from '../page-loading/page-loading.module';
+import { VendorCardComponent } from './card/vendor-card.component';
+import { VendorsComponent } from './vendors.component';
+import { VendorsRoutingModule } from './vendors.routing.module';
 
 @NgModule({
     imports: [
@@ -27,11 +27,8 @@ import { VendorsRoutingModule }    from './vendors.routing.module';
         VendorsRoutingModule,
         PageHeaderModule,
         PageLoadingModule,
-        ActionModule
+        ActionModule,
     ],
-    declarations: [
-        VendorsComponent,
-        VendorCardComponent
-    ]
+    declarations: [VendorsComponent, VendorCardComponent],
 })
-export class VendorsModule { }
+export class VendorsModule {}

--- a/galaxyui/src/app/vendors/vendors.resolver.service.ts
+++ b/galaxyui/src/app/vendors/vendors.resolver.service.ts
@@ -1,24 +1,16 @@
-import {
-    Injectable
-} from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import {
-    ActivatedRouteSnapshot,
-    Resolve,
-    RouterStateSnapshot
-} from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
 
-import { Observable }            from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 
-import { NamespaceService }      from '../resources/namespaces/namespace.service';
-import { PagedResponse }         from '../resources/paged-response';
+import { NamespaceService } from '../resources/namespaces/namespace.service';
+import { PagedResponse } from '../resources/paged-response';
 
 @Injectable()
 export class VendorListResolver implements Resolve<PagedResponse> {
-    constructor(
-        private namespaceService: NamespaceService,
-    ) {}
+    constructor(private namespaceService: NamespaceService) {}
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<PagedResponse> {
-        return this.namespaceService.pagedQuery({is_vendor: 'true'});
+        return this.namespaceService.pagedQuery({ is_vendor: 'true' });
     }
 }

--- a/galaxyui/src/app/vendors/vendors.routing.module.ts
+++ b/galaxyui/src/app/vendors/vendors.routing.module.ts
@@ -1,36 +1,24 @@
-import {
-       NgModule
+import { NgModule } from '@angular/core';
 
-} from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
 
-import {
-    RouterModule,
-    Routes
-} from '@angular/router';
+import { VendorListResolver } from './vendors.resolver.service';
 
-import {
-    VendorListResolver
-}  from './vendors.resolver.service';
+import { VendorsComponent } from './vendors.component';
 
-import { VendorsComponent }         from './vendors.component';
-
-const routes: Routes = [{
-    path: 'partners',
-    component: VendorsComponent,
-    resolve: {
-        vendors: VendorListResolver
-    }
-}];
+const routes: Routes = [
+    {
+        path: 'partners',
+        component: VendorsComponent,
+        resolve: {
+            vendors: VendorListResolver,
+        },
+    },
+];
 
 @NgModule({
-    imports: [
-        RouterModule.forChild(routes)
-    ],
-    exports: [
-        RouterModule
-    ],
-    providers: [
-        VendorListResolver
-    ]
+    imports: [RouterModule.forChild(routes)],
+    exports: [RouterModule],
+    providers: [VendorListResolver],
 })
-export class VendorsRoutingModule { }
+export class VendorsRoutingModule {}

--- a/galaxyui/src/environments/environment.prod.ts
+++ b/galaxyui/src/environments/environment.prod.ts
@@ -1,3 +1,3 @@
 export const environment = {
-  production: true
+    production: true,
 };

--- a/galaxyui/src/environments/environment.ts
+++ b/galaxyui/src/environments/environment.ts
@@ -4,5 +4,5 @@
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
 export const environment = {
-  production: false
+    production: false,
 };

--- a/galaxyui/src/main.ts
+++ b/galaxyui/src/main.ts
@@ -5,8 +5,9 @@ import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
 if (environment.production) {
-  enableProdMode();
+    enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.log(err));
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch(err => console.log(err));

--- a/galaxyui/src/polyfills.ts
+++ b/galaxyui/src/polyfills.ts
@@ -53,7 +53,7 @@ import 'core-js/es7/reflect';
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js/dist/zone'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/galaxyui/src/test.ts
+++ b/galaxyui/src/test.ts
@@ -1,19 +1,13 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
 import { getTestBed } from '@angular/core/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting
-} from '@angular/platform-browser-dynamic/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 import 'zone.js/dist/zone-testing';
 
 declare const require: any;
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.

--- a/galaxyui/src/typings.d.ts
+++ b/galaxyui/src/typings.d.ts
@@ -1,5 +1,5 @@
 /* SystemJS module definition */
 declare var module: NodeModule;
 interface NodeModule {
-  id: string;
+    id: string;
 }

--- a/galaxyui/yarn.lock
+++ b/galaxyui/yarn.lock
@@ -5766,6 +5766,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.0.tgz#847c235522035fd988100f1f43cf20a7d24f9372"
+
 pretty-error@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"

--- a/scripts/docker/dev/start-develop.sh
+++ b/scripts/docker/dev/start-develop.sh
@@ -7,7 +7,6 @@ cd /galaxy
 
 make waitenv
 make build/yarn
-make test/jslint
 make build/static
 
 cd /galaxy


### PR DESCRIPTION
- Added `galaxyui/.prettierrc.yaml` to configure code formatting options
- Added `make dev/prettier` to format `.ts` and `.less` files in `galaxyui/src`
- Added prettier to node dependencies
- Added `make test/prettier` to check for unformatted code
- Added check during dev container start to verify that no unformatted code is added
- Updated contributing guide

#861