### PR TITLE
New survey and Import status email notifications

### DIFF
--- a/galaxy/api/tasks.py
+++ b/galaxy/api/tasks.py
@@ -20,8 +20,8 @@ from galaxy.worker import tasks as worker_tasks
 
 
 def create_import_task(
-        repository, user, import_branch=None,
-        travis_status_url='', travis_build_url=''):
+        repository, user, import_branch=None, travis_status_url='',
+        travis_build_url='', user_initiated=False):
 
     task = models.ImportTask.objects.create(
         repository=repository,
@@ -31,5 +31,8 @@ def create_import_task(
         travis_build_url=travis_build_url,
         state=models.ImportTask.STATE_PENDING
     )
-    worker_tasks.import_repository.delay(task.id)
+    worker_tasks.import_repository.delay(
+        task.id,
+        user_initiated=user_initiated
+    )
     return task

--- a/galaxy/api/views/repository.py
+++ b/galaxy/api/views/repository.py
@@ -152,7 +152,11 @@ class RepositoryList(views.ListCreateAPIView):
             else:
                 owner.repositories.add(repository)
 
-        import_task = tasks.create_import_task(repository, request.user)
+        import_task = tasks.create_import_task(
+            repository,
+            request.user,
+            user_initiated=True
+        )
 
         serializer = self.get_serializer(repository)
         data = serializer.data
@@ -238,7 +242,11 @@ class RepositoryDetail(views.RetrieveUpdateDestroyAPIView):
         # Don't create an import task if we're just updating the deprication
         # status
         if updated != ['deprecated']:
-            import_task = tasks.create_import_task(instance, request.user)
+            import_task = tasks.create_import_task(
+                instance,
+                request.user,
+                user_initiated=True
+            )
 
             data['summary_fields']['latest_import'] = \
                 serializers.ImportTaskSerializer(import_task).data

--- a/galaxy/api/views/survey.py
+++ b/galaxy/api/views/survey.py
@@ -55,7 +55,7 @@ class CommunitySurveyList(base_views.ListCreateAPIView):
 
         headers = self.get_success_headers(serializer.data)
 
-        # Each question answered comes as a separate POST request, so delay
+        # Each question answered comes as a separate HTTP request, so delay
         # the email update by 2 minutes to allow for all the questions to be
         # submitted so that the score includes all of the submitted answers.
         user_notifications.new_survey.apply_async(

--- a/galaxy/api/views/views.py
+++ b/galaxy/api/views/views.py
@@ -425,7 +425,7 @@ class ImportTaskList(base_views.ListCreateAPIView):
 
         task = tasks.create_import_task(
             repository, request.user,
-            import_branch=github_reference)
+            import_branch=github_reference, user_initiated=True)
 
         serializer = self.get_serializer(instance=task)
         response = {'results': [serializer.data]}


### PR DESCRIPTION
This PR relies on commits from #1213 and must wait for #1213 to be merged before merging.

Import status:
- Notifies all of the owners of a namespace that an import has failed/succeeded. If an import is triggered manually by one of the owners of the namespace, they are omitted from the email list.
```
Hello,

This message is to notify you that a recent import of newswangerd.galaxy_debops_examples on Ansible galaxy has succeeded.

Cheers,
   Ansible Galaxy

-- To stop seeing these messages, visit http://localhost:8000/preferences/ to update your settings.
```

New Survey:
- Notifies all the owners of a namespace when a new survey is submitted for one of their repos.
```
Hello,

Someone has just submitted a new rating for galaxy_test_galaxy_content on Ansible Galaxy.Your collection now has a user rating of 3.0.

Visit http://localhost:8000/newswangerd/galaxy_test_galaxy_content/ for more details.

Cheers,
   Ansible Galaxy

-- To stop seeing these messages, visit http://localhost:8000/preferences/ to update your settings.
```