### PR TITLE
Fixes failed imports when video_links is present in meta/main.yml

### DIFF
--- a/galaxy/worker/importers/role.py
+++ b/galaxy/worker/importers/role.py
@@ -65,8 +65,8 @@ class RoleImporter(base.ContentImporter):
         role.videos.all().delete()
         for video in videos:
             role.videos.create(
-                url=video['url'],
-                description=video['title'])
+                url=video.url,
+                description=video.description)
 
     def _add_tags(self, role, tags):
         if not tags:


### PR DESCRIPTION
Imports fail when video_links is present in meta/main.yml. This patch references the video object.