### PR TITLE
Change provider namespace lookups to be case sensitive

### DIFF
--- a/galaxy/api/views/provider_source.py
+++ b/galaxy/api/views/provider_source.py
@@ -55,11 +55,11 @@ class ProviderSourceList(ListAPIView):
                 for source in sources:
                     source['provider'] = {
                         'id': provider.pk,
-                        'name': provider.name.lower(),
+                        'name': provider.name,
                     }
                     try:
                         provider_namespace = ProviderNamespace.objects.get(
-                            provider=provider, name__iexact=source['name']
+                            provider=provider, name=source['name']
                         )
                         source['provider_namespace'] = {
                             'id': provider_namespace.id,

--- a/galaxy/api/views/repository_source.py
+++ b/galaxy/api/views/repository_source.py
@@ -60,7 +60,7 @@ class RepositorySourceList(ListAPIView):
 
         try:
             provider_namespace = ProviderNamespace.objects.get(
-                provider=provider, name__iexact=request_namespace
+                provider=provider, name=request_namespace
             )
         except ObjectDoesNotExist:
             provider_namespace = None
@@ -141,7 +141,7 @@ class RepositorySourceDetail(ListAPIView):
 
         try:
             provider_namespace = ProviderNamespace.objects.get(
-                provider=provider, name__iexact=request_namespace
+                provider=provider, name=request_namespace
             )
         except ObjectDoesNotExist:
             provider_namespace = None

--- a/galaxy/main/signals/handlers.py
+++ b/galaxy/main/signals/handlers.py
@@ -44,7 +44,7 @@ def user_logged_in_handler(request, user, **kwargs):
     sanitized_username = username.lower().replace('-', '_')
 
     try:
-        namespace = models.ProviderNamespace.objects.get(name__iexact=username)
+        namespace = models.ProviderNamespace.objects.get(name=username)
         return
     except models.ProviderNamespace.DoesNotExist:
         namespace = None


### PR DESCRIPTION
Right now in most cases we're performing `ProviderNamespace` lookups case insensitively. 

This has caused the following issues after changing the capitalization on usernames:
- github api calls are case sensitive, so users can no longer import content
- if the user logs in and either re runs an existing import or updates their namespace, a new provider namespace is created with the new capitalization that causes `MultipleObjectsReturned` errors whenever provider namespaces are looked up (such as during the login process #1185). 