### PR TITLE
Fix django urls import

### DIFF
--- a/galaxy/accounts/models.py
+++ b/galaxy/accounts/models.py
@@ -109,7 +109,7 @@ class CustomUser(auth_models.AbstractBaseUser,
     def __str__(self):
         return self.username
 
-    # FIXME: replace with django.core.urlresolvers.reverse(..)
+    # FIXME: replace with django.urls.reverse(..)
     def get_absolute_url(self):
         return "/users/%s/" % urlquote(self.username)
 

--- a/galaxy/api/serializers/content.py
+++ b/galaxy/api/serializers/content.py
@@ -17,7 +17,7 @@
 
 import logging
 
-from django.core import urlresolvers as urls
+from django import urls
 from rest_framework import serializers
 from collections import OrderedDict
 

--- a/galaxy/api/serializers/email.py
+++ b/galaxy/api/serializers/email.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 from allauth.account.models import EmailAddress, EmailConfirmation
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework.validators import UniqueValidator, UniqueTogetherValidator
 from rest_framework import serializers
 from .serializers import BaseSerializer

--- a/galaxy/api/serializers/namespace.py
+++ b/galaxy/api/serializers/namespace.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from galaxy.main import models
 from . import serializers
 

--- a/galaxy/api/serializers/provider_namespace.py
+++ b/galaxy/api/serializers/provider_namespace.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from galaxy.main.models import ProviderNamespace
 from . import serializers

--- a/galaxy/api/serializers/provider_source.py
+++ b/galaxy/api/serializers/provider_source.py
@@ -16,7 +16,7 @@
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
 from collections import OrderedDict
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework.serializers import BaseSerializer
 
 

--- a/galaxy/api/serializers/repository.py
+++ b/galaxy/api/serializers/repository.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework import serializers as drf_serializers
 
 from galaxy.main.models import Repository

--- a/galaxy/api/serializers/repository_source.py
+++ b/galaxy/api/serializers/repository_source.py
@@ -16,7 +16,7 @@
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
 from collections import OrderedDict
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework.serializers import BaseSerializer
 
 

--- a/galaxy/api/serializers/roles.py
+++ b/galaxy/api/serializers/roles.py
@@ -16,7 +16,7 @@
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
 from rest_framework import serializers as drf_serializers
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from galaxy.main.models import Content
 from .serializers import BaseSerializer, BASE_FIELDS

--- a/galaxy/api/serializers/serializers.py
+++ b/galaxy/api/serializers/serializers.py
@@ -22,7 +22,7 @@ from rest_framework import serializers
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from collections import OrderedDict
 
 

--- a/galaxy/api/serializers/survey.py
+++ b/galaxy/api/serializers/survey.py
@@ -19,7 +19,7 @@ from . import serializers
 
 from galaxy.main import models
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 
 __all__ = (

--- a/galaxy/api/serializers/token.py
+++ b/galaxy/api/serializers/token.py
@@ -1,6 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token

--- a/galaxy/api/serializers/users.py
+++ b/galaxy/api/serializers/users.py
@@ -6,7 +6,7 @@ from allauth.account.models import EmailAddress
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from rest_framework import serializers
 

--- a/galaxy/api/views/search.py
+++ b/galaxy/api/views/search.py
@@ -22,7 +22,7 @@ import six
 
 from django.db.models import F, Func, Value, Count, ExpressionWrapper, Q
 from django.db.models import fields as db_fields
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.postgres import search as psql_search
 
 from rest_framework.response import Response

--- a/galaxy/api/views/views.py
+++ b/galaxy/api/views/views.py
@@ -22,7 +22,7 @@ from collections import OrderedDict
 from allauth.socialaccount.models import SocialToken
 from django.conf import settings
 from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import Count, Max
 from django.http import Http404, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404

--- a/galaxy/main/models.py
+++ b/galaxy/main/models.py
@@ -22,7 +22,7 @@ import six
 import uuid
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.forms.models import model_to_dict
 from django.contrib.postgres import fields as psql_fields


### PR DESCRIPTION
In oler versions of django functions like `reverse` were located
in module `django.core.urlresolvers`. Since Django 1.10 these
function has been moved to `django.urls` and old module have become
deprecated.

This patch replaces deprecated `django.core.urlresolvers` module
usage with `django.urls`.