### PR TITLE
Remove tests from coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ addopts =
 
 [coverage:run]
 omit = */migrations/*
+       */test_*.py
 
 [flake8]
 # W503 - line break before binary operator, to be replaced with W504.


### PR DESCRIPTION
It's not very useful to monitor code coverage in tests, bacause it's
100% in most cases and <100% when tests are skipped and/or there are
some extra lines of code to make debug easier.
So coverage <100% is not an issue and may not be improved in general.

This patch adds test_*.py files to exclude list in cov config.
