### PR TITLE
Added generic services

### DIFF
--- a/galaxyui/src/app/content-detail/cards/survey/community-survey.component.ts
+++ b/galaxyui/src/app/content-detail/cards/survey/community-survey.component.ts
@@ -90,7 +90,7 @@ export class CardCommunitySurveyComponent implements OnInit {
             this.myUserId = me.id;
 
             // The user id has to be set before surveys are loaded from the API
-            this.surveyService.query({ repository: this.contentId }).subscribe(surveys => {
+            this.surveyService.query({ repository: this.contentId, pageSize: 1000 }).subscribe(surveys => {
                 this.communitySurveys = surveys;
                 this.numberOfSurveys = this.communitySurveys.length;
                 this.loadMySurvey();

--- a/galaxyui/src/app/content-detail/cards/survey/community-survey.component.ts
+++ b/galaxyui/src/app/content-detail/cards/survey/community-survey.component.ts
@@ -90,7 +90,7 @@ export class CardCommunitySurveyComponent implements OnInit {
             this.myUserId = me.id;
 
             // The user id has to be set before surveys are loaded from the API
-            this.surveyService.query({ repository: this.contentId, pageSize: 1000 }).subscribe(surveys => {
+            this.surveyService.query({ repository: this.contentId, page_size: 1000 }).subscribe(surveys => {
                 this.communitySurveys = surveys;
                 this.numberOfSurveys = this.communitySurveys.length;
                 this.loadMySurvey();

--- a/galaxyui/src/app/resources/base/base-type.ts
+++ b/galaxyui/src/app/resources/base/base-type.ts
@@ -1,0 +1,3 @@
+export class BaseType {
+    id: number;
+}

--- a/galaxyui/src/app/resources/base/generic-query-save.ts
+++ b/galaxyui/src/app/resources/base/generic-query-save.ts
@@ -1,0 +1,37 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+
+import { Observable } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
+
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
+
+import { BaseType } from './base-type';
+
+import { GenericQuery } from './generic-query';
+
+const httpOptions = {
+    headers: new HttpHeaders({
+        'Content-Type': 'application/json',
+    }),
+};
+export class GenericQuerySave<ServiceType extends BaseType> extends GenericQuery<ServiceType> {
+    protected ObjectType: any;
+
+    constructor(http: HttpClient, notificationService: NotificationService, url, serviceName) {
+        super(http, notificationService, url, serviceName);
+    }
+
+    save(object: ServiceType): Observable<ServiceType> {
+        let httpResult: Observable<Object>;
+        if (object.id) {
+            httpResult = this.http.put<ServiceType>(`${this.url}/${object.id}/`, object, httpOptions);
+        } else {
+            httpResult = this.http.post<ServiceType>(`${this.url}/`, object, httpOptions);
+        }
+
+        return httpResult.pipe(
+            tap((newObject: ServiceType) => this.log(`Saved ${this.serviceName} w/ id=${newObject.id}`)),
+            catchError(this.handleError<ServiceType>('Save')),
+        );
+    }
+}

--- a/galaxyui/src/app/resources/base/generic-query.ts
+++ b/galaxyui/src/app/resources/base/generic-query.ts
@@ -12,7 +12,16 @@ export class GenericQuery<ServiceType> {
     constructor(protected http: HttpClient, protected notificationService: NotificationService, protected url, protected serviceName) {}
 
     query(params?: any): Observable<ServiceType[]> {
-        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
+        let objectUrl = this.url;
+        let objectParams = null;
+        if (params) {
+            if (typeof params === 'string') {
+                objectUrl += `?${params}`;
+            } else {
+                objectParams = params;
+            }
+        }
+        return this.http.get<PagedResponse>(objectUrl + '/', { params: objectParams }).pipe(
             map(response => response.results),
             tap(_ => this.log(`fetched ${this.serviceName}`)),
             catchError(this.handleError('Query', [] as ServiceType[])),

--- a/galaxyui/src/app/resources/base/generic-query.ts
+++ b/galaxyui/src/app/resources/base/generic-query.ts
@@ -1,0 +1,36 @@
+import { HttpClient } from '@angular/common/http';
+
+import { Observable, of } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
+
+import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
+import { PagedResponse } from '../paged-response';
+
+export class GenericQuery<ServiceType> {
+    protected ObjectType: any;
+
+    constructor(protected http: HttpClient, protected notificationService: NotificationService, protected url, protected serviceName) {}
+
+    query(params?: any): Observable<ServiceType[]> {
+        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
+            map(response => response.results),
+            tap(_ => this.log(`fetched ${this.serviceName}`)),
+            catchError(this.handleError('Query', [] as ServiceType[])),
+        );
+    }
+
+    handleError<T>(operation = '', result?: T) {
+        return (error: any): Observable<T> => {
+            console.error(`${operation} failed, error:`, error);
+            this.log(`${operation} ${this.serviceName} error: ${error.message}`);
+            this.notificationService.httpError(`${operation} ${this.serviceName} failed:`, { data: error });
+
+            // Let the app keep running by returning an empty result.
+            return of(result as T);
+        };
+    }
+
+    log(message: string) {
+        console.log(`${this.serviceName}: ${message}`);
+    }
+}

--- a/galaxyui/src/app/resources/survey/survey.service.ts
+++ b/galaxyui/src/app/resources/survey/survey.service.ts
@@ -1,59 +1,14 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
-import { Observable, of } from 'rxjs';
-import { catchError, map, tap } from 'rxjs/operators';
-
 import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
-import { PagedResponse } from '../paged-response';
 import { Survey } from './survey';
 
-const httpOptions = {
-    headers: new HttpHeaders({
-        'Content-Type': 'application/json',
-    }),
-};
+import { GenericQuerySave } from '../base/generic-query-save';
+
 @Injectable()
-export class SurveyService {
-    private url = '/api/v1/community_surveys';
-
-    constructor(private http: HttpClient, private notificationService: NotificationService) {}
-
-    query(params?: any): Observable<Survey[]> {
-        params.page_size = 1000;
-        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
-            map(response => response.results),
-            tap(_ => this.log('fetched surveys')),
-            catchError(this.handleError('Query', [] as Survey[])),
-        );
-    }
-
-    save(survey: Survey): Observable<Survey> {
-        let httpResult: Observable<Object>;
-        if (survey.id) {
-            httpResult = this.http.put<Survey>(`${this.url}/${survey.id}/`, survey, httpOptions);
-        } else {
-            httpResult = this.http.post<Survey>(`${this.url}/`, survey, httpOptions);
-        }
-
-        return httpResult.pipe(
-            tap((newSurvey: Survey) => this.log(`Saved survey w/ id=${newSurvey.id}`)),
-            catchError(this.handleError<Survey>('Save')),
-        );
-    }
-
-    private handleError<T>(operation = '', result?: T) {
-        return (error: any): Observable<T> => {
-            console.error(`${operation} failed, error:`, error);
-            this.log(`${operation} survey error: ${error.message}`);
-            this.notificationService.httpError(`${operation} survey failed:`, { data: error });
-
-            // Let the app keep running by returning an empty result.
-            return of(result as T);
-        };
-    }
-
-    private log(message: string) {
-        console.log('SurveyService: ' + message);
+export class SurveyService extends GenericQuerySave<Survey> {
+    constructor(http: HttpClient, notificationService: NotificationService) {
+        super(http, notificationService, '/api/v1/community_surveys', 'survey');
     }
 }


### PR DESCRIPTION
Added two new classes: `GenericQuery` and `GenericQuerySave`. The purpose of these classes it to handle the query logic for most of our angular Services. In most cases our services just need to define two functions `query()` and `save()`. Generally the functionality of these two functions is the same across all our services, so they can be abstracted into generic services.

To use the generic queries simply create a service that extends `GenericQuery` or `GenericQuerySave` and pass in a type that the service returns as well as the URL for the API and name of the service like so:

```
export class SurveyService extends GenericQuerySave<Survey> {
    constructor(http: HttpClient, notificationService: NotificationService) {
        super(http, notificationService, '/api/v1/community_surveys', 'survey');
    }
}
```

In this case `Survey` is passed as the type for `GenericQuerySave`, the API URL is set to `/api/v1/community_surveys` and the service name is set to `survey`.