### PR TITLE
Email management API endpoints

### DIFF
--- a/galaxy/api/access.py
+++ b/galaxy/api/access.py
@@ -19,6 +19,7 @@
 
 import logging
 
+from allauth.account.models import EmailAddress
 from django.contrib.auth import get_user_model
 from rest_framework.authtoken.models import Token
 
@@ -252,7 +253,7 @@ class SubscriptionAccess(BaseAccess):
     def can_change(self, obj, data):
         return False
 
-    def can_delete(self, data):
+    def can_delete(self, obj):
         return self.user.is_authenticated()
 
 
@@ -263,7 +264,7 @@ class StargazerAccess(BaseAccess):
     def can_change(self, obj, data):
         return False
 
-    def can_delete(self, data):
+    def can_delete(self, obj):
         return self.user.is_authenticated()
 
 
@@ -277,7 +278,7 @@ class NamespaceAccess(BaseAccess):
     def can_change(self, obj, data):
         return self.user.is_authenticated()
 
-    def can_delete(self, data):
+    def can_delete(self, obj):
         return self.user.is_authenticated() and self.user.is_staff
 
 
@@ -291,7 +292,7 @@ class ProviderNamespaceAccess(BaseAccess):
     def can_change(self, obj, data):
         return self.user.is_authenticated()
 
-    def can_delete(self, data):
+    def can_delete(self, obj):
         return self.user.is_authenticated()
 
 
@@ -305,7 +306,7 @@ class RepositoryAccess(BaseAccess):
     def can_change(self, obj, data):
         return self.user.is_authenticated()
 
-    def can_delete(self, data):
+    def can_delete(self, obj):
         return self.user.is_authenticated()
 
 
@@ -358,7 +359,42 @@ class CommunitySurveyAccess(BaseAccess):
         return False
 
 
+class EmailAddressAccess(BaseAccess):
+    model = EmailAddress
+
+    def can_read(self, obj):
+        if self.user.is_authenticated():
+            if self.user.is_staff:
+                return True
+            if self.user == obj.user:
+                return True
+        return False
+
+    def can_add(self, data):
+        if self.user.is_authenticated():
+            if self.user.id == data.get('user'):
+                return True
+        return False
+
+    def can_change(self, obj, data):
+        if self.user.is_authenticated():
+            if self.user == obj.user:
+                return True
+        return False
+
+    def can_delete(self, obj):
+        if self.user.is_authenticated():
+            if self.user.is_staff:
+                return True
+            if self.user == obj.user:
+                return True
+        return False
+
+
 register_access(User, UserAccess)
+register_access(EmailAddress, EmailAddressAccess)
+register_access(Token, UserTokenAccess)
+
 register_access(models.Content, RoleAccess)
 register_access(models.RepositoryVersion, RepositoryVersionAccess)
 register_access(models.ImportTask, ImportTaskAccess)
@@ -374,5 +410,4 @@ register_access(models.Repository, RepositoryAccess)
 register_access(models.ContentBlock, ContentBlockAccess)
 register_access(models.ContentType, ContentTypeAccess)
 register_access(models.CloudPlatform, CloudPlatformsAccess)
-register_access(Token, UserTokenAccess)
 register_access(models.CommunitySurvey, CommunitySurveyAccess)

--- a/galaxy/api/serializers/__init__.py
+++ b/galaxy/api/serializers/__init__.py
@@ -18,6 +18,7 @@
 from .content import *             # noqa
 from .content_block import *       # noqa
 from .content_type import *        # noqa
+from .email import *               # noqa
 from .namespace import *           # noqa
 from .notification import *        # noqa
 from .provider import *            # noqa

--- a/galaxy/api/serializers/email.py
+++ b/galaxy/api/serializers/email.py
@@ -1,0 +1,76 @@
+from collections import OrderedDict
+
+from allauth.account.models import EmailAddress
+from django.core.urlresolvers import reverse
+from rest_framework.validators import UniqueValidator, UniqueTogetherValidator
+from rest_framework import serializers
+from .serializers import BaseSerializer
+
+__all__ = [
+    'EmailSerializer',
+]
+
+
+class IsVerified(object):
+
+    def __call__(self, value):
+        if self.instance and self.instance.verified:
+            # This is an Update to a verified address
+            if self.instance.email != self.data.get('email'):
+                message = 'Verified email addresses cannot be modified'
+                raise serializers.ValidationError(message)
+
+    def set_context(self, serializer_field):
+        self.instance = getattr(serializer_field.parent, 'instance', None)
+        self.data = getattr(serializer_field.parent, 'initial_data', None)
+
+
+class EmailSerializer(BaseSerializer):
+    id = serializers.IntegerField(read_only=True)
+    email = serializers.EmailField(
+        required=True,
+        validators=[
+            UniqueValidator(queryset=EmailAddress.objects.all()),
+            IsVerified()
+        ]
+    )
+    verified = serializers.BooleanField(read_only=True)
+    primary = serializers.BooleanField(default=False)
+
+    class Meta:
+        model = EmailAddress
+        fields = (
+            'url',
+            'related',
+            'summary_fields',
+            'id',
+            'email',
+            'verified',
+            'primary'
+        )
+        validators = [
+            UniqueTogetherValidator(
+                queryset=EmailAddress.objects.all(),
+                fields=('email', 'user', 'primary'),
+                message="Only one email address can be primary"),
+        ]
+
+    def get_url(self, obj):
+        if obj is None:
+            return ''
+        return reverse('api:email_detail', args=(obj.pk,))
+
+    def get_related(self, obj):
+        d = super(EmailSerializer, self).get_related(obj)
+        d['user'] = reverse('api:user_detail', args=(obj.user.pk,))
+        return d
+
+    def get_summary_fields(self, obj):
+        if obj is None:
+            return {}
+        d = super(EmailSerializer, self).get_summary_fields(obj)
+        d['user'] = OrderedDict([
+            ('id', obj.user.id),
+            ('username', obj.user.username)
+        ])
+        return d

--- a/galaxy/api/urls.py
+++ b/galaxy/api/urls.py
@@ -19,10 +19,17 @@ from django.conf.urls import include, url
 
 from galaxy.api import views
 
+email_urls = [
+    url(r'^$', views.EmailList.as_view(), name='email_list'),
+    url(r'^(?P<pk>[0-9]+)/$',
+        views.EmailDetail.as_view(), name='email_detail'),
+]
 
 user_urls = [
     url(r'^$', views.UserList.as_view(), name='user_list'),
     url(r'^(?P<pk>[0-9]+)/$', views.UserDetail.as_view(), name='user_detail'),
+    url(r'^(?P<pk>[0-9]+)/emails/$', views.UserEmailList.as_view(),
+        name='user_email_list'),
     url(r'^(?P<pk>[0-9]+)/repos/$', views.UserRepositoriesList.as_view(),
         name='user_repositories_list'),
     url(r'^(?P<pk>[0-9]+)/subscriptions/$',
@@ -236,6 +243,7 @@ v1_urls = [
     url(r'^$', views.ApiV1RootView.as_view(), name='api_v1_root_view'),
     url(r'^account/', include(account_urls)),
     url(r'^me/$', views.ActiveUserView.as_view(), name='active_user_view'),
+    url(r'^emails/', include(email_urls)),
     url(r'^users/', include(user_urls)),
     url(r'^roles/', include(role_urls)),
     url(r'^content/', include(content_urls)),

--- a/galaxy/api/views/__init__.py
+++ b/galaxy/api/views/__init__.py
@@ -19,6 +19,7 @@ from .account import *              # noqa
 from .content import *              # noqa
 from .content_block import *        # noqa
 from .content_type import *         # noqa
+from .email import *                # noqa
 from .namespace import *            # noqa
 from .notification import *         # noqa
 from .repository import *           # noqa

--- a/galaxy/api/views/email.py
+++ b/galaxy/api/views/email.py
@@ -1,0 +1,57 @@
+
+import logging
+
+from allauth.account.models import EmailAddress
+from django.contrib.auth import get_user_model
+from django.core.exceptions import PermissionDenied
+
+from galaxy.api.views import base_views
+from galaxy.api import serializers
+
+__all__ = [
+    'UserEmailList',
+    'EmailList',
+    'EmailDetail'
+]
+
+logger = logging.getLogger(__name__)
+User = get_user_model()
+
+
+class UserEmailList(base_views.SubListAPIView):
+    model = EmailAddress
+    serializer_class = serializers.EmailSerializer
+    parent_model = User
+    relationship = 'emailaddress_set'
+
+    def get_queryset(self):
+        user_id = self.kwargs.get(self.lookup_field)
+        if not self.request.user.is_staff:
+            if self.request.user.id != int(user_id):
+                # Non-admin access own email addresses only
+                raise PermissionDenied()
+        return super(UserEmailList, self).get_queryset()
+
+
+class EmailList(base_views.ListCreateAPIView):
+    model = EmailAddress
+    serializer_class = serializers.EmailSerializer
+
+    def get_queryset(self):
+        qs = super(EmailList, self).get_queryset()
+        if not self.request.user.is_staff:
+            qs = qs.filter(user=self.request.user)
+        return qs
+
+
+class EmailDetail(base_views.RetrieveUpdateDestroyAPIView):
+    model = EmailAddress
+    serializer_class = serializers.EmailSerializer
+
+    def get_object(self, qs=None):
+        obj = super(EmailDetail, self).get_object()
+        if not self.request.user.is_staff:
+            if obj.user != self.request.user:
+                # Non-admin access own email addresses only
+                raise PermissionDenied()
+        return obj

--- a/galaxy/api/views/views.py
+++ b/galaxy/api/views/views.py
@@ -159,6 +159,7 @@ class ApiV1RootView(base_views.APIView):
         data['tags'] = reverse('api:tag_list')
         data['users'] = reverse('api:user_list')
         data['surveys'] = reverse('api:community_survey_list')
+        data['emails'] = reverse('api:email_list')
         return Response(data)
 
 


### PR DESCRIPTION
The endpoints:
- View all emails, and create new email by posting to `/api/v1/emails`
- Update and Delete an emails at `/api/v1/emails/#/`
- View all emails for a user at `/api/v1/users/#/emails/`
- View user's primary email at `/api/v1/me/`

Security:
- An authenticated user can only update his/her own email addresses
- Non-admin can only view his/her own email addresses
- Anonymous users cannot view email addresses

Caveats:

There is no way to check that at least one email address is marked as primary, as I'm not sure where we would put that check. Wondering if we can check for a primary_email at `/api/v1/me/` when the user logs in, throw a warning with link/directions on how to fix.