### PR TITLE
Refactor default parameters on search page.

### DIFF
--- a/galaxyui/src/app/search/search.component.ts
+++ b/galaxyui/src/app/search/search.component.ts
@@ -42,6 +42,8 @@ import { PopularEvent } from './popular/popular.component';
 
 import { Content } from '../resources/content-search/content';
 
+import { DefaultParams } from './search.resolver.service';
+
 import * as moment from 'moment';
 
 @Component({
@@ -108,7 +110,7 @@ export class SearchComponent implements OnInit, AfterViewInit {
                 {
                     id: 'contributor_type',
                     title: 'Contributor Type',
-                    placeholder: 'Contributur Type',
+                    placeholder: 'Contributor Type',
                     type: FilterType.TYPEAHEAD,
                     queries: [
                         {
@@ -192,20 +194,16 @@ export class SearchComponent implements OnInit, AfterViewInit {
                 // If there is an error on the search API, the content search services
                 // returns nothing, so we have to check if results actually exist.
                 if (data.content.results) {
-                    if (!data.content.results.length && !Object.keys(params).length) {
-                        // No vendors exists
-                        const default_params = { vendor: false };
-                        this.setSortConfig();
-                        this.setAppliedFilters(default_params);
-                        this.searchContent();
-                    } else {
-                        this.setSortConfig(params['order_by']);
-                        this.setPageSize(params);
-                        this.setAppliedFilters(params);
-                        this.prepareContent(data.content.results, data.content.count);
-                        this.setQuery();
-                        this.pageLoading = false;
+                    // If no params exist, set to the default params
+                    if (Object.keys(params).length === 0) {
+                        params = DefaultParams.params;
                     }
+                    this.setSortConfig(params['order_by']);
+                    this.setPageSize(params);
+                    this.setAppliedFilters(params);
+                    this.prepareContent(data.content.results, data.content.count);
+                    this.setQuery();
+                    this.pageLoading = false;
                 } else {
                     this.notificationService.message(NotificationType.WARNING, 'Error', 'Invalid search query', false, null, null);
 
@@ -378,10 +376,6 @@ export class SearchComponent implements OnInit, AfterViewInit {
         let filterParams = '';
 
         const params = JSON.parse(JSON.stringify(queryParams));
-        if (!Object.keys(params).length) {
-            // When no prior query, default Contributor Type to vendor
-            params['vendor'] = true;
-        }
 
         for (const key in params) {
             if (params.hasOwnProperty(key)) {
@@ -396,10 +390,10 @@ export class SearchComponent implements OnInit, AfterViewInit {
                     const ffield: Filter = {} as Filter;
                     ffield.field = field;
                     field.queries.forEach((query: FilterQuery) => {
-                        if (query.id === ContributorTypes.community && !params[key]) {
+                        if (query.id === ContributorTypes.community && params[key] === 'false') {
                             ffield.query = query;
                             ffield.value = query.value;
-                        } else if (query.id === ContributorTypes.vendor && params[key]) {
+                        } else if (query.id === ContributorTypes.vendor && params[key] === 'true') {
                             ffield.query = query;
                             ffield.value = query.value;
                         }

--- a/galaxyui/src/app/search/search.resolver.service.ts
+++ b/galaxyui/src/app/search/search.resolver.service.ts
@@ -22,6 +22,26 @@ import { TagsService } from '../resources/tags/tags.service';
 
 import { ContributorTypes } from '../enums/contributor-types.enum';
 
+// This class represents the default set of filters to be used when the search
+// page is loaded without any params specified
+export class DefaultParams {
+    static params = {
+        // vendor: 'false',
+        // deprecated: 'false',
+        order_by: '-relevance',
+    };
+
+    static getParamString(): string {
+        let paramString = '';
+        for (const key of Object.keys(this.params)) {
+            paramString += key + '=' + encodeURIComponent(this.params[key]) + '&';
+        }
+
+        // Remove trailing '&'
+        return paramString.substring(0, paramString.length - 1);
+    }
+}
+
 @Injectable()
 export class SearchContentResolver implements Resolve<ContentResponse> {
     constructor(private contentService: ContentSearchService) {}
@@ -46,10 +66,9 @@ export class SearchContentResolver implements Resolve<ContentResponse> {
             }
         }
         if (params === '') {
-            // When no prior query, default Contributor Type to vendor.
-            params += 'vendor=true';
+            params += DefaultParams.getParamString();
         }
-        // Add default params
+        // if order_by has not been specified yet, make sure it gets set
         if (!route.queryParams['order_by']) {
             if (params !== '') {
                 params += '&';


### PR DESCRIPTION
Partial backport of #1071.

In #1071 I changed the default param system for the search page to accommodate more default params as part of a new feature. This had the side effect of stopping the search page from performing two searches (one to determine if there was partner content and another if there were no partners). We're backporting this to galaxy v3.0 to reduce load on the search page.