### PR TITLE
Add spinner to indicate when page is loading.

### DIFF
--- a/galaxyui/src/app/app.component.html
+++ b/galaxyui/src/app/app.component.html
@@ -8,8 +8,13 @@
         [pinnableMenus]="true"
         [showBadges]="true"
         [showIcons]="true"
-        [updateActiveItemsOnClick]="false">
+        [updateActiveItemsOnClick]="true">
         <div>
+            <div *ngIf="isLoading" class="header-spinner">
+                <div class="inner-spinner">
+                    <div class="spinner spinner-inverse spinner-sm"></div>
+                </div>
+            </div>
             <ul class="nav navbar-nav navbar-right navbar-iconic">
                 <li>
                     <a href="" [routerLink]="" (click)="about(aboutTemplate)" class="nav-item-iconic nav-link">

--- a/galaxyui/src/app/app.component.less
+++ b/galaxyui/src/app/app.component.less
@@ -34,7 +34,8 @@
 .nav-link {
     font-size: 14px;
 }
-.nav>li>a:focus, .nav>li>a:hover {
+.nav > li > a:focus,
+.nav > li > a:hover {
     background-color: transparent;
 }
 a.nav-link {
@@ -46,6 +47,15 @@ a.nav-link {
 }
 
 .nav-sym-link:hover {
-    background-color: #E1F5FE;
+    background-color: #e1f5fe;
     cursor: pointer;
+}
+
+.header-spinner {
+    display: flex;
+    height: 0px;
+    align-items: center;
+    width: 20px;
+    position: relative;
+    top: 29px;
 }

--- a/galaxyui/src/app/app.component.ts
+++ b/galaxyui/src/app/app.component.ts
@@ -56,6 +56,14 @@ export class AppComponent implements OnInit {
                     this.notificationService.remove(notice);
                 });
             }
+
+            if (event instanceof NavigationStart) {
+                this.isLoading = true;
+            }
+
+            if (event instanceof NavigationEnd) {
+                this.isLoading = false;
+            }
         });
     }
 
@@ -68,6 +76,7 @@ export class AppComponent implements OnInit {
     redirectUrl: string = null;
     teamMembers: string[];
     pfBody: any;
+    isLoading = true;
 
     ngOnInit(): void {
         // Patternfly embeds everything not related to navigation in a div with

--- a/galaxyui/src/app/page-header/page-header.component.less
+++ b/galaxyui/src/app/page-header/page-header.component.less
@@ -3,11 +3,11 @@
     margin-right: -20px;
     margin-bottom: 20px;
 
-    margin-top: 0px;
+    margin-top: 2.5px;
 
     padding-left: 35px;
     padding-right: 35px;
-    padding-bottom: 20px;
+    padding-bottom: 22.5px;
 
     border-bottom: 1px solid #bbb;
     font-size: 16px;
@@ -30,13 +30,13 @@
     }
 
     .hide-on-mobile {
-        @media(max-width: 1000px){
+        @media (max-width: 1000px) {
             display: none;
         }
     }
 
     .show-on-mobile {
-        @media(min-width: 1000px){
+        @media (min-width: 1000px) {
             display: none;
         }
     }


### PR DESCRIPTION
Adds a spinner (shown bellow) to indicate when angular is loading a page. Some pages (most notably search) take a few seconds to load and we don't have any visual cues to tell the user that this is happening.

<img width="294" alt="screen shot 2018-08-10 at 4 28 37 pm" src="https://user-images.githubusercontent.com/6063371/43979979-82484b58-9cba-11e8-9137-c0952b0e2fbd.png">
