### PR TITLE
Support multiple Travis CI servers

### DIFF
--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -272,8 +272,6 @@ SITE_ENV = 'PROD'
 
 SITE_NAME = 'localhost'
 
-TRAVIS_CONFIG_URL = 'https://api.travis-ci.org/config'
-
 # TODO(cutwater): Consider removing wait_for from settings
 WAIT_FOR = []
 


### PR DESCRIPTION
- Allows for webhook notifications to come from both travis-ci.com and travis-ci.org.
- Attempts to improve error logging
- Fixes #676 