### PR TITLE
Add explicit `on_delete` parameter for `ForeignKey`

### DIFF
--- a/galaxy/main/migrations/0001_initial.py
+++ b/galaxy/main/migrations/0001_initial.py
@@ -200,6 +200,7 @@ class Migration(migrations.Migration):
                         related_name='roles',
                         editable=False,
                         to=settings.AUTH_USER_MODEL,
+                        on_delete=models.CASCADE,
                     ),
                 ),
                 (
@@ -260,7 +261,11 @@ class Migration(migrations.Migration):
                 ),
                 (
                     'role',
-                    models.ForeignKey(related_name='imports', to='main.Role'),
+                    models.ForeignKey(
+                        related_name='imports',
+                        to='main.Role',
+                        on_delete=models.CASCADE,
+                    ),
                 ),
             ],
             options={'get_latest_by': 'released'},
@@ -309,12 +314,18 @@ class Migration(migrations.Migration):
                 (
                     'owner',
                     models.ForeignKey(
-                        related_name='ratings', to=settings.AUTH_USER_MODEL
+                        related_name='ratings',
+                        to=settings.AUTH_USER_MODEL,
+                        on_delete=models.CASCADE,
                     ),
                 ),
                 (
                     'role',
-                    models.ForeignKey(related_name='ratings', to='main.Role'),
+                    models.ForeignKey(
+                        related_name='ratings',
+                        to='main.Role',
+                        on_delete=models.CASCADE,
+                    ),
                 ),
                 (
                     'up_votes',
@@ -359,7 +370,11 @@ class Migration(migrations.Migration):
                 ),
                 (
                     'role',
-                    models.ForeignKey(related_name='versions', to='main.Role'),
+                    models.ForeignKey(
+                        related_name='versions',
+                        to='main.Role',
+                        on_delete=models.CASCADE,
+                    ),
                 ),
             ],
             options={'ordering': ('-loose_version',)},
@@ -381,7 +396,9 @@ class Migration(migrations.Migration):
                 (
                     'alias_of',
                     models.ForeignKey(
-                        related_name='aliases', to=settings.AUTH_USER_MODEL
+                        related_name='aliases',
+                        to=settings.AUTH_USER_MODEL,
+                        on_delete=models.CASCADE,
                     ),
                 ),
             ],

--- a/galaxy/main/migrations/0019_auto_20151113_0936.py
+++ b/galaxy/main/migrations/0019_auto_20151113_0936.py
@@ -75,12 +75,15 @@ class Migration(migrations.Migration):
                     models.ForeignKey(
                         related_name='import_tasks',
                         to=settings.AUTH_USER_MODEL,
+                        on_delete=models.CASCADE,
                     ),
                 ),
                 (
                     'role',
                     models.ForeignKey(
-                        related_name='import_tasks', to='main.Role'
+                        related_name='import_tasks',
+                        to='main.Role',
+                        on_delete=models.CASCADE,
                     ),
                 ),
             ],
@@ -113,7 +116,9 @@ class Migration(migrations.Migration):
                 (
                     'task',
                     models.ForeignKey(
-                        related_name='messages', to='main.ImportTask'
+                        related_name='messages',
+                        to='main.ImportTask',
+                        on_delete=models.CASCADE,
                     ),
                 ),
             ],
@@ -153,6 +158,7 @@ class Migration(migrations.Migration):
                         related_name='notifications',
                         to=settings.AUTH_USER_MODEL,
                         editable=False,
+                        on_delete=models.CASCADE,
                     ),
                 ),
                 (
@@ -231,6 +237,7 @@ class Migration(migrations.Migration):
                     models.ForeignKey(
                         related_name='notification_secrets',
                         to=settings.AUTH_USER_MODEL,
+                        on_delete=models.CASCADE,
                     ),
                 ),
                 (

--- a/galaxy/main/migrations/0026_auto_20151122_0827.py
+++ b/galaxy/main/migrations/0026_auto_20151122_0827.py
@@ -55,6 +55,7 @@ class Migration(migrations.Migration):
                         related_name='repositories',
                         editable=False,
                         to=settings.AUTH_USER_MODEL,
+                        on_delete=models.CASCADE,
                     ),
                 ),
             ],

--- a/galaxy/main/migrations/0030_auto_20151127_0824.py
+++ b/galaxy/main/migrations/0030_auto_20151127_0824.py
@@ -51,7 +51,9 @@ class Migration(migrations.Migration):
                 (
                     'owner',
                     models.ForeignKey(
-                        related_name='starred', to=settings.AUTH_USER_MODEL
+                        related_name='starred',
+                        to=settings.AUTH_USER_MODEL,
+                        on_delete=models.CASCADE,
                     ),
                 ),
             ],
@@ -96,6 +98,7 @@ class Migration(migrations.Migration):
                     models.ForeignKey(
                         related_name='subscriptions',
                         to=settings.AUTH_USER_MODEL,
+                        on_delete=models.CASCADE,
                     ),
                 ),
             ],

--- a/galaxy/main/migrations/0031_auto_20151129_1230.py
+++ b/galaxy/main/migrations/0031_auto_20151129_1230.py
@@ -14,7 +14,9 @@ class Migration(migrations.Migration):
             model_name='repository',
             name='owner',
             field=models.ForeignKey(
-                related_name='repositories', to=settings.AUTH_USER_MODEL
+                related_name='repositories',
+                to=settings.AUTH_USER_MODEL,
+                on_delete=models.CASCADE,
             ),
         ),
         migrations.AlterUniqueTogether(

--- a/galaxy/main/migrations/0051_auto_20171108_2028.py
+++ b/galaxy/main/migrations/0051_auto_20171108_2028.py
@@ -14,7 +14,11 @@ class Migration(migrations.Migration):
             model_name='video',
             name='role',
             field=models.ForeignKey(
-                related_name='videos', to='main.Role', help_text=b'', null=True
+                related_name='videos',
+                to='main.Role',
+                help_text=b'',
+                null=True,
+                on_delete=models.CASCADE,
             ),
         ),
         migrations.AlterField(

--- a/galaxy/main/migrations/0057_stargazer_role_reference.py
+++ b/galaxy/main/migrations/0057_stargazer_role_reference.py
@@ -43,7 +43,11 @@ class Migration(migrations.Migration):
             model_name='stargazer',
             name='role',
             field=models.ForeignKey(
-                to='main.Role', null=True, default=None),
+                to='main.Role',
+                null=True,
+                default=None,
+                on_delete=models.CASCADE,
+            ),
         ),
         migrations.AlterField(
             model_name='stargazer',
@@ -60,7 +64,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='stargazer',
             name='role',
-            field=models.ForeignKey(to='main.Role'),
+            field=models.ForeignKey(to='main.Role', on_delete=models.CASCADE),
         ),
         migrations.AlterUniqueTogether(
             name='stargazer',

--- a/galaxy/main/migrations/0058_stargazer_role_not_null.py
+++ b/galaxy/main/migrations/0058_stargazer_role_not_null.py
@@ -14,6 +14,10 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='stargazer',
             name='role',
-            field=models.ForeignKey(related_name='stars', to='main.Role'),
+            field=models.ForeignKey(
+                related_name='stars',
+                to='main.Role',
+                on_delete=models.CASCADE,
+            ),
         ),
     ]

--- a/galaxy/main/migrations/0060_user_repository.py
+++ b/galaxy/main/migrations/0060_user_repository.py
@@ -71,7 +71,11 @@ class Migration(migrations.Migration):
             model_name='repository',
             name='owner',
             field=models.ForeignKey(
-                to=settings.AUTH_USER_MODEL, null=True, default=None),
+                to=settings.AUTH_USER_MODEL,
+                null=True,
+                default=None,
+                on_delete=models.CASCADE,
+            ),
         ),
         migrations.RunSQL(
             sql=(UPGRADE_USER_REPOSITORY_DATA,

--- a/galaxy/main/migrations/0065_namespace_refactor.py
+++ b/galaxy/main/migrations/0065_namespace_refactor.py
@@ -185,9 +185,11 @@ class Migration(migrations.Migration):
                 ('namespace', models.ForeignKey(
                     related_name='namespaces', editable=False,
                     to='main.Namespace', null=True,
+                    on_delete=models.CASCADE,
                     verbose_name=b'Namespace')),
                 ('provider', models.ForeignKey(
                     related_name='provider', verbose_name=b'Provider',
+                    on_delete=models.CASCADE,
                     to='main.Provider', null=True)),
             ],
             options={

--- a/galaxy/main/migrations/0066_content_type.py
+++ b/galaxy/main/migrations/0066_content_type.py
@@ -63,7 +63,8 @@ class Migration(migrations.Migration):
             name='content_type',
             field=models.ForeignKey(
                 to='main.ContentType',
-                null=True
+                null=True,
+                on_delete=models.CASCADE,
             ),
         ),
         migrations.RunSQL(sql=(UPGRADE_INSERT_CONTENT_TYPES,

--- a/galaxy/main/migrations/0067_bind_stargazers_to_repo.py
+++ b/galaxy/main/migrations/0067_bind_stargazers_to_repo.py
@@ -29,7 +29,9 @@ class Migration(migrations.Migration):
             name='repository',
             field=models.ForeignKey(
                 to='main.Repository',
-                null=True),
+                null=True,
+                on_delete=models.CASCADE,
+            ),
         ),
         migrations.RunSQL(sql=UPGRADE_SET_REPOSITORY_REF,
                           reverse_sql=DOWNGRADE_SET_CONTENT_REF),
@@ -38,7 +40,9 @@ class Migration(migrations.Migration):
             name='repository',
             field=models.ForeignKey(
                 to='main.Repository',
-                related_name='stars'),
+                related_name='stars',
+                on_delete=models.CASCADE,
+            ),
         ),
         migrations.AlterUniqueTogether(
             name='stargazer',

--- a/galaxy/main/migrations/0068_auto_20180102_1126.py
+++ b/galaxy/main/migrations/0068_auto_20180102_1126.py
@@ -16,7 +16,9 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(
                 related_name='provider_namespaces',
                 editable=False, to='main.Namespace',
-                null=True, verbose_name=b'Namespace'),
+                null=True, on_delete=models.CASCADE,
+                verbose_name=b'Namespace'
+            ),
         ),
         migrations.AlterField(
             model_name='providernamespace',
@@ -24,6 +26,8 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(
                 related_name='provider_namespaces',
                 verbose_name=b'Provider',
-                to='main.Provider', null=True),
+                to='main.Provider', null=True,
+                on_delete=models.CASCADE,
+            ),
         ),
     ]

--- a/galaxy/main/migrations/0069_importtask_repository_ref.py
+++ b/galaxy/main/migrations/0069_importtask_repository_ref.py
@@ -26,7 +26,9 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(
                 related_name='import_tasks',
                 null=True, default=None,
-                to='main.Repository'),
+                to='main.Repository',
+                on_delete=models.CASCADE,
+            ),
             preserve_default=False,
         ),
         # NOTE(cutwater): Due to ambiguity in the next migrations
@@ -37,7 +39,9 @@ class Migration(migrations.Migration):
             name='repository',
             field=models.ForeignKey(
                 related_name='import_tasks',
-                to='main.Repository'),
+                to='main.Repository',
+                on_delete=models.CASCADE,
+            ),
             preserve_default=False,
         ),
         migrations.RemoveField(

--- a/galaxy/main/migrations/0072_add_fields_choices.py
+++ b/galaxy/main/migrations/0072_add_fields_choices.py
@@ -16,7 +16,9 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(
                 related_name='content_objects',
                 editable=False,
-                to='main.Repository'),
+                to='main.Repository',
+                on_delete=models.CASCADE,
+            ),
         ),
         migrations.AlterField(
             model_name='content',

--- a/galaxy/main/migrations/0075_repo_namespace_ref.py
+++ b/galaxy/main/migrations/0075_repo_namespace_ref.py
@@ -65,7 +65,9 @@ class Migration(migrations.Migration):
             name='provider_namespace',
             field=models.ForeignKey(
                 to='main.ProviderNamespace',
-                null=True),
+                null=True,
+                on_delete=models.CASCADE,
+            ),
         ),
         migrations.RunSQL(sql=UPGRADE_SET_REPO_NAMESPACE_REF,
                           reverse_sql=migrations.RunSQL.noop),
@@ -76,7 +78,9 @@ class Migration(migrations.Migration):
             name='provider_namespace',
             field=models.ForeignKey(
                 related_name='repositories',
-                to='main.ProviderNamespace'),
+                to='main.ProviderNamespace',
+                on_delete=models.CASCADE,
+            ),
         ),
         migrations.AlterUniqueTogether(
             name='repository',

--- a/galaxy/main/migrations/0076_content_namespace_ref.py
+++ b/galaxy/main/migrations/0076_content_namespace_ref.py
@@ -29,7 +29,9 @@ class Migration(migrations.Migration):
             name='namespace',
             field=models.ForeignKey(
                 to='main.Namespace',
-                null=True),
+                null=True,
+                on_delete=models.CASCADE,
+            ),
         ),
         migrations.RunSQL(sql=UPGRADE_SET_CONTENT_NAMESPACE_REF),
         migrations.AlterField(
@@ -37,7 +39,9 @@ class Migration(migrations.Migration):
             name='namespace',
             field=models.ForeignKey(
                 related_name='content_objects',
-                to='main.Namespace'),
+                to='main.Namespace',
+                on_delete=models.CASCADE,
+            ),
         ),
         migrations.AlterUniqueTogether(
             name='content',

--- a/galaxy/main/migrations/0093_link_content_version_w_repo.py
+++ b/galaxy/main/migrations/0093_link_content_version_w_repo.py
@@ -28,7 +28,8 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(
                 to='main.Repository',
                 related_name='versions',
-                null=True
+                null=True,
+                on_delete=models.CASCADE,
             ),
         ),
         migrations.RunSQL(
@@ -40,6 +41,7 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(
                 to='main.Repository',
                 related_name='versions',
+                on_delete=models.CASCADE,
             ),
         ),
         migrations.RemoveField(

--- a/galaxy/main/models.py
+++ b/galaxy/main/models.py
@@ -187,6 +187,7 @@ class UserAlias(models.Model):
     alias_of = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         related_name='aliases',
+        on_delete=models.CASCADE,
     )
     alias_name = models.CharField(
         # must be in-sync with galaxy/accounts/models.py:CustomUser
@@ -300,6 +301,7 @@ class Content(CommonModelNameNotUnique):
         'Repository',
         related_name='content_objects',
         editable=False,
+        on_delete=models.CASCADE,
     )
 
     content_type = models.ForeignKey(
@@ -311,6 +313,7 @@ class Content(CommonModelNameNotUnique):
     namespace = models.ForeignKey(
         'Namespace',
         related_name='content_objects',
+        on_delete=models.CASCADE,
     )
     readme = models.ForeignKey(
         'Readme',
@@ -676,7 +679,11 @@ class RepositoryVersion(BaseModel):
     class Meta:
         unique_together = ('repository', 'version')
 
-    repository = models.ForeignKey('Repository', related_name='versions')
+    repository = models.ForeignKey(
+        'Repository',
+        related_name='versions',
+        on_delete=models.CASCADE
+    )
 
     version = fields.VersionField(null=True)
     tag = models.CharField(max_length=64)
@@ -700,11 +707,13 @@ class ImportTaskMessage(PrimordialModel):
     task = models.ForeignKey(
         'ImportTask',
         related_name='messages',
+        on_delete=models.CASCADE,
     )
     content = models.ForeignKey(
         'Content',
         related_name='messages',
         null=True,
+        on_delete=models.CASCADE,
     )
     message_type = models.CharField(
         max_length=10,
@@ -761,11 +770,13 @@ class ImportTask(PrimordialModel):
     repository = models.ForeignKey(
         'Repository',
         related_name='import_tasks',
+        on_delete=models.CASCADE,
     )
     owner = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         related_name='import_tasks',
         db_index=True,
+        on_delete=models.CASCADE,
     )
     import_branch = models.CharField(
         max_length=256,
@@ -856,6 +867,7 @@ class NotificationSecret(PrimordialModel):
         settings.AUTH_USER_MODEL,
         related_name='notification_secrets',
         db_index=True,
+        on_delete=models.CASCADE,
     )
     source = models.CharField(
         max_length=20,
@@ -890,7 +902,8 @@ class Notification(PrimordialModel):
         settings.AUTH_USER_MODEL,
         related_name='notifications',
         db_index=True,
-        editable=False
+        editable=False,
+        on_delete=models.CASCADE,
     )
     source = models.CharField(
         max_length=20,
@@ -927,12 +940,14 @@ class Notification(PrimordialModel):
         'Repository',
         related_name='notifications',
         editable=False,
+        on_delete=models.CASCADE,
     )
     import_task = models.ForeignKey(
         ImportTask,
         related_name='notifications',
         verbose_name='Tasks',
-        editable=False
+        editable=False,
+        on_delete=models.CASCADE,
     )
 
 
@@ -952,6 +967,7 @@ class Repository(BaseModel):
     provider_namespace = models.ForeignKey(
         ProviderNamespace,
         related_name='repositories',
+        on_delete=models.CASCADE,
     )
     readme = models.ForeignKey(
         'Readme',
@@ -1079,6 +1095,7 @@ class Subscription(PrimordialModel):
     owner = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         related_name='subscriptions',
+        on_delete=models.CASCADE,
     )
     # TODO(cutwater): Replace with reference to a Repository model
     github_user = models.CharField(
@@ -1098,11 +1115,13 @@ class Stargazer(BaseModel):
     owner = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         related_name='starred',
+        on_delete=models.CASCADE,
     )
 
     repository = models.ForeignKey(
         Repository,
-        related_name='stars'
+        related_name='stars',
+        on_delete=models.CASCADE,
     )
 
 
@@ -1181,6 +1200,7 @@ class CommunitySurvey(BaseModel):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         null=False,
+        on_delete=models.CASCADE,
     )
 
     # Survey scores


### PR DESCRIPTION
Since Django 2.0 `on_delete` parameter of `ForeignKey.__init__`
has become required. This patch adds missing on_delete parameters
equal to former default value `CASCADE`.