### PR TITLE
Fix django urls deprecated parameter usage

### DIFF
--- a/galaxy/api/urls.py
+++ b/galaxy/api/urls.py
@@ -282,6 +282,7 @@ internal_urls = [
     url(r'^events/', include(event_tracking_urls)),
 ]
 
+app_name = 'api'
 urlpatterns = [
     url(r'^$', views.ApiRootView.as_view(), name='api_root_view'),
     url(r'^v1/', include(v1_urls)),

--- a/galaxy/main/urls.py
+++ b/galaxy/main/urls.py
@@ -22,6 +22,7 @@ from django.contrib.staticfiles.views import serve as serve_staticfiles
 from django.views.static import serve as serve_static
 
 
+app_name = 'main'
 urlpatterns = []
 
 if settings.DEBUG:

--- a/galaxy/urls.py
+++ b/galaxy/urls.py
@@ -26,15 +26,14 @@ admin.autodiscover()
 
 urlpatterns = [
     url(r'^accounts/', include('allauth.urls')),
-    url(r'^api/', include('galaxy.api.urls', namespace='api', app_name='api')),
+    url(r'^api/', include('galaxy.api.urls')),
     url(r'^api-auth/', include('rest_framework.urls',
                                namespace='rest_framework')),
-    # url(r'^avatar/', include('avatar.urls')),
-    url(settings.ADMIN_URL_PATTERN, include(admin.site.urls)),
+    url(settings.ADMIN_URL_PATTERN, admin.site.urls),
     url(r'^robots\.txt$', TemplateView.as_view(template_name="robots.txt",
                                                content_type='text/plain')),
     url(r'', include('django_prometheus.urls')),
-    url(r'', include('galaxy.main.urls', namespace='main', app_name='main')),
+    url(r'', include('galaxy.main.urls')),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
The `app_name` parameter of `include` function is deprecated
and has been removed since Django 2.0.
This patch moves `app_name` parameter to corresponding
urls modules as it is recommended by Django's documentation:
https://docs.djangoproject.com/en/1.11/ref/urls/#include