### PR TITLE
Fix search ranking getting set to 0.

### DIFF
--- a/galaxy/api/views/search.py
+++ b/galaxy/api/views/search.py
@@ -117,8 +117,14 @@ class ContentSearchView(base.ListAPIView):
         queryset = self.add_deprecated_filter(queryset, is_deprecated)
 
         # Support for ansible-galaxy <= 2.6 autocomplete params
-        keywords = request.GET.get('autocomplete', '').split()
-        queryset = self.add_keywords_filter(queryset, keywords)
+        keywords = request.GET.get('autocomplete', None)
+
+        # Calling self.add_keywords_filter() with no keywords sets existing
+        # search_rank values to 0, so we want to avoid calling if autocomplete
+        # is missing.
+        if keywords is not None:
+            queryset = self.add_keywords_filter(queryset, keywords.split())
+
         tags = request.GET.get('tags_autocomplete', '').split()
         queryset = self.add_tags_filter(queryset, tags)
         platforms = request.GET.get('platforms_autocomplete', '').split()


### PR DESCRIPTION
The relevance score on the search page is calculated as `ln(download_count + 1) + postgres_search_rank`. The `postgres_search_rank` was always getting set to 0, which meant that search results were actually being sorted by number of downloads, rather than a real relevance score.

#1093
#1024