### PR TITLE
Move JS tests to end of travis file so yarn has time to install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ script:
 - make dev/waitenv
 - make dev/shellcheck
 - make dev/test
-- make dev/jslint
-- make test/prettier
 
 # check images running
 - docker ps -a
@@ -40,6 +38,10 @@ script:
 - pushd testing/simple
 - ansible-playbook -i inventory test.yml
 - popd
+
+# Run JavaScript test
+- make dev/jslint
+- make test/prettier
 
 # Check the logs
 - docker ps -a


### PR DESCRIPTION
Yarn install JS dependencies during the container start up process rather than during the container build, so we can't run JS tests right after the container starts because yarn needs time to install the JS dependencies.