### PR TITLE
Disable ordered-import TSLint rule.

### DIFF
--- a/galaxyui/tslint.json
+++ b/galaxyui/tslint.json
@@ -16,6 +16,7 @@
     "object-literal-shorthand": false,
     "trailing-comma": false,
     "class-name": true,
+    "ordered-imports": false,
     "comment-format": [
       true,
       "check-space"


### PR DESCRIPTION
Ordered imports requires that Angular imports be alphabetized by the folder that they are in. It drives me crazy and has so far provided no utility so I'm disabling it.