### PR TITLE
Moved linter rules repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ dev/lint-rule-update:
 	@echo "Update galaxy-lint-rules repo"
 	@$(DOCKER_COMPOSE) exec galaxy git config --global user.email "dev@galaxy_1"
 	@$(DOCKER_COMPOSE) exec galaxy git config --global user.name "dev galaxy_1"
-	@$(DOCKER_COMPOSE) exec galaxy bash -c "cd /galaxy-lint-rules && git pull --ff-only  https://github.com/ansible/galaxy-lint-rules.git master"
+	@$(DOCKER_COMPOSE) exec galaxy bash -c "cd /usr/local/galaxy-lint-rules && git pull --ff-only  https://github.com/ansible/galaxy-lint-rules.git master"
 
 .PHONY: dev/setup-metrics
 dev/setup-metrics:

--- a/galaxy/importer/linters/__init__.py
+++ b/galaxy/importer/linters/__init__.py
@@ -118,7 +118,7 @@ class AnsibleLinter(BaseLinter):
     cmd = 'ansible-lint'
 
     def _check_files(self, paths):
-        rules_path = '/galaxy-lint-rules/rules'
+        rules_path = '/usr/local/galaxy-lint-rules/rules'
         cmd = [self.cmd, '-p', '-r', rules_path, '.']
         logger.debug('CMD: ' + ' '.join(cmd))
 

--- a/scripts/docker/dev/Dockerfile
+++ b/scripts/docker/dev/Dockerfile
@@ -48,7 +48,7 @@ ENV PYTHONIOENCODING utf8
 
 COPY scripts/docker/dev/entrypoint.sh /entrypoint.sh
 
-RUN git clone https://github.com/ansible/galaxy-lint-rules.git /galaxy-lint-rules
+RUN git clone https://github.com/ansible/galaxy-lint-rules.git /usr/local/galaxy-lint-rules
 
 WORKDIR /galaxy
 ENTRYPOINT ["/entrypoint.sh"]

--- a/scripts/docker/release/Dockerfile
+++ b/scripts/docker/release/Dockerfile
@@ -32,6 +32,8 @@ COPY --from=galaxy-build:latest /galaxy/dist/*.whl /tmp
 COPY --from=galaxy-build:latest /galaxy/build/static/ /var/lib/galaxy/public/static/
 RUN ${VENV_BIN}/pip install "/tmp/galaxy-$(< /var/lib/galaxy/VERSION)-py2-none-any.whl"
 
+RUN git clone https://github.com/ansible/galaxy-lint-rules.git /usr/local/galaxy-lint-rules
+
 WORKDIR /var/lib/galaxy
 
 ENV DJANGO_SETTINGS_MODULE galaxy.settings.production

--- a/scripts/docker/release/Dockerfile.build
+++ b/scripts/docker/release/Dockerfile.build
@@ -13,7 +13,6 @@ RUN yum -y install wget \
 
 RUN mkdir -p /galaxy
 COPY . /galaxy
-RUN git clone https://github.com/ansible/galaxy-lint-rules.git /galaxy-lint-rules
 WORKDIR /galaxy
 
 RUN /galaxy/scripts/docker/release/build.sh


### PR DESCRIPTION
The `galaxy-lint-rules` repo is not available on galaxy-dev, it is not on the `galaxy` docker image. This edit fixes that via testing with `make build/release`