### PR TITLE
Prevent queries on sensitive fields

### DIFF
--- a/galaxy/api/filters.py
+++ b/galaxy/api/filters.py
@@ -65,6 +65,8 @@ class FieldLookupBackend(BaseFilterBackend):
                          'regex', 'iregex', 'gt', 'gte', 'lt', 'lte', 'in',
                          'isnull')
 
+    SENSITIVE_NAMES = ('secret', 'password')
+
     def get_field_from_lookup(self, model, lookup):
         field = None
         parts = lookup.split('__')
@@ -174,7 +176,10 @@ class FieldLookupBackend(BaseFilterBackend):
             for key, values in request.GET.lists():
                 if key in self.RESERVED_NAMES:
                     continue
-
+                if key in self.SENSITIVE_NAMES:
+                    raise ValidationError(
+                        "Your are not authorized to query on %s" % key
+                    )
                 # Custom __int filter suffix (internal use only).
                 q_int = False
                 if key.endswith('__int'):

--- a/galaxy/api/serializers/notification.py
+++ b/galaxy/api/serializers/notification.py
@@ -44,12 +44,7 @@ class NotificationSecretSerializer(BaseSerializer):
 
     def get_secret(self, obj):
         # show only last 4 digits of secret
-        last = ''
-        try:
-            last = obj.secret[-4:]
-        except Exception:
-            pass
-        return '******' + last
+        return '******'
 
 
 class NotificationSerializer(BaseSerializer):


### PR DESCRIPTION
Insure query params like 'secret' and 'password' are verboten.