### PR TITLE
Change metrics URL to `/metrics`

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -336,7 +336,7 @@ Log into Grafana at `http://localhost:3000`_ using the admin user with
 password ``admin``. Navigate to ``Galaxy Search Metrics - InfluxDB`` and
 ``Galaxy Search Metrics - Prometheus`` dashboards.
 
-Search metrics are exposed at `http://localhost:8000/api/metrics`_. From
+Search metrics are exposed at `http://localhost:8000/metrics`_. From
 there, the metrics are being scraped by Prometheus
 (`http://localhost:9090/`_). Prometheus serves as a short-term storage.
 For a long-term metrics storage, the metrics are being sent from

--- a/galaxy/api/urls.py
+++ b/galaxy/api/urls.py
@@ -247,5 +247,4 @@ v1_urls = [
 urlpatterns = [
     url(r'^$', views.ApiRootView.as_view(), name='api_root_view'),
     url(r'^v1/', include(v1_urls)),
-    url(r'', include('django_prometheus.urls')),
 ]

--- a/galaxy/urls.py
+++ b/galaxy/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     url(settings.ADMIN_URL_PATTERN, include(admin.site.urls)),
     url(r'^robots\.txt$', TemplateView.as_view(template_name="robots.txt",
                                                content_type='text/plain')),
+    url(r'', include('django_prometheus.urls')),
     url(r'', include('galaxy.main.urls', namespace='main', app_name='main')),
 ]
 

--- a/galaxyui/proxy.conf.js
+++ b/galaxyui/proxy.conf.js
@@ -14,6 +14,10 @@ const PROXY_CONFIG = {
     "/accounts": {
         'target': "http://localhost:8888",
         'secure': false
+    },
+    "/metrics": {
+        'target': "http://localhost:8888",
+        'secure': false
     }
 }
 

--- a/scripts/docker/dev/prometheus.yml
+++ b/scripts/docker/dev/prometheus.yml
@@ -2,7 +2,7 @@ scrape_configs:
   - job_name: 'galaxy'
     scrape_interval: '60s'
     honor_labels: true
-    metrics_path: '/api/metrics'
+    metrics_path: '/metrics'
     static_configs:
       - targets:
           - 'galaxy.svc:8000'


### PR DESCRIPTION
Metrics is not a part of public API and better to be moved
outside API url path.

Backport: #1124 

(cherry picked from commit e01c10dee33480eb3f83c373cd5b4b4b254c9e35)