### PR TITLE
Fix patternfly error messages.

### DIFF
--- a/galaxyui/src/app/app.module.ts
+++ b/galaxyui/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 
 import { HttpClientModule, HttpClientXsrfModule } from '@angular/common/http';
 
-import { ToastNotificationModule, VerticalNavigationModule } from 'patternfly-ng';
+import { AboutModalModule, ToastNotificationListModule, VerticalNavigationModule } from 'patternfly-ng';
 
 import { BsDropdownModule, ModalModule, TooltipModule } from 'ngx-bootstrap';
 
@@ -55,8 +55,7 @@ import { VendorsModule } from './vendors/vendors.module';
         HomeModule,
         LoginModule,
         MyContentModule,
-        ModalModule,
-        ToastNotificationModule,
+        ToastNotificationListModule,
         ContentDetailModule,
         ExceptionPagesModule,
         VendorsModule,


### PR DESCRIPTION
Patternfly 4 upgrade broke the notifications when the front end encountered an HTTP 500 error.

Backport #1043 