### PR TITLE
Allow hyphens and underscores in tags

### DIFF
--- a/galaxy/constants.py
+++ b/galaxy/constants.py
@@ -24,7 +24,7 @@ import re
 
 MAX_TAGS_COUNT = 20
 PROVIDER_GITHUB = 'GitHub'
-TAG_REGEXP = re.compile('^[a-z0-9]+$')
+TAG_REGEXP = re.compile('^[a-z0-9_-]+$')
 
 
 class Enum(enum.Enum):

--- a/galaxy/importer/loaders/apb.py
+++ b/galaxy/importer/loaders/apb.py
@@ -31,7 +31,9 @@ from galaxy.common import sanitize_content_name
 
 class APBMetaParser(object):
     # Tags should contain lowercase letters and digits only
-    TAG_REGEXP = re.compile('^[a-z0-9]+$')
+    # Underscores and hyphens are valid as well for spacing
+    # and identifiers
+    TAG_REGEXP = re.compile('^[a-z0-9_-]+$')
 
     # APB parameters should be in json-schema form
     PARAM_KEY_MAP = {


### PR DESCRIPTION
This feature allows hyphens and/or underscores in tags. This is useful for spaces or identifiers e.g. nist_800-53 which is more accurate for a tag than nist80053