### PR TITLE
Reformat some APB paramater metadata on save

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Chris Church <chris@ninemoreminutes.com>
 Chris Houseknecht <chouseknecht@ansible.com>
 Christopher Chase <cchase@redhat.com>
 David Newswanger <dnewswan@redhat.com>
+David Zager <dzager@redhat.com>
 Ivan Remizov <iremizov@gmail.com>
 James Cammarata <jimi@sngx.net>
 Jiri Tyr <jtyr@users.noreply.github.com>

--- a/galaxy/importer/loaders/apb.py
+++ b/galaxy/importer/loaders/apb.py
@@ -33,6 +33,18 @@ class APBMetaParser(object):
     # Tags should contain lowercase letters and digits only
     TAG_REGEXP = re.compile('^[a-z0-9]+$')
 
+    # APB parameters should be in json-schema form
+    PARAM_KEY_MAP = {
+        'maxlength': 'maxLength',
+        'max_length': 'maxLength',
+        'min_length': 'minLength',
+        'multiple_of': 'multipleOf',
+        'exclusive_maximum': 'exclusiveMaximum',
+        'exclusive_minimum': 'exclusiveMinimum',
+        'display_type': 'displayType',
+        'display_group': 'displayGroup'
+    }
+
     def __init__(self, metadata, logger=None):
         self.metadata = metadata
         self.log = logger or base.default_logger
@@ -100,9 +112,13 @@ class APBMetaParser(object):
             raise exc.APBContentLoadError(
                 'Expecting "plans" in metadata to be a list')
 
-        expected_plan_keys = ('description', 'free', 'metadata', 'parameters')
+        expected_plan_keys = ('description',
+                              'free',
+                              'metadata',
+                              'bindable',
+                              'parameters')
         expected_plan_meta_keys = ('displayName', 'longDescription', 'cost')
-        expected_parameter_keys = ('name', 'title', 'type')
+        expected_parameter_keys = ('name', 'title', 'type', 'required')
         idx = 0
         for plan in plans:
             if not isinstance(plan, dict):
@@ -137,6 +153,13 @@ class APBMetaParser(object):
                         expected_parameter_keys,
                         'plans[{0}].parameters[{1}]'.format(idx, pidx),
                         params)
+                    for param_key in params.keys():
+                        if param_key in self.PARAM_KEY_MAP:
+                            new_key = self.PARAM_KEY_MAP[param_key]
+                            self.metadata[fieldname][idx]['parameters'][pidx][
+                                new_key] = self.metadata[fieldname][idx][
+                                    'parameters'][pidx].pop(param_key)
+
                     pidx += 1
             idx += 1
 
@@ -167,6 +190,9 @@ class APBMetaParser(object):
             return False
         return True
 
+    def parse_metadata(self):
+        return self.metadata
+
     def parse_tags(self):
         tags = []
         apb_tags = self.metadata.get('tags', [])
@@ -190,11 +216,11 @@ class APBLoader(base.BaseLoader):
 
     def load(self):
         self.log.info('Loading metadata file: {0}'.format(self.metadata_file))
-        metadata = self._load_metadata()
-        meta_parser = APBMetaParser(metadata, logger=self.log)
+        meta_parser = APBMetaParser(self._load_metadata(), logger=self.log)
         name = meta_parser.parse_name()
         description = meta_parser.parse_description()
         meta_parser.check_data()
+        metadata = meta_parser.parse_metadata()
         data = {'tags': meta_parser.parse_tags()}
         readme = self._get_readme()
 

--- a/galaxy/importer/tests/test_apb_loader.py
+++ b/galaxy/importer/tests/test_apb_loader.py
@@ -327,6 +327,16 @@ class TestAPBMetaParser(unittest.TestCase):
         msg = 'Missing "version" field in metadata.'
         assert msg in excinfo.value.message
 
+    def test_param_keys(self):
+        parser = apb_loader.APBMetaParser(self.data, self.log)
+        parser.check_data()
+        metadata = parser.parse_metadata()
+        assert 'displayGroup' in metadata['plans'][0]['parameters'][0]
+        assert 'displayType' in metadata['plans'][0]['parameters'][1]
+        assert 'displayGroup' in metadata['plans'][0]['parameters'][1]
+        assert 'minLength' in metadata['plans'][0]['parameters'][1]
+        assert 'maxLength' in metadata['plans'][0]['parameters'][1]
+
     def test_version_format(self):
         self.data['version'] = 'foo'
         parser = apb_loader.APBMetaParser(self.data, self.log)


### PR DESCRIPTION
This makes it possible for the [Ansible Galaxy Adapter](https://github.com/openshift/ansible-service-broker/blob/master/docs/config.md#ansible-galaxy-registry) in the [broker](https://github.com/openshift/ansible-service-broker) can properly handle parameter fields when rendering an APB in the service-catalog UI (for OpenShift).