### PR TITLE
Token management endpoint

### DIFF
--- a/galaxy/api/filters.py
+++ b/galaxy/api/filters.py
@@ -65,7 +65,7 @@ class FieldLookupBackend(BaseFilterBackend):
                          'regex', 'iregex', 'gt', 'gte', 'lt', 'lte', 'in',
                          'isnull')
 
-    SENSITIVE_NAMES = ('secret', 'password', 'notification_secrets')
+    SENSITIVE_NAMES = ('secret', 'password', 'notification_secrets', 'token')
 
     def get_field_from_lookup(self, model, lookup):
         field = None

--- a/galaxy/api/serializers/__init__.py
+++ b/galaxy/api/serializers/__init__.py
@@ -27,3 +27,4 @@ from .repository import *          # noqa
 from .provider_namespace import *  # noqa
 from .roles import *               # noqa
 from .serializers import *         # noqa
+from .token import *               # noqa

--- a/galaxy/api/serializers/serializers.py
+++ b/galaxy/api/serializers/serializers.py
@@ -242,6 +242,8 @@ class UserListSerializer(BaseSerializer):
                 'api:user_starred_list', args=(obj.pk,)),
             repositories=reverse(
                 'api:user_repositories_list', args=(obj.pk,)),
+            token=reverse(
+                'api:user_token_view', args=(obj.pk,)),
         ))
         return res
 
@@ -329,6 +331,8 @@ class UserDetailSerializer(BaseSerializer):
                 'api:user_subscription_list', args=(obj.pk,)),
             starred=reverse(
                 'api:user_starred_list', args=(obj.pk,)),
+            token=reverse(
+                'api:user_token_view', args=(obj.pk,)),
         ))
         return res
 

--- a/galaxy/api/serializers/token.py
+++ b/galaxy/api/serializers/token.py
@@ -1,0 +1,51 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.core.urlresolvers import reverse
+
+from rest_framework import serializers
+from rest_framework.authtoken.models import Token
+
+from .serializers import BaseSerializer
+
+__all__ = [
+    'TokenSerializer',
+]
+
+User = get_user_model()
+
+
+class TokenSerializer(BaseSerializer):
+    token = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Token
+        fields = ('url', 'related', 'summary_fields', 'token',
+                  'created')
+
+    def get_url(self, obj):
+        if obj is None or isinstance(obj, AnonymousUser):
+            return ''
+        return reverse('api:user_token_view', args=(obj.user.pk,))
+
+    def get_related(self, obj):
+        if obj is None or isinstance(obj, AnonymousUser):
+            return {}
+        res = super(TokenSerializer, self).get_related(obj)
+        res.update({
+            'user': reverse(
+                'api:user_detail', kwargs={'pk': obj.user.pk})
+        })
+        return res
+
+    def get_summary_fields(self, obj):
+        if obj is None or isinstance(obj, AnonymousUser):
+            return {}
+        res = super(TokenSerializer, self).get_summary_fields(obj)
+        res['user'] = {
+            'id': obj.user.id,
+            'username': obj.user.username,
+        }
+        return res
+
+    def get_token(self, obj):
+        return obj.key

--- a/galaxy/api/urls.py
+++ b/galaxy/api/urls.py
@@ -32,6 +32,9 @@ user_urls = [
     url(r'^(?P<pk>[0-9]+)/secrets/$',
         views.UserNotificationSecretList.as_view(),
         name='user_notification_secret_list'),
+    url(r'^(?P<pk>[0-9]+)/token/$',
+        views.UserTokenView.as_view(),
+        name='user_token_view')
 ]
 
 role_urls = [

--- a/galaxy/api/views/__init__.py
+++ b/galaxy/api/views/__init__.py
@@ -27,4 +27,5 @@ from .repository_source import *    # noqa
 from .provider_namespace import *   # noqa
 from .roles import *                # noqa
 from .search import *               # noqa
+from .token import *                # noqa
 from .views import *                # noqa

--- a/galaxy/api/views/token.py
+++ b/galaxy/api/views/token.py
@@ -1,0 +1,117 @@
+import logging
+import requests
+
+from allauth.socialaccount.models import SocialAccount
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
+
+from rest_framework.authtoken.models import Token
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.authentication import SessionAuthentication
+
+from galaxy.api.views import base_views
+from galaxy.api.serializers import TokenSerializer
+
+__all__ = [
+    'TokenView',
+    'UserTokenView',
+]
+
+logger = logging.getLogger(__name__)
+User = get_user_model()
+
+
+class UserTokenView(base_views.RetrieveUpdateAPIView):
+    model = Token
+    serializer_class = TokenSerializer
+    authentication_classes = (SessionAuthentication,)
+
+    def get_object(self):
+        user_id = self.kwargs[self.lookup_field]
+        try:
+            user = User.objects.get(pk=user_id)
+        except ObjectDoesNotExist:
+            raise PermissionDenied()
+        instance, created = Token.objects.get_or_create(user=user)
+        self.check_object_permissions(self.request, instance)
+        return instance
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance=instance)
+        return Response(serializer.data)
+
+    def patch(self, request, *args, **kwargs):
+        instance = self.get_object()
+        user = instance.user
+        instance.delete()
+        instance = Token.objects.create(user=user)
+        serializer = self.get_serializer(instance=instance)
+        return Response(serializer.data)
+
+    def put(self, request, *args, **kwargs):
+        return self.patch(request, *args, **kwargs)
+
+
+class TokenView(base_views.APIView):
+    """
+    Allows ansible-galaxy CLI to retrieve an auth token. This will be
+    deprecated with the deprecation of `ansible-galaxy`.
+    """
+
+    def post(self, request, *args, **kwargs):
+        """
+        Uses a GitHub token to authenticate the user, and returns
+        a Galaxy Token on success.
+        """
+        gh_user = None
+        user = None
+        token = None
+        github_token = request.data.get('github_token', None)
+
+        if github_token is None:
+            raise ValidationError({'detail': "Invalid request."})
+
+        try:
+            git_status = requests.get(settings.GITHUB_SERVER)
+            git_status.raise_for_status()
+        except Exception:
+            raise ValidationError({
+                'detail': "Error accessing GitHub API. Please try again later."
+            })
+
+        try:
+            header = dict(Authorization='token ' + github_token)
+            gh_user = requests.get(
+                settings.GITHUB_SERVER + '/user', headers=header
+            )
+            gh_user.raise_for_status()
+            gh_user = gh_user.json()
+            if hasattr(gh_user, 'message'):
+                raise ValidationError({'detail': gh_user['message']})
+        except Exception:
+            raise ValidationError({
+                'detail': "Error accessing GitHub with provided token."
+            })
+
+        if SocialAccount.objects.filter(
+                provider='github', uid=gh_user['id']).count() > 0:
+            user = SocialAccount.objects.get(
+                provider='github', uid=gh_user['id']).user
+        else:
+            msg = (
+                "Galaxy user not found. You must first log into Galaxy using "
+                "your GitHub account."
+            )
+            raise ValidationError({'detail': msg})
+
+        if Token.objects.filter(user=user).count() > 0:
+            token = Token.objects.filter(user=user)[0]
+        else:
+            token = Token.objects.create(user=user)
+            token.save()
+        result = dict(token=token.key, username=user.username)
+        return Response(result, status=status.HTTP_200_OK)


### PR DESCRIPTION
Adds `/api/v1/users/#/token/` endpoint for retrieving and regenerating API tokens.

Use a GET request to retrieve the user's token. If one does not exist, a new one will be created. The endpoint returns the following:

```json
{
    "url": "/api/v1/users/2/token/",
    "related": {
        "user": "/api/v1/users/2/"
    },
    "summary_fields": {
        "user": {
            "username": "chouseknecht",
            "id": 2
        }
    },
    "token": "79596f12bea3ddc485682e9f4569bf694f114914",
    "created": "2018-08-15T18:55:34.618864Z",
    "modified": null,
    "active": null
}
```

To regenerate the token (i.e., replace the existing token with a new value), make an UPDATE or PATCH request with no payload. The same data structure above will be returned.

Security:
- Anonymous users have no access to tokens
- Non-admins can only view their own token
- Non-admins can only patch/update their own token