### PR TITLE
Fixes default route to /home

### DIFF
--- a/galaxyui/src/app/app-routing.module.ts
+++ b/galaxyui/src/app/app-routing.module.ts
@@ -14,12 +14,6 @@ import { NamespaceDetailResolver, RepositoryResolver as AuthorRepositoryResolver
 import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
 
 const appRoutes: Routes = [
-    {
-        path: '',
-        redirectTo: '/home',
-        pathMatch: 'full',
-    },
-
     // Lazily loaded modules
     {
         path: 'search',

--- a/galaxyui/src/app/home/home.routing.module.ts
+++ b/galaxyui/src/app/home/home.routing.module.ts
@@ -8,6 +8,14 @@ import { ContentBlockResolver, VendorListResolver } from './home.resolver.servic
 
 const homeRoutes: Routes = [
     {
+        path: '',
+        component: HomeComponent,
+        resolve: {
+            vendors: VendorListResolver,
+            contentBlocks: ContentBlockResolver,
+        },
+    },
+    {
         path: 'home',
         component: HomeComponent,
         resolve: {


### PR DESCRIPTION
Closes #1120 

Lazy loads the HomeModule first, so that the default route of '' points to `/home`.