### PR TITLE
Fix make dev/log (#1041)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ dev/makemigrations:
 
 .PHONY: dev/log
 dev/log:
-	@$(DOCKER_COMPOSE) logs galaxy
+	@$(DOCKER_COMPOSE) logs --tail 100 galaxy
 
 .PHONY: dev/logf
 dev/logf:


### PR DESCRIPTION
Backport #1060 Fix `make devl/log` for Travis builds by limiting output to 100 lines.