### PR TITLE
Fix django debug toolbar usage

### DIFF
--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -83,7 +83,6 @@ INSTALLED_APPS = (
 MIDDLEWARE_CLASSES = (
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'log_request_id.middleware.RequestIDMiddleware',
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/galaxy/settings/development.py
+++ b/galaxy/settings/development.py
@@ -37,6 +37,10 @@ INSTALLED_APPS += (  # noqa: F405
     'debug_toolbar',
 )
 
+MIDDLEWARE_CLASSES += (  # noqa: F405
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+)
+
 # Database
 # ---------------------------------------------------------
 

--- a/galaxy/settings/testing.py
+++ b/galaxy/settings/testing.py
@@ -30,13 +30,6 @@ DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 
-# Application definition
-# ---------------------------------------------------------
-
-INSTALLED_APPS += (  # noqa: F405
-    'debug_toolbar',
-)
-
 # Database
 # ---------------------------------------------------------
 

--- a/galaxy/urls.py
+++ b/galaxy/urls.py
@@ -37,7 +37,7 @@ urlpatterns = [
     url(r'', include('galaxy.main.urls', namespace='main', app_name='main')),
 ]
 
-if settings.DEBUG:
+if settings.DEBUG and 'debug_toolbar' in settings.INSTALLED_APPS:
     import debug_toolbar
     urlpatterns = [
         url(r'^__debug__/', include(debug_toolbar.urls)),


### PR DESCRIPTION
* Remove debug toolbar middleware from default settings (it causes integrity check error in future django versions)
* Enable debug toolbar URLs only when it's configured in settings.