### PR TITLE
Release/3.0.8 request id logging

### DIFF
--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -77,6 +77,7 @@ INSTALLED_APPS = (
 # FIXME(cutwater): Deprecated from Django 1.10, use MIDDLEWARE setting
 # instead.
 MIDDLEWARE_CLASSES = (
+    'log_request_id.middleware.RequestIDMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -304,6 +304,11 @@ LOGGING = {
     'disable_existing_loggers': False,
 
     'formatters': {
+        'json': {
+            '()': 'jog.JogFormatter',
+            'format': ('%(asctime)s %(request_id)s %(levelname)s] '
+                       '%(module)s: %(message)s'),
+        },
         'verbose': {
             'format': '%(asctime)s %(levelname)s %(module)s: %(message)s',
         },
@@ -315,7 +320,10 @@ LOGGING = {
     'filters': {
         'require_debug_false': {
             '()': 'django.utils.log.RequireDebugFalse'
-        }
+        },
+        'request_id': {
+            '()': 'log_request_id.filters.RequestIDFilter'
+        },
     },
 
     'handlers': {

--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -306,7 +306,7 @@ LOGGING = {
     'formatters': {
         'json': {
             '()': 'jog.JogFormatter',
-            'format': ('%(asctime)s %(request_id)s %(levelname)s] '
+            'format': ('%(asctime)s %(request_id)s %(levelname)s '
                        '%(module)s: %(message)s'),
         },
         'verbose': {

--- a/galaxy/settings/production.py
+++ b/galaxy/settings/production.py
@@ -165,6 +165,144 @@ ADMIN_URL_PATTERN = r'^{}/'.format(ADMIN_URL_PATH)
 
 CONTENT_DOWNLOAD_DIR = '/var/lib/galaxy/downloads'
 
+GITHUB_TASK_USERS = ['galaxytasks01', 'galaxytasks02', 'galaxytasks03',
+                     'galaxytasks04', 'galaxytasks05']
+
+# https://github.com/dabapps/django-log-request-id
+LOG_REQUEST_ID_HEADER = "HTTP_X_REQUEST_ID"
+GENERATE_REQUEST_ID_IF_NOT_IN_HEADER = True
+REQUEST_ID_RESPONSE_HEADER = "X-REQUEST-ID"
+# LOG_REQUESTS = True
+
+LOGGING = {
+    'version': 1,
+
+    'disable_existing_loggers': False,
+
+    'formatters': {
+        'verbose': {
+            'format': '%(asctime)s %(request_id)s %(levelname)s] %(module)s: %(message)s',
+        },
+        'simple': {
+            'format': '%(levelname)s %(message)s',
+        },
+        'json': {
+            '()': 'jog.JogFormatter',
+            'format': '%(asctime)s %(request_id)s %(levelname)s] %(module)s: %(message)s',
+        },
+        'django_server': {
+            '()': 'django.utils.log.ServerFormatter',
+            'format': '[%(server_time)s] %(message)s - %(request_id)s',
+        },
+
+    },
+
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        },
+        'request_id': {
+            '()': 'log_request_id.filters.RequestIDFilter'
+        },
+    },
+
+    'handlers': {
+        'mail_admins': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'django.utils.log.AdminEmailHandler'
+        },
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            # 'formatter': 'verbose',
+            'formatter': 'json',
+            'filters': ['request_id'],
+        },
+        'import_task': {
+            'level': 'DEBUG',
+            'class': 'galaxy.common.logutils.ImportTaskHandler',
+            'formatter': 'simple',
+            # 'formatter': 'verbose',
+        },
+    },
+
+    'loggers': {
+        'django.request': {
+            # 'handlers': ['mail_admins'],
+            'handlers': ['console'],
+            'level': 'INFO',
+            # 'level': 'DEBUG',
+            'propagate': True,
+        },
+        'django': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'django.db': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+        'django.server': {
+            'handlers': ['console'],
+            'level': 'INFO',
+        },
+        'galaxy.api': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'galaxy.api.permissions': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+        'galaxy.api.access': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            # 'level': 'DEBUG',
+            'propagate': True,
+        },
+        'galaxy.api.throttling': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+        'galaxy.accounts': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'galaxy.main': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'galaxy.models': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'galaxy.worker': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'galaxy.worker.tasks.import_repository': {
+            'handlers': ['import_task'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'allauth': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+    }
+}
+
 # =========================================================
 # System Settings
 # =========================================================

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,9 @@ pytest-django
 
 # Docs
 Sphinx
+
+# logging related
+# add request-id to django logs
+django-log-request-id
+# format log output as json
+jog


### PR DESCRIPTION
[backport of https://github.com/ansible/galaxy/pull/1034 to release/3.0.8]

Add 'request_id' and json formatting to galaxy logs

This adds a log_request_id.filters.RequestIDFilter log filter
to the console/stdout log handlers. The filter adds the
request-id to log records so they can be used by the formatters.

Also add and setup a 'jog.JogFormatter' for formatting normal
python log entries as JSON.

Add RequestIdMiddleware to MIDDLEWARE_CLASSES

This enables adding or tracking a X-Request-Id per
request that can be used in logging.

https://github.com/dabapps/django-log-request-id