### PR TITLE
Backport/739 lazy loading

### DIFF
--- a/galaxyui/src/app/app-routing.module.ts
+++ b/galaxyui/src/app/app-routing.module.ts
@@ -1,12 +1,26 @@
-import { NgModule }             from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
-import { NotFoundComponent }    from './exception-pages/not-found/not-found.component';
+import { NgModule }              from '@angular/core';
+import { RouterModule, Routes }  from '@angular/router';
+import { NotFoundComponent }     from './exception-pages/not-found/not-found.component';
+import { AuthorDetailComponent } from './authors/detail/author-detail.component'
+import {
+    NamespaceDetailResolver,
+    RepositoryResolver
+}  from './authors/authors.resolver.service';
+
+
 
 const appRoutes: Routes = [
     {
         path: '',
         redirectTo: '/home',
         pathMatch: 'full'
+    }, {
+        path: ':namespace',
+        component: AuthorDetailComponent,
+        resolve: {
+            namespace: NamespaceDetailResolver,
+            repositories: RepositoryResolver
+        }
     }, {
         path: '**',
         component: NotFoundComponent

--- a/galaxyui/src/app/app-routing.module.ts
+++ b/galaxyui/src/app/app-routing.module.ts
@@ -15,6 +15,9 @@ const appRoutes: Routes = [
         redirectTo: '/home',
         pathMatch: 'full'
     }, {
+        path: 'my-imports',
+        loadChildren: './my-imports/my-imports.module#MyImportsModule'
+    }, {
         path: ':namespace',
         component: AuthorDetailComponent,
         resolve: {

--- a/galaxyui/src/app/app-routing.module.ts
+++ b/galaxyui/src/app/app-routing.module.ts
@@ -1,18 +1,25 @@
 import { NgModule }              from '@angular/core';
-import { RouterModule, Routes }  from '@angular/router';
 import { NotFoundComponent }     from './exception-pages/not-found/not-found.component';
-import { AuthorDetailComponent } from './authors/detail/author-detail.component'
-import {
-    NamespaceDetailResolver,
-    RepositoryResolver as AuthorRepositoryResolver
-}  from './authors/authors.resolver.service';
-
+import { AuthorDetailComponent } from './authors/detail/author-detail.component';
 import { ContentDetailComponent } from './content-detail/content-detail.component';
+
 import {
     ContentResolver,
     RepositoryResolver as ContentRepositoryResolver,
     NamespaceResolver
 } from './content-detail/content-detail.resolver.service';
+
+import {
+    NamespaceDetailResolver,
+    RepositoryResolver as AuthorRepositoryResolver
+}  from './authors/authors.resolver.service';
+
+
+import {
+    RouterModule,
+    Routes,
+    PreloadAllModules
+}  from '@angular/router';
 
 
 const appRoutes: Routes = [
@@ -21,11 +28,14 @@ const appRoutes: Routes = [
         redirectTo: '/home',
         pathMatch: 'full'
     }, {
-        path: 'my-imports',
-        loadChildren: './my-imports/my-imports.module#MyImportsModule'
+        path: 'search',
+        loadChildren: './search/search.module#SearchModule'
     }, {
         path: 'my-content',
         loadChildren: './my-content/my-content.module#MyContentModule'
+    }, {
+        path: 'my-imports',
+        loadChildren: './my-imports/my-imports.module#MyImportsModule'
     }, {
         path: ':namespace/:repository/:content_name',
         component: ContentDetailComponent,
@@ -59,7 +69,8 @@ const appRoutes: Routes = [
     imports: [
         RouterModule.forRoot(appRoutes, {
             enableTracing: false,
-            onSameUrlNavigation: 'reload'
+            onSameUrlNavigation: 'reload',
+            preloadingStrategy: PreloadAllModules
         })
     ],
     exports: [ RouterModule ]

--- a/galaxyui/src/app/app-routing.module.ts
+++ b/galaxyui/src/app/app-routing.module.ts
@@ -2,6 +2,7 @@ import { NgModule }              from '@angular/core';
 import { NotFoundComponent }     from './exception-pages/not-found/not-found.component';
 import { AuthorDetailComponent } from './authors/detail/author-detail.component';
 import { ContentDetailComponent } from './content-detail/content-detail.component';
+import { AuthService }           from './auth/auth.service';
 
 import {
     ContentResolver,
@@ -27,16 +28,26 @@ const appRoutes: Routes = [
         path: '',
         redirectTo: '/home',
         pathMatch: 'full'
-    }, {
+    },
+
+    // Lazily loaded modules
+    {
         path: 'search',
         loadChildren: './search/search.module#SearchModule'
     }, {
         path: 'my-content',
-        loadChildren: './my-content/my-content.module#MyContentModule'
+        loadChildren: './my-content/my-content.module#MyContentModule',
+        canLoad: [AuthService]
     }, {
         path: 'my-imports',
-        loadChildren: './my-imports/my-imports.module#MyImportsModule'
-    }, {
+        loadChildren: './my-imports/my-imports.module#MyImportsModule',
+        canLoad: [AuthService]
+    },
+
+    // Routes that resolve variables have to go in app-routing.module to ensure
+    // that they are resolved between the static routes ('/search', '/my-content' etc)
+    // and the wildcard ('**')
+     {
         path: ':namespace/:repository/:content_name',
         component: ContentDetailComponent,
         resolve: {

--- a/galaxyui/src/app/app-routing.module.ts
+++ b/galaxyui/src/app/app-routing.module.ts
@@ -4,9 +4,15 @@ import { NotFoundComponent }     from './exception-pages/not-found/not-found.com
 import { AuthorDetailComponent } from './authors/detail/author-detail.component'
 import {
     NamespaceDetailResolver,
-    RepositoryResolver
+    RepositoryResolver as AuthorRepositoryResolver
 }  from './authors/authors.resolver.service';
 
+import { ContentDetailComponent } from './content-detail/content-detail.component';
+import {
+    ContentResolver,
+    RepositoryResolver as ContentRepositoryResolver,
+    NamespaceResolver
+} from './content-detail/content-detail.resolver.service';
 
 
 const appRoutes: Routes = [
@@ -18,11 +24,30 @@ const appRoutes: Routes = [
         path: 'my-imports',
         loadChildren: './my-imports/my-imports.module#MyImportsModule'
     }, {
+        path: 'my-content',
+        loadChildren: './my-content/my-content.module#MyContentModule'
+    }, {
+        path: ':namespace/:repository/:content_name',
+        component: ContentDetailComponent,
+        resolve: {
+            content: ContentResolver,
+            repository: ContentRepositoryResolver,
+            namespace: NamespaceResolver
+        }
+    }, {
+        path: ':namespace/:repository',
+        component: ContentDetailComponent,
+        resolve: {
+            content: ContentResolver,
+            repository: ContentRepositoryResolver,
+            namespace: NamespaceResolver
+        }
+    }, {
         path: ':namespace',
         component: AuthorDetailComponent,
         resolve: {
             namespace: NamespaceDetailResolver,
-            repositories: RepositoryResolver
+            repositories: AuthorRepositoryResolver
         }
     }, {
         path: '**',

--- a/galaxyui/src/app/app-routing.module.ts
+++ b/galaxyui/src/app/app-routing.module.ts
@@ -37,11 +37,9 @@ const appRoutes: Routes = [
     }, {
         path: 'my-content',
         loadChildren: './my-content/my-content.module#MyContentModule',
-        canLoad: [AuthService]
     }, {
         path: 'my-imports',
         loadChildren: './my-imports/my-imports.module#MyImportsModule',
-        canLoad: [AuthService]
     },
 
     // Routes that resolve variables have to go in app-routing.module to ensure

--- a/galaxyui/src/app/app.module.ts
+++ b/galaxyui/src/app/app.module.ts
@@ -30,7 +30,7 @@ import { HomeModule }                 from './home/home.module';
 import { LoginModule }                from './login/login.module';
 // import { MyContentModule }            from './my-content/my-content.module';
 // import { MyImportsModule }            from './my-imports/my-imports.module';
-import { SearchModule }               from './search/search.module';
+// import { SearchModule }               from './search/search.module';
 import { UserNotificationsComponent } from './user-notifications/user-notifications.component';
 import { AuthorsModule }              from './authors/authors.module';
 import { VendorsModule }              from './vendors/vendors.module';
@@ -76,7 +76,7 @@ import { UserService }                from './resources/users/user.service';
         LoginModule,
         // MyContentModule,
         // MyImportsModule,
-        SearchModule,
+        // SearchModule,
         ModalModule,
         ContentDetailModule,
         ExceptionPagesModule,

--- a/galaxyui/src/app/app.module.ts
+++ b/galaxyui/src/app/app.module.ts
@@ -29,7 +29,7 @@ import { NotificationService }        from 'patternfly-ng/notification/notificat
 import { HomeModule }                 from './home/home.module';
 import { LoginModule }                from './login/login.module';
 import { MyContentModule }            from './my-content/my-content.module';
-import { MyImportsModule }            from './my-imports/my-imports.module';
+// import { MyImportsModule }            from './my-imports/my-imports.module';
 import { SearchModule }               from './search/search.module';
 import { UserNotificationsComponent } from './user-notifications/user-notifications.component';
 import { AuthorsModule }              from './authors/authors.module';
@@ -75,7 +75,7 @@ import { UserService }                from './resources/users/user.service';
         HomeModule,
         LoginModule,
         MyContentModule,
-        MyImportsModule,
+        // MyImportsModule,
         SearchModule,
         ModalModule,
         ContentDetailModule,

--- a/galaxyui/src/app/app.module.ts
+++ b/galaxyui/src/app/app.module.ts
@@ -28,7 +28,7 @@ import { NotificationService }        from 'patternfly-ng/notification/notificat
 
 import { HomeModule }                 from './home/home.module';
 import { LoginModule }                from './login/login.module';
-import { MyContentModule }            from './my-content/my-content.module';
+// import { MyContentModule }            from './my-content/my-content.module';
 // import { MyImportsModule }            from './my-imports/my-imports.module';
 import { SearchModule }               from './search/search.module';
 import { UserNotificationsComponent } from './user-notifications/user-notifications.component';
@@ -74,7 +74,7 @@ import { UserService }                from './resources/users/user.service';
         NotificationModule,
         HomeModule,
         LoginModule,
-        MyContentModule,
+        // MyContentModule,
         // MyImportsModule,
         SearchModule,
         ModalModule,

--- a/galaxyui/src/app/auth/auth.service.ts
+++ b/galaxyui/src/app/auth/auth.service.ts
@@ -14,7 +14,8 @@ import {
     CanActivate,
     Router,
     RouterStateSnapshot,
-    ActivatedRouteSnapshot
+    ActivatedRouteSnapshot,
+    Route
 } from '@angular/router';
 
 
@@ -91,5 +92,16 @@ export class AuthService implements CanActivate {
                 this.meCache = result;
                 return this.checkPermissions(route);
             });
+    }
+
+    canLoad(route: Route): boolean {
+        if (this.meCache) {
+            if (this.meCache.authenticated) {
+                return true;
+            }
+        }
+
+        this.router.navigate(['/login', {error: true}]);
+        return false;
     }
 }

--- a/galaxyui/src/app/auth/auth.service.ts
+++ b/galaxyui/src/app/auth/auth.service.ts
@@ -93,15 +93,4 @@ export class AuthService implements CanActivate {
                 return this.checkPermissions(route);
             });
     }
-
-    canLoad(route: Route): boolean {
-        if (this.meCache) {
-            if (this.meCache.authenticated) {
-                return true;
-            }
-        }
-
-        this.router.navigate(['/login', {error: true}]);
-        return false;
-    }
 }

--- a/galaxyui/src/app/authors/authors.routing.module.ts
+++ b/galaxyui/src/app/authors/authors.routing.module.ts
@@ -24,7 +24,9 @@ const routes: Routes = [{
         resolve: {
             namespaces: NamespaceListResolver
         }
-    }];
+    }
+    // ':namespace/ moved to app-routing.module
+];
 
 @NgModule({
     imports: [

--- a/galaxyui/src/app/authors/authors.routing.module.ts
+++ b/galaxyui/src/app/authors/authors.routing.module.ts
@@ -24,13 +24,6 @@ const routes: Routes = [{
         resolve: {
             namespaces: NamespaceListResolver
         }
-    }, {
-        path: ':namespace',
-        component: AuthorDetailComponent,
-        resolve: {
-            namespace: NamespaceDetailResolver,
-            repositories: RepositoryResolver
-        }
     }];
 
 @NgModule({

--- a/galaxyui/src/app/content-detail/content-detail.routing.module.ts
+++ b/galaxyui/src/app/content-detail/content-detail.routing.module.ts
@@ -13,24 +13,7 @@ import {
 } from './content-detail.resolver.service';
 
 const routes: Routes = [
-    {
-        path: ':namespace/:repository/:content_name',
-        component: ContentDetailComponent,
-        resolve: {
-            content: ContentResolver,
-            repository: RepositoryResolver,
-            namespace: NamespaceResolver
-        }
-    },
-    {
-        path: ':namespace/:repository',
-        component: ContentDetailComponent,
-        resolve: {
-            content: ContentResolver,
-            repository: RepositoryResolver,
-            namespace: NamespaceResolver
-        }
-    },
+
 ];
 
 @NgModule({

--- a/galaxyui/src/app/content-detail/content-detail.routing.module.ts
+++ b/galaxyui/src/app/content-detail/content-detail.routing.module.ts
@@ -13,7 +13,8 @@ import {
 } from './content-detail.resolver.service';
 
 const routes: Routes = [
-
+    // ':namespace/:repository/:content_name' and ':namespace/:repository/ moved
+    // to app-routing.module
 ];
 
 @NgModule({

--- a/galaxyui/src/app/my-content/my-content.routing.module.ts
+++ b/galaxyui/src/app/my-content/my-content.routing.module.ts
@@ -18,13 +18,13 @@ import { NamespaceListResolver }    from './namespace-list/namespace-list-resolv
 
 const myContentRoutes: Routes = [
     {
-        path: 'my-content',
-        redirectTo: 'my-content/namespaces',
+        path: '',
+        redirectTo: 'namespaces',
         pathMatch: 'full',
         canActivate: [AuthService]
     },
     {
-        path: 'my-content/namespaces/new',
+        path: 'namespaces/new',
         component: NamespaceDetailComponent,
         resolve: {
             me: MeResolver,
@@ -36,7 +36,7 @@ const myContentRoutes: Routes = [
         canActivate: [AuthService]
     },
     {
-        path: 'my-content/namespaces/:id',
+        path: 'namespaces/:id',
         component: NamespaceDetailComponent,
         resolve: {
             me: MeResolver,
@@ -45,7 +45,7 @@ const myContentRoutes: Routes = [
         canActivate: [AuthService]
     },
     {
-        path: 'my-content/namespaces',
+        path: 'namespaces',
         component: NamespaceListComponent,
         resolve: {
             me: MeResolver,

--- a/galaxyui/src/app/my-imports/my-imports.routing.module.ts
+++ b/galaxyui/src/app/my-imports/my-imports.routing.module.ts
@@ -29,7 +29,7 @@ import { ImportListComponent }      from './import-list/import-list.component';
 
 const myImportRoutes: Routes = [
     {
-        path: 'my-imports',
+        path: '',
         component: ImportListComponent,
         resolve: {
             imports: ImportListResolver

--- a/galaxyui/src/app/search/search-routing.module.ts
+++ b/galaxyui/src/app/search/search-routing.module.ts
@@ -19,7 +19,7 @@ import {
 
 const routes: Routes = [
     {
-        path: 'search',
+        path: '',
         component: SearchComponent,
         runGuardsAndResolvers: 'always',
         resolve: {


### PR DESCRIPTION
Back port: #739 

Configures Angular to load the search, my content and my imports pages in the background after the initial page load. This should decrease the time it takes for the app to load on the initial page request.