### PR TITLE
Revert deletion of CustomUser model methods

### DIFF
--- a/galaxy/accounts/models.py
+++ b/galaxy/accounts/models.py
@@ -93,6 +93,14 @@ class CustomUser(auth_models.AbstractBaseUser,
     def get_absolute_url(self):
         return "/users/%s/" % urlquote(self.username)
 
+    # FIXME: This method implementation is optional since Django 2.0
+    def get_full_name(self):
+        return self.full_name.strip()
+
+    # FIXME: This method implementation is optional since Django 2.0
+    def get_short_name(self):
+        return self.short_name.strip()
+
     def get_subscriptions(self):
         return [{
             'id': g.id,


### PR DESCRIPTION
A `CustomUser` class is inherited from an abstract base
`AbstractBaseUser`, which requires methods `get_full_name()` and
`get_short_name()` to be implemented.

Note: These methods are not required since Django 2.0 and
their usage should be reviwed after upgrade.

Signed-off-by: Alexander Saprykin <osapryki@redhat.com>