### PR TITLE
Fix typo

### DIFF
--- a/docs/docsite/rst/mazer/examples.rst
+++ b/docs/docsite/rst/mazer/examples.rst
@@ -173,7 +173,7 @@ the complete directory tree created on the local file system by Mazer:
 Setting the Content path
 ------------------------
 
-Mazer installs content to ``~/.ansible/content``. To override the deault path, set *content_path* in Mazer's configuration file,
+Mazer installs content to ``~/.ansible/content``. To override the default path, set *content_path* in Mazer's configuration file,
 ``~/.ansible/mazer.yml``. The following shows an example configuration file that sets the value of *content_path*:
 
 .. code-block:: yaml


### PR DESCRIPTION
In file examples.rst there was a typo in the word `default` it was instead `deault`