### PR TITLE
Change JavaScript max line length from 140 to 80

### DIFF
--- a/galaxyui/.prettierrc.yaml
+++ b/galaxyui/.prettierrc.yaml
@@ -1,4 +1,4 @@
-printWidth: 140
+printWidth: 80
 singleQuote: true
 trailingComma: 'all'
 tabWidth: 4

--- a/galaxyui/src/app/app-routing.module.ts
+++ b/galaxyui/src/app/app-routing.module.ts
@@ -9,7 +9,10 @@ import {
     RepositoryResolver as ContentRepositoryResolver,
 } from './content-detail/content-detail.resolver.service';
 
-import { NamespaceDetailResolver, RepositoryResolver as AuthorRepositoryResolver } from './authors/authors.resolver.service';
+import {
+    NamespaceDetailResolver,
+    RepositoryResolver as AuthorRepositoryResolver,
+} from './authors/authors.resolver.service';
 
 import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
 

--- a/galaxyui/src/app/app.component.spec.ts
+++ b/galaxyui/src/app/app.component.spec.ts
@@ -20,6 +20,8 @@ describe('AppComponent', () => {
         const fixture = TestBed.createComponent(AppComponent);
         fixture.detectChanges();
         const compiled = fixture.debugElement.nativeElement;
-        expect(compiled.querySelector('h1').textContent).toContain('Welcome to app!');
+        expect(compiled.querySelector('h1').textContent).toContain(
+            'Welcome to app!',
+        );
     }));
 });

--- a/galaxyui/src/app/app.component.ts
+++ b/galaxyui/src/app/app.component.ts
@@ -33,7 +33,10 @@ import { AuthService } from './auth/auth.service';
 import { ApiRootService } from './resources/api-root/api-root.service';
 import { EventLoggerService } from './resources/logger/event-logger.service';
 
-import { BodyCommand, PFBodyService } from './resources/pf-body/pf-body.service';
+import {
+    BodyCommand,
+    PFBodyService,
+} from './resources/pf-body/pf-body.service';
 
 @Component({
     selector: 'galaxy-nav',
@@ -54,7 +57,10 @@ export class AppComponent implements OnInit {
         private eventLogger: EventLoggerService,
     ) {
         this.router.events.subscribe(event => {
-            if (event instanceof NavigationEnd || event instanceof NavigationStart) {
+            if (
+                event instanceof NavigationEnd ||
+                event instanceof NavigationStart
+            ) {
                 // When user navigates away from a page, remove any lingering notifications
                 const notices: Notification[] = this.notificationService.getNotifications();
                 notices.forEach((notice: Notification) => {
@@ -71,7 +77,11 @@ export class AppComponent implements OnInit {
 
             if (event instanceof NavigationEnd) {
                 this.isLoading = false;
-                this.eventLogger.logPageLoad(window.performance.now() - this.timeAtLoad, this.startComponent, this.startUrl);
+                this.eventLogger.logPageLoad(
+                    window.performance.now() - this.timeAtLoad,
+                    this.startComponent,
+                    this.startUrl,
+                );
             }
         });
     }
@@ -139,9 +149,18 @@ export class AppComponent implements OnInit {
         ] as VerticalNavigationItem[];
 
         this.apiRootService.get().subscribe(apiInfo => {
-            this.aboutConfig.productInfo.push({ name: 'Server Version', value: apiInfo.server_version });
-            this.aboutConfig.productInfo.push({ name: 'Version Name', value: apiInfo.version_name });
-            this.aboutConfig.productInfo.push({ name: 'Api Version', value: apiInfo.current_version });
+            this.aboutConfig.productInfo.push({
+                name: 'Server Version',
+                value: apiInfo.server_version,
+            });
+            this.aboutConfig.productInfo.push({
+                name: 'Version Name',
+                value: apiInfo.version_name,
+            });
+            this.aboutConfig.productInfo.push({
+                name: 'Api Version',
+                value: apiInfo.current_version,
+            });
 
             this.teamMembers = apiInfo.team_members;
         });
@@ -296,7 +315,10 @@ export class AppComponent implements OnInit {
 
     private optionallyAddMobileButtons(): void {
         const layoutElement = document.getElementById('verticalNavLayout');
-        const layoutWidth = parseInt(window.getComputedStyle(layoutElement).width, 10);
+        const layoutWidth = parseInt(
+            window.getComputedStyle(layoutElement).width,
+            10,
+        );
         if (layoutWidth <= 768) {
             this.addMobileButtons();
         }

--- a/galaxyui/src/app/app.module.ts
+++ b/galaxyui/src/app/app.module.ts
@@ -4,7 +4,11 @@ import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 
 import { HttpClientModule, HttpClientXsrfModule } from '@angular/common/http';
 
-import { AboutModalModule, ToastNotificationListModule, VerticalNavigationModule } from 'patternfly-ng';
+import {
+    AboutModalModule,
+    ToastNotificationListModule,
+    VerticalNavigationModule,
+} from 'patternfly-ng';
 
 import { BsDropdownModule, ModalModule, TooltipModule } from 'ngx-bootstrap';
 

--- a/galaxyui/src/app/auth/auth.service.ts
+++ b/galaxyui/src/app/auth/auth.service.ts
@@ -6,7 +6,12 @@ import { Observable, of } from 'rxjs';
 
 import { map } from 'rxjs/operators';
 
-import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
+import {
+    ActivatedRouteSnapshot,
+    CanActivate,
+    Router,
+    RouterStateSnapshot,
+} from '@angular/router';
 
 export interface IMe {
     url: string;
@@ -25,7 +30,10 @@ export interface IMe {
 export class AuthService implements CanActivate {
     constructor(private http: HttpClient, private router: Router) {}
 
-    headers: HttpHeaders = new HttpHeaders().set('Content-Type', 'application/json');
+    headers: HttpHeaders = new HttpHeaders().set(
+        'Content-Type',
+        'application/json',
+    );
     meCache: IMe = null;
     meUrl = '/api/v1/me/';
     redirectUrl = '/home';
@@ -44,13 +52,15 @@ export class AuthService implements CanActivate {
 
     logout(): Observable<any> {
         this.meCache = null;
-        return this.http.post('/api/v1/account/logout', {}, { headers: this.headers }).pipe(
-            map(result => {
-                this.meCache = null;
-                this.redirectUrl = '/home';
-                return result;
-            }),
-        );
+        return this.http
+            .post('/api/v1/account/logout', {}, { headers: this.headers })
+            .pipe(
+                map(result => {
+                    this.meCache = null;
+                    this.redirectUrl = '/home';
+                    return result;
+                }),
+            );
     }
 
     checkPermissions(route: ActivatedRouteSnapshot): boolean {
@@ -61,7 +71,10 @@ export class AuthService implements CanActivate {
             result = false;
         }
         if (route['data'] && route['data']['expectedRole']) {
-            if (route['data']['expectedRole'] === 'isStaff' && !this.meCache.staff) {
+            if (
+                route['data']['expectedRole'] === 'isStaff' &&
+                !this.meCache.staff
+            ) {
                 // User does not have is_staff=True
                 this.router.navigate(['/access-denied', { error: true }]);
                 result = false;
@@ -70,7 +83,10 @@ export class AuthService implements CanActivate {
         return result;
     }
 
-    canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
+    canActivate(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<boolean> {
         this.redirectUrl = state.url;
         if (this.meCache) {
             return Observable.create(observer => {

--- a/galaxyui/src/app/authors/authors.component.ts
+++ b/galaxyui/src/app/authors/authors.component.ts
@@ -20,7 +20,11 @@ import { Namespace } from '../resources/namespaces/namespace';
 import { NamespaceService } from '../resources/namespaces/namespace.service';
 import { PFBodyService } from '../resources/pf-body/pf-body.service';
 
-import { ContentTypes, ContentTypesIconClasses, ContentTypesPluralChoices } from '../enums/content-types.enum';
+import {
+    ContentTypes,
+    ContentTypesIconClasses,
+    ContentTypesPluralChoices,
+} from '../enums/content-types.enum';
 
 @Component({
     selector: 'app-authors',
@@ -143,9 +147,11 @@ export class AuthorsComponent implements OnInit {
         if ($event.appliedFilters.length) {
             $event.appliedFilters.forEach(filter => {
                 if (filter.field.type === 'typeahead') {
-                    this.filterBy['or__' + filter.field.id + '__icontains'] = filter.query.id;
+                    this.filterBy['or__' + filter.field.id + '__icontains'] =
+                        filter.query.id;
                 } else {
-                    this.filterBy['or__' + filter.field.id + '__icontains'] = filter.value;
+                    this.filterBy['or__' + filter.field.id + '__icontains'] =
+                        filter.value;
                 }
             });
         } else {
@@ -202,23 +208,41 @@ export class AuthorsComponent implements OnInit {
                             // summarize plugins
                             let count = 0;
                             const countObj = {};
-                            for (const count_key in item['summary_fields']['content_counts']) {
-                                if (item['summary_fields']['content_counts'].hasOwnProperty(count_key)) {
+                            for (const count_key in item['summary_fields'][
+                                'content_counts'
+                            ]) {
+                                if (
+                                    item['summary_fields'][
+                                        'content_counts'
+                                    ].hasOwnProperty(count_key)
+                                ) {
                                     if (count_key.indexOf('plugin') > -1) {
-                                        count += item['summary_fields']['content_counts'][count_key];
+                                        count +=
+                                            item['summary_fields'][
+                                                'content_counts'
+                                            ][count_key];
                                     }
                                 }
                             }
                             if (count > 0) {
-                                countObj['title'] = ContentTypesPluralChoices[ct];
+                                countObj['title'] =
+                                    ContentTypesPluralChoices[ct];
                                 countObj['count'] = count;
-                                countObj['iconClass'] = ContentTypesIconClasses[ct];
+                                countObj['iconClass'] =
+                                    ContentTypesIconClasses[ct];
                                 contentCounts.push(countObj);
                             }
-                        } else if (item['summary_fields']['content_counts'][ContentTypes[ct]] > 0) {
+                        } else if (
+                            item['summary_fields']['content_counts'][
+                                ContentTypes[ct]
+                            ] > 0
+                        ) {
                             const countObj = {};
                             countObj['title'] = ContentTypesPluralChoices[ct];
-                            countObj['count'] = item['summary_fields']['content_counts'][ContentTypes[ct]];
+                            countObj['count'] =
+                                item['summary_fields']['content_counts'][
+                                    ContentTypes[ct]
+                                ];
                             countObj['iconClass'] = ContentTypesIconClasses[ct];
                             contentCounts.push(countObj);
                         }

--- a/galaxyui/src/app/authors/authors.module.ts
+++ b/galaxyui/src/app/authors/authors.module.ts
@@ -31,6 +31,10 @@ import { DetailActionsComponent } from './detail/detail-actions/detail-actions.c
         ActionModule,
         UtilitiesModule,
     ],
-    declarations: [DetailActionsComponent, AuthorsComponent, AuthorDetailComponent],
+    declarations: [
+        DetailActionsComponent,
+        AuthorsComponent,
+        AuthorDetailComponent,
+    ],
 })
 export class AuthorsModule {}

--- a/galaxyui/src/app/authors/authors.resolver.service.ts
+++ b/galaxyui/src/app/authors/authors.resolver.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@angular/core';
 
-import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+import {
+    ActivatedRouteSnapshot,
+    Resolve,
+    RouterStateSnapshot,
+} from '@angular/router';
 
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -13,7 +17,10 @@ import { RepositoryService } from '../resources/repositories/repository.service'
 @Injectable()
 export class NamespaceListResolver implements Resolve<PagedResponse> {
     constructor(private namespaceService: NamespaceService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<PagedResponse> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<PagedResponse> {
         return this.namespaceService.pagedQuery({ is_vendor: false });
     }
 }
@@ -21,7 +28,10 @@ export class NamespaceListResolver implements Resolve<PagedResponse> {
 @Injectable()
 export class NamespaceDetailResolver implements Resolve<Namespace> {
     constructor(private namespaceService: NamespaceService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Namespace> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<Namespace> {
         const namespace = route.params['namespace'].toLowerCase();
         const params = {
             name__iexact: namespace,
@@ -41,7 +51,10 @@ export class NamespaceDetailResolver implements Resolve<Namespace> {
 @Injectable()
 export class RepositoryResolver implements Resolve<PagedResponse> {
     constructor(private repositoryService: RepositoryService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<PagedResponse> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<PagedResponse> {
         const namespace = route.params['namespace'].toLowerCase();
         const params = {
             provider_namespace__namespace__name__iexact: namespace,

--- a/galaxyui/src/app/authors/authors.routing.module.ts
+++ b/galaxyui/src/app/authors/authors.routing.module.ts
@@ -2,7 +2,11 @@ import { NgModule } from '@angular/core';
 
 import { RouterModule, Routes } from '@angular/router';
 
-import { NamespaceDetailResolver, NamespaceListResolver, RepositoryResolver } from './authors.resolver.service';
+import {
+    NamespaceDetailResolver,
+    NamespaceListResolver,
+    RepositoryResolver,
+} from './authors.resolver.service';
 
 import { AuthorsComponent } from './authors.component';
 
@@ -20,6 +24,10 @@ const routes: Routes = [
 @NgModule({
     imports: [RouterModule.forChild(routes)],
     exports: [RouterModule],
-    providers: [NamespaceDetailResolver, NamespaceListResolver, RepositoryResolver],
+    providers: [
+        NamespaceDetailResolver,
+        NamespaceListResolver,
+        RepositoryResolver,
+    ],
 })
 export class AuthorsRoutingModule {}

--- a/galaxyui/src/app/authors/detail/author-detail.component.ts
+++ b/galaxyui/src/app/authors/detail/author-detail.component.ts
@@ -28,9 +28,17 @@ import { RepositoryService } from '../../resources/repositories/repository.servi
 import { UserPreferences } from '../../resources/preferences/user-preferences';
 import { PreferencesService } from '../../resources/preferences/preferences.service';
 
-import { ContentTypes, ContentTypesIconClasses, ContentTypesPluralChoices } from '../../enums/content-types.enum';
+import {
+    ContentTypes,
+    ContentTypesIconClasses,
+    ContentTypesPluralChoices,
+} from '../../enums/content-types.enum';
 
-import { RepoFormats, RepoFormatsIconClasses, RepoFormatsTooltips } from '../../enums/repo-types.enum';
+import {
+    RepoFormats,
+    RepoFormatsIconClasses,
+    RepoFormatsTooltips,
+} from '../../enums/repo-types.enum';
 
 @Component({
     selector: 'app-author-detail',
@@ -180,10 +188,14 @@ export class AuthorDetailComponent implements OnInit {
                     }
                 });
                 if (this.namespace.is_vendor) {
-                    this.pageTitle = `Partners;/partners;${this.namespace.name}`;
+                    this.pageTitle = `Partners;/partners;${
+                        this.namespace.name
+                    }`;
                     this.pageIcon = 'fa fa-star';
                 } else {
-                    this.pageTitle = `Community Authors;/community;${this.namespace.name}`;
+                    this.pageTitle = `Community Authors;/community;${
+                        this.namespace.name
+                    }`;
                     this.pageIcon = 'fa fa-users';
                 }
                 this.parepareNamespace();
@@ -199,7 +211,11 @@ export class AuthorDetailComponent implements OnInit {
 
     handleListClick($event: ListEvent): void {
         const repository = $event.item;
-        this.router.navigate(['/', repository.summary_fields['namespace']['name'], repository.name]);
+        this.router.navigate([
+            '/',
+            repository.summary_fields['namespace']['name'],
+            repository.name,
+        ]);
     }
 
     filterChanged($event: FilterEvent): void {
@@ -208,7 +224,8 @@ export class AuthorDetailComponent implements OnInit {
                 if (filter.field.type === 'typeahead') {
                     this.filterBy['or__' + filter.field.id] = filter.query.id;
                 } else {
-                    this.filterBy['or__' + filter.field.id + '__icontains'] = filter.value;
+                    this.filterBy['or__' + filter.field.id + '__icontains'] =
+                        filter.value;
                 }
             });
         } else {
@@ -246,7 +263,9 @@ export class AuthorDetailComponent implements OnInit {
     followUser() {
         this.followerClass = 'fa fa-spin fa-spinner';
         if (this.isFollower) {
-            const index = this.preferences.namespaces_followed.indexOf(this.namespace.id);
+            const index = this.preferences.namespaces_followed.indexOf(
+                this.namespace.id,
+            );
             this.preferences.namespaces_followed.splice(index, 1);
         } else {
             this.preferences.namespaces_followed.push(this.namespace.id);
@@ -262,7 +281,11 @@ export class AuthorDetailComponent implements OnInit {
     // private
 
     private setFollower() {
-        if (this.preferences.namespaces_followed.find(x => x === this.namespace.id) !== undefined) {
+        if (
+            this.preferences.namespaces_followed.find(
+                x => x === this.namespace.id,
+            ) !== undefined
+        ) {
             this.isFollower = true;
             this.followerClass = 'fa fa-user-times';
         } else {
@@ -273,7 +296,9 @@ export class AuthorDetailComponent implements OnInit {
 
     private searchRepositories() {
         this.pageLoading = true;
-        this.filterBy['provider_namespace__namespace__name'] = this.namespace.name;
+        this.filterBy[
+            'provider_namespace__namespace__name'
+        ] = this.namespace.name;
         this.filterBy['order'] = this.sortBy;
         this.filterBy['page_size'] = this.pageSize;
         this.filterBy['page'] = this.pageNumber;
@@ -294,9 +319,13 @@ export class AuthorDetailComponent implements OnInit {
                 // summarize plugins
                 let count = 0;
                 const countObj = {};
-                for (const count_key in this.namespace['summary_fields']['content_counts']) {
+                for (const count_key in this.namespace['summary_fields'][
+                    'content_counts'
+                ]) {
                     if (count_key.indexOf('plugin') > -1) {
-                        count += this.namespace['summary_fields']['content_counts'][count_key];
+                        count += this.namespace['summary_fields'][
+                            'content_counts'
+                        ][count_key];
                     }
                 }
                 if (count > 0) {
@@ -305,10 +334,16 @@ export class AuthorDetailComponent implements OnInit {
                     countObj['iconClass'] = ContentTypesIconClasses[ct];
                     contentCounts.push(countObj);
                 }
-            } else if (this.namespace['summary_fields']['content_counts'][ContentTypes[ct]] > 0) {
+            } else if (
+                this.namespace['summary_fields']['content_counts'][
+                    ContentTypes[ct]
+                ] > 0
+            ) {
                 const countObj = {};
                 countObj['title'] = ContentTypesPluralChoices[ct];
-                countObj['count'] = this.namespace['summary_fields']['content_counts'][ContentTypes[ct]];
+                countObj['count'] = this.namespace['summary_fields'][
+                    'content_counts'
+                ][ContentTypes[ct]];
                 countObj['iconClass'] = ContentTypesIconClasses[ct];
                 contentCounts.push(countObj);
             }
@@ -330,9 +365,15 @@ export class AuthorDetailComponent implements OnInit {
 
             item.last_import = 'NA';
             item.last_import_state = 'NA';
-            if (item.summary_fields['latest_import'] && item.summary_fields['latest_import']['finished']) {
-                item.last_import = moment(item.summary_fields['latest_import']['finished']).fromNow();
-                item.last_import_state = item.summary_fields['latest_import']['state'];
+            if (
+                item.summary_fields['latest_import'] &&
+                item.summary_fields['latest_import']['finished']
+            ) {
+                item.last_import = moment(
+                    item.summary_fields['latest_import']['finished'],
+                ).fromNow();
+                item.last_import_state =
+                    item.summary_fields['latest_import']['state'];
             }
 
             item.last_commit = 'NA';
@@ -345,7 +386,8 @@ export class AuthorDetailComponent implements OnInit {
             if (!item.description) {
                 // Legacy Repository objects are missing a description. Will get fixed on first import.
                 if (item.summary_fields['content_objects']) {
-                    for (const contentObject of item.summary_fields.content_objects) {
+                    for (const contentObject of item.summary_fields
+                        .content_objects) {
                         if (contentObject.description) {
                             item.description = contentObject.description;
                             break;

--- a/galaxyui/src/app/authors/detail/detail-actions/detail-actions.component.ts
+++ b/galaxyui/src/app/authors/detail/detail-actions/detail-actions.component.ts
@@ -42,7 +42,8 @@ export class DetailActionsComponent implements OnInit {
                 {
                     id: 'scmView',
                     title: 'View SCM Repository',
-                    tooltip: 'Opens the SCM repository in new browser window or tab',
+                    tooltip:
+                        'Opens the SCM repository in new browser window or tab',
                 },
                 {
                     disabled: this._repository.issue_tracker_url ? true : false,
@@ -57,7 +58,11 @@ export class DetailActionsComponent implements OnInit {
     handleAction($event) {
         switch ($event.id) {
             case 'more':
-                this.router.navigate(['/', this.repository.summary_fields['namespace']['name'], this.repository.name]);
+                this.router.navigate([
+                    '/',
+                    this.repository.summary_fields['namespace']['name'],
+                    this.repository.name,
+                ]);
                 break;
             case 'scmView':
                 window.open(this.repository.external_url, '_blank');

--- a/galaxyui/src/app/content-detail/cards/info/card-info.component.ts
+++ b/galaxyui/src/app/content-detail/cards/info/card-info.component.ts
@@ -58,18 +58,28 @@ export class CardInfoComponent implements OnInit {
         if (this._repoContent) {
             if (this._repoType === 'multi') {
                 this._repoContent['install_cmd'] =
-                    `mazer install ${this._repoContent.summary_fields['namespace']['name']}.` +
+                    `mazer install ${
+                        this._repoContent.summary_fields['namespace']['name']
+                    }.` +
                     `${this._repoContent.summary_fields['repository']['name']}`;
             } else {
                 this._repoContent['install_cmd'] =
-                    `ansible-galaxy install ${this._repoContent.summary_fields['namespace']['name']}.` + `${this._repoContent.name}`;
+                    `ansible-galaxy install ${
+                        this._repoContent.summary_fields['namespace']['name']
+                    }.` + `${this._repoContent.name}`;
             }
-            this._repoContent['tags'] = this._repoContent.summary_fields['tags'];
+            this._repoContent['tags'] = this._repoContent.summary_fields[
+                'tags'
+            ];
             this._repoContent['hasTags'] =
-                this.repoContent.summary_fields['tags'] && this._repoContent.summary_fields['tags'].length ? true : false;
+                this.repoContent.summary_fields['tags'] &&
+                this._repoContent.summary_fields['tags'].length
+                    ? true
+                    : false;
             this.example_name = this._repoContent.name;
             this.example_type = this._repoContent.content_type;
-            this.example_type_plural = ContentTypesPlural[this._repoContent.content_type];
+            this.example_type_plural =
+                ContentTypesPlural[this._repoContent.content_type];
         }
     }
     get repoContent(): Content {

--- a/galaxyui/src/app/content-detail/cards/quality-details/quality-details.component.ts
+++ b/galaxyui/src/app/content-detail/cards/quality-details/quality-details.component.ts
@@ -42,9 +42,15 @@ export class QualityDetailsComponent implements OnInit {
         this.metaWarn = new Warning();
         this.compatibilityWarn = new Warning();
 
-        this.content.content_score = this.convertScore(this.content.content_score);
-        this.content.metadata_score = this.convertScore(this.content.metadata_score);
-        this.content.compatibility_score = this.convertScore(this.content.compatibility_score);
+        this.content.content_score = this.convertScore(
+            this.content.content_score,
+        );
+        this.content.metadata_score = this.convertScore(
+            this.content.metadata_score,
+        );
+        this.content.compatibility_score = this.convertScore(
+            this.content.compatibility_score,
+        );
 
         for (const el of this.content.summary_fields.task_messages) {
             if (el.is_linter_rule_violation && el.rule_severity > 0) {

--- a/galaxyui/src/app/content-detail/cards/survey/community-survey.component.ts
+++ b/galaxyui/src/app/content-detail/cards/survey/community-survey.component.ts
@@ -20,7 +20,11 @@ export class CardCommunitySurveyComponent implements OnInit {
     // Used to track which component is being loaded
     componentName = 'CardCommunitySurveyComponent';
 
-    constructor(private surveyService: SurveyService, private authService: AuthService, private router: Router) {}
+    constructor(
+        private surveyService: SurveyService,
+        private authService: AuthService,
+        private router: Router,
+    ) {}
 
     config: CardConfig;
     communitySurveys: Survey[];
@@ -120,18 +124,22 @@ export class CardCommunitySurveyComponent implements OnInit {
             this.myUserId = me.id;
 
             // The user id has to be set before surveys are loaded from the API
-            this.surveyService.query({ repository: this.contentId, page_size: 1000 }).subscribe(surveys => {
-                this.communitySurveys = surveys;
-                this.numberOfSurveys = this.communitySurveys.length;
-                this.loadMySurvey();
-                this.loading = false;
-            });
+            this.surveyService
+                .query({ repository: this.contentId, page_size: 1000 })
+                .subscribe(surveys => {
+                    this.communitySurveys = surveys;
+                    this.numberOfSurveys = this.communitySurveys.length;
+                    this.loadMySurvey();
+                    this.loading = false;
+                });
         });
     }
 
     // Loads the list of survey that belong to this repo
     private loadMySurvey() {
-        this.mySurvey = this.communitySurveys.find(x => x.user === this.myUserId);
+        this.mySurvey = this.communitySurveys.find(
+            x => x.user === this.myUserId,
+        );
 
         if (!this.mySurvey) {
             this.mySurvey = {
@@ -227,7 +235,9 @@ export class CardCommunitySurveyComponent implements OnInit {
         this.surveyService.save(this.mySurvey).subscribe(dbSurvey => {
             this.mySurvey.id = dbSurvey.id;
             this.communityBarText = null;
-            this.setCommunityScore(dbSurvey.summary_fields.repository.community_score);
+            this.setCommunityScore(
+                dbSurvey.summary_fields.repository.community_score,
+            );
 
             // Submit the cached survey data.
             if (this.waitingForId) {

--- a/galaxyui/src/app/content-detail/content-detail.component.ts
+++ b/galaxyui/src/app/content-detail/content-detail.component.ts
@@ -140,17 +140,26 @@ export class ContentDetailComponent implements OnInit {
 
                 const req_content_name = params['content_name'];
 
-                if (req_content_name && data['content'] && data['content'].length) {
-                    this.selectedContent = this.findSelectedContent(req_content_name);
+                if (
+                    req_content_name &&
+                    data['content'] &&
+                    data['content'].length
+                ) {
+                    this.selectedContent = this.findSelectedContent(
+                        req_content_name,
+                    );
                 }
                 if (
                     !this.repository ||
                     !this.content ||
-                    (this.repository.format === RepoFormats.multi && req_content_name && !this.selectedContent)
+                    (this.repository.format === RepoFormats.multi &&
+                        req_content_name &&
+                        !this.selectedContent)
                 ) {
                     // Requested content from a multicontent repo not found || No content found
                     this.showEmptyState = true;
-                    this.pageTitle = '<i class="fa fa-frown-o"></i> Content Not Found';
+                    this.pageTitle =
+                        '<i class="fa fa-frown-o"></i> Content Not Found';
                     this.pageLoading = false;
                 } else {
                     // Append author type to breadcrumb
@@ -163,24 +172,41 @@ export class ContentDetailComponent implements OnInit {
                     }
 
                     // Append author namespace and repository name to breadcrumb
-                    this.pageTitle += `${this.namespace.name};/${this.namespace.name};${params['repository']};`;
+                    this.pageTitle += `${this.namespace.name};/${
+                        this.namespace.name
+                    };${params['repository']};`;
 
                     // If content is specified, append it to the breadcrumb
                     if (this.selectedContent) {
-                        this.pageTitle += `/${this.namespace.name}/${params['repository']};${req_content_name}`;
+                        this.pageTitle += `/${this.namespace.name}/${
+                            params['repository']
+                        };${req_content_name}`;
                     }
                     this.repository.last_import = 'NA';
                     this.repository.last_commit = 'NA';
-                    if (this.repository.summary_fields['latest_import'] && this.repository.summary_fields['latest_import']['finished']) {
-                        this.repository.last_import = moment(this.repository.summary_fields['latest_import']['finished']).fromNow();
+                    if (
+                        this.repository.summary_fields['latest_import'] &&
+                        this.repository.summary_fields['latest_import'][
+                            'finished'
+                        ]
+                    ) {
+                        this.repository.last_import = moment(
+                            this.repository.summary_fields['latest_import'][
+                                'finished'
+                            ],
+                        ).fromNow();
                     }
 
                     if (this.repository.commit_created) {
-                        this.repository.last_commit = moment(this.repository.commit_created).fromNow();
+                        this.repository.last_commit = moment(
+                            this.repository.commit_created,
+                        ).fromNow();
                     }
 
                     if (this.repository.quality_score_date) {
-                        this.repository.quality_score_date = moment(this.repository.quality_score_date).fromNow();
+                        this.repository.quality_score_date = moment(
+                            this.repository.quality_score_date,
+                        ).fromNow();
                     }
 
                     if (this.content && this.content.length) {
@@ -271,23 +297,40 @@ export class ContentDetailComponent implements OnInit {
                 }
             }
             // Make it easier to access related data
-            ['platforms', 'versions', 'cloud_platforms', 'task_messages', 'dependencies'].forEach(key => {
+            [
+                'platforms',
+                'versions',
+                'cloud_platforms',
+                'task_messages',
+                'dependencies',
+            ].forEach(key => {
                 this.repoContent[key] = this.repoContent.summary_fields[key];
                 let hasKey = 'has' + key[0].toUpperCase() + key.substring(1);
                 hasKey = hasKey.replace(/\_(\w)/, this.toCamel);
-                this.repoContent[hasKey] = this.repoContent[key] && this.repoContent[key].length ? true : false;
+                this.repoContent[hasKey] =
+                    this.repoContent[key] && this.repoContent[key].length
+                        ? true
+                        : false;
             });
             if (this.repository.format === RepoFormats.multi) {
                 this.getContentTypeCounts();
                 if (this.selectedContent) {
                     // For multi-content repo, set the detail view to the selected content item
-                    if (this.selectedContent.content_type === ContentTypes.module) {
+                    if (
+                        this.selectedContent.content_type ===
+                        ContentTypes.module
+                    ) {
                         this.showingView = ViewTypes.modules;
-                    } else if (this.selectedContent.content_type === ContentTypes.moduleUtils) {
+                    } else if (
+                        this.selectedContent.content_type ===
+                        ContentTypes.moduleUtils
+                    ) {
                         this.showingView = ViewTypes.moduleUtils;
                     } else if (PluginTypes[this.selectedContent.content_type]) {
                         this.showingView = ViewTypes.plugins;
-                    } else if (this.selectedContent.content_type === ContentTypes.role) {
+                    } else if (
+                        this.selectedContent.content_type === ContentTypes.role
+                    ) {
                         this.showingView = ViewTypes.roles;
                     }
                 }
@@ -296,7 +339,12 @@ export class ContentDetailComponent implements OnInit {
         });
     }
 
-    private toCamel(match: string, p1: string, offset: number, value: string): string {
+    private toCamel(
+        match: string,
+        p1: string,
+        offset: number,
+        value: string,
+    ): string {
         return p1.toUpperCase();
     }
 
@@ -305,21 +353,23 @@ export class ContentDetailComponent implements OnInit {
         if (page) {
             params['page'] = page;
         }
-        this.contentService.pagedQuery(params).subscribe((result: PagedResponse) => {
-            result.results.forEach(item => {
-                const ct = item['content_type'];
-                if (PluginTypes[ct]) {
-                    this.contentCounts.plugin++;
-                } else {
-                    const ctKey = ct.replace(/\_(\w)/, this.toCamel);
-                    this.contentCounts[ctKey]++;
+        this.contentService
+            .pagedQuery(params)
+            .subscribe((result: PagedResponse) => {
+                result.results.forEach(item => {
+                    const ct = item['content_type'];
+                    if (PluginTypes[ct]) {
+                        this.contentCounts.plugin++;
+                    } else {
+                        const ctKey = ct.replace(/\_(\w)/, this.toCamel);
+                        this.contentCounts[ctKey]++;
+                    }
+                });
+                if (result.next) {
+                    const matches = result.next.match(/page=(\d+)/);
+                    this.getContentTypeCounts(parseInt(matches[1], 10));
                 }
             });
-            if (result.next) {
-                const matches = result.next.match(/page=(\d+)/);
-                this.getContentTypeCounts(parseInt(matches[1], 10));
-            }
-        });
     }
 
     private getRepoVersions(page?: number) {
@@ -327,12 +377,16 @@ export class ContentDetailComponent implements OnInit {
         if (page) {
             params['page'] = page;
         }
-        this.repoService.getVersions(this.repository.id, params).subscribe(result => {
-            this.repositoryVersions = this.repositoryVersions.concat(result.results);
-            if (result.next) {
-                const matches = result.next.match(/page=(\d+)/);
-                this.getRepoVersions(parseInt(matches[1], 10));
-            }
-        });
+        this.repoService
+            .getVersions(this.repository.id, params)
+            .subscribe(result => {
+                this.repositoryVersions = this.repositoryVersions.concat(
+                    result.results,
+                );
+                if (result.next) {
+                    const matches = result.next.match(/page=(\d+)/);
+                    this.getRepoVersions(parseInt(matches[1], 10));
+                }
+            });
     }
 }

--- a/galaxyui/src/app/content-detail/content-detail.resolver.service.ts
+++ b/galaxyui/src/app/content-detail/content-detail.resolver.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@angular/core';
 
-import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+import {
+    ActivatedRouteSnapshot,
+    Resolve,
+    RouterStateSnapshot,
+} from '@angular/router';
 
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -15,7 +19,10 @@ import { RepositoryService } from '../resources/repositories/repository.service'
 @Injectable()
 export class ContentResolver implements Resolve<Content[]> {
     constructor(private contentService: ContentService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Content[]> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<Content[]> {
         const repository = route.params['repository'].toLowerCase();
         const namespace = route.params['namespace'].toLowerCase();
         const name = route.params['content_name'];
@@ -33,25 +40,35 @@ export class ContentResolver implements Resolve<Content[]> {
 @Injectable()
 export class RepositoryResolver implements Resolve<Repository> {
     constructor(private repositoryService: RepositoryService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Repository> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<Repository> {
         const repository = route.params['repository'].toLowerCase();
         const namespace = route.params['namespace'].toLowerCase();
         const params = {
             name__iexact: repository,
             provider_namespace__namespace__name__iexact: namespace,
         };
-        return this.repositoryService.query(params).pipe(map(results => results[0]));
+        return this.repositoryService
+            .query(params)
+            .pipe(map(results => results[0]));
     }
 }
 
 @Injectable()
 export class NamespaceResolver implements Resolve<Namespace> {
     constructor(private namespaceService: NamespaceService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Namespace> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<Namespace> {
         const namespace = route.params['namespace'].toLowerCase();
         const params = {
             name__iexact: namespace,
         };
-        return this.namespaceService.query(params).pipe(map(results => results[0]));
+        return this.namespaceService
+            .query(params)
+            .pipe(map(results => results[0]));
     }
 }

--- a/galaxyui/src/app/content-detail/content-detail.routing.module.ts
+++ b/galaxyui/src/app/content-detail/content-detail.routing.module.ts
@@ -2,7 +2,11 @@ import { NgModule } from '@angular/core';
 
 import { RouterModule, Routes } from '@angular/router';
 
-import { ContentResolver, NamespaceResolver, RepositoryResolver } from './content-detail.resolver.service';
+import {
+    ContentResolver,
+    NamespaceResolver,
+    RepositoryResolver,
+} from './content-detail.resolver.service';
 
 const routes: Routes = [
     // ':namespace/:repository/:content_name' and ':namespace/:repository/ moved

--- a/galaxyui/src/app/content-detail/content/module-utils/module-utils.component.ts
+++ b/galaxyui/src/app/content-detail/content/module-utils/module-utils.component.ts
@@ -119,7 +119,9 @@ export class ModuleUtilsComponent implements OnInit {
             } as Filter);
         }
 
-        this.queryContentList(this.selectedContent ? this.selectedContent.name : null);
+        this.queryContentList(
+            this.selectedContent ? this.selectedContent.name : null,
+        );
     }
 
     handlePageSizeChange($event: PaginationEvent) {
@@ -145,7 +147,11 @@ export class ModuleUtilsComponent implements OnInit {
         let query: string = null;
         if ($event.appliedFilters.length) {
             $event.appliedFilters.forEach((filter: Filter) => {
-                params.push(`or__${filter.field.id}__icontains=${filter.value.toLowerCase()}`);
+                params.push(
+                    `or__${
+                        filter.field.id
+                    }__icontains=${filter.value.toLowerCase()}`,
+                );
             });
             query = '?' + params.join('&');
         }
@@ -173,7 +179,8 @@ export class ModuleUtilsComponent implements OnInit {
                 _tmp.push(`${key}=${params[key]}`);
             }
         }
-        queryString += queryString === '?' ? _tmp.join('&') : '&' + _tmp.join('&');
+        queryString +=
+            queryString === '?' ? _tmp.join('&') : '&' + _tmp.join('&');
         this.contentService.pagedQuery(queryString).subscribe(results => {
             this._modules = results.results as Content[];
             this.filterConfig.resultsCount = results.count;

--- a/galaxyui/src/app/content-detail/content/modules/modules.component.ts
+++ b/galaxyui/src/app/content-detail/content/modules/modules.component.ts
@@ -119,7 +119,9 @@ export class ModulesComponent implements OnInit {
             } as Filter);
         }
 
-        this.queryContentList(this.selectedContent ? this.selectedContent.name : null);
+        this.queryContentList(
+            this.selectedContent ? this.selectedContent.name : null,
+        );
     }
 
     handlePageSizeChange($event: PaginationEvent) {
@@ -142,7 +144,11 @@ export class ModulesComponent implements OnInit {
         let query: string = null;
         if ($event.appliedFilters.length) {
             $event.appliedFilters.forEach((filter: Filter) => {
-                params.push(`or__${filter.field.id}__icontains=${filter.value.toLowerCase()}`);
+                params.push(
+                    `or__${
+                        filter.field.id
+                    }__icontains=${filter.value.toLowerCase()}`,
+                );
             });
             query = '?' + params.join('&');
         }
@@ -170,7 +176,8 @@ export class ModulesComponent implements OnInit {
                 _tmp.push(`${key}=${params[key]}`);
             }
         }
-        queryString += queryString === '?' ? _tmp.join('&') : '&' + _tmp.join('&');
+        queryString +=
+            queryString === '?' ? _tmp.join('&') : '&' + _tmp.join('&');
         this.contentService.pagedQuery(queryString).subscribe(results => {
             this._modules = results.results as Content[];
             this.filterConfig.resultsCount = results.count;

--- a/galaxyui/src/app/content-detail/content/plugins/plugins.component.ts
+++ b/galaxyui/src/app/content-detail/content/plugins/plugins.component.ts
@@ -142,7 +142,9 @@ export class PluginsComponent implements OnInit {
             } as Filter);
         }
 
-        this.queryContentList(this.selectedContent ? this.selectedContent.name : null);
+        this.queryContentList(
+            this.selectedContent ? this.selectedContent.name : null,
+        );
     }
 
     handlePageSizeChange($event: PaginationEvent) {
@@ -168,8 +170,15 @@ export class PluginsComponent implements OnInit {
         let query: string = null;
         if ($event.appliedFilters.length) {
             $event.appliedFilters.forEach((filter: Filter) => {
-                if (filter.field.id === 'name' || filter.field.id === 'description') {
-                    params.push(`or__${filter.field.id}__icontains=${filter.value.toLowerCase()}`);
+                if (
+                    filter.field.id === 'name' ||
+                    filter.field.id === 'description'
+                ) {
+                    params.push(
+                        `or__${
+                            filter.field.id
+                        }__icontains=${filter.value.toLowerCase()}`,
+                    );
                 } else if (filter.field.id === 'plugin_type') {
                     params.push(`content_type__name=${filter.query.id}`);
                 }
@@ -202,7 +211,8 @@ export class PluginsComponent implements OnInit {
                 _tmp.push(`${key}=${params[key]}`);
             }
         }
-        queryString += queryString === '?' ? _tmp.join('&') : '&' + _tmp.join('&');
+        queryString +=
+            queryString === '?' ? _tmp.join('&') : '&' + _tmp.join('&');
         this.contentService.pagedQuery(queryString).subscribe(results => {
             this._plugins = results.results as Content[];
             this.filterConfig.resultsCount = results.count;
@@ -228,7 +238,8 @@ export class PluginsComponent implements OnInit {
             this.items.forEach(item => {
                 if (!item.description) {
                     if (item.metadata && item.metadata['documentation']) {
-                        item.description = item.metadata['documentation']['short_description'];
+                        item.description =
+                            item.metadata['documentation']['short_description'];
                     }
                 }
             });

--- a/galaxyui/src/app/content-detail/content/roles/roles.component.ts
+++ b/galaxyui/src/app/content-detail/content/roles/roles.component.ts
@@ -110,7 +110,9 @@ export class RolesComponent implements OnInit {
             } as Filter);
         }
 
-        this.queryContentList(this.selectedContent ? this.selectedContent.name : null);
+        this.queryContentList(
+            this.selectedContent ? this.selectedContent.name : null,
+        );
     }
 
     handlePageSizeChange($event: PaginationEvent) {
@@ -136,7 +138,11 @@ export class RolesComponent implements OnInit {
         let query: string = null;
         if ($event.appliedFilters.length) {
             $event.appliedFilters.forEach((filter: Filter) => {
-                params.push(`or__${filter.field.id}__icontains=${filter.value.toLowerCase()}`);
+                params.push(
+                    `or__${
+                        filter.field.id
+                    }__icontains=${filter.value.toLowerCase()}`,
+                );
             });
             query = '?' + params.join('&');
         }
@@ -164,7 +170,8 @@ export class RolesComponent implements OnInit {
                 _tmp.push(`${key}=${params[key]}`);
             }
         }
-        queryString += queryString === '?' ? _tmp.join('&') : '&' + _tmp.join('&');
+        queryString +=
+            queryString === '?' ? _tmp.join('&') : '&' + _tmp.join('&');
         this.contentService.pagedQuery(queryString).subscribe(results => {
             this._roles = results.results as Content[];
             this.filterConfig.resultsCount = results.count;
@@ -188,20 +195,25 @@ export class RolesComponent implements OnInit {
         forkJoin(queries).subscribe((results: Content[]) => {
             this.items = JSON.parse(JSON.stringify(results));
             this.items.forEach(item => {
-                item['install_cmd'] = `mazer install ${item.summary_fields['namespace']['name']}.${
-                    item.summary_fields['repository']['name']
-                }`;
+                item['install_cmd'] = `mazer install ${
+                    item.summary_fields['namespace']['name']
+                }.${item.summary_fields['repository']['name']}`;
                 item['hasTags'] = false;
-                if (item.summary_fields['tags'] && item.summary_fields['tags'].length) {
+                if (
+                    item.summary_fields['tags'] &&
+                    item.summary_fields['tags'].length
+                ) {
                     item['tags'] = item.summary_fields['tags'];
                     item['hasTags'] = true;
                 }
-                ['dependencies', 'platforms', 'cloud_platforms'].forEach(key => {
-                    item[key] = [];
-                    if (item.summary_fields[key]) {
-                        item[key] = item.summary_fields[key];
-                    }
-                });
+                ['dependencies', 'platforms', 'cloud_platforms'].forEach(
+                    key => {
+                        item[key] = [];
+                        if (item.summary_fields[key]) {
+                            item[key] = item.summary_fields[key];
+                        }
+                    },
+                );
             });
             this.loading = false;
         });

--- a/galaxyui/src/app/content-detail/repository/repository.component.ts
+++ b/galaxyui/src/app/content-detail/repository/repository.component.ts
@@ -10,7 +10,11 @@ import { AuthService } from '../../auth/auth.service';
 import { UserPreferences } from '../../resources/preferences/user-preferences';
 import { PreferencesService } from '../../resources/preferences/preferences.service';
 
-import { RepoFormats, RepoFormatsIconClasses, RepoFormatsTooltips } from '../../enums/repo-types.enum';
+import {
+    RepoFormats,
+    RepoFormatsIconClasses,
+    RepoFormatsTooltips,
+} from '../../enums/repo-types.enum';
 
 class RepositoryView {
     repoType: RepoFormats;
@@ -45,7 +49,11 @@ export class RepositoryComponent implements OnInit {
     // Used to track which component is being loaded
     componentName = 'RepositoryComponent';
 
-    constructor(private authService: AuthService, private preferencesService: PreferencesService, private router: Router) {}
+    constructor(
+        private authService: AuthService,
+        private preferencesService: PreferencesService,
+        private router: Router,
+    ) {}
 
     @Input()
     repository: Repository;
@@ -76,7 +84,9 @@ export class RepositoryComponent implements OnInit {
         this.followerClass = 'fa fa-spin fa-spinner';
 
         if (this.isFollower) {
-            const index = this.preferences.repositories_followed.indexOf(this.repository.id);
+            const index = this.preferences.repositories_followed.indexOf(
+                this.repository.id,
+            );
             this.preferences.repositories_followed.splice(index, 1);
         } else {
             this.preferences.repositories_followed.push(this.repository.id);
@@ -91,7 +101,11 @@ export class RepositoryComponent implements OnInit {
 
     // private
     private setFollower() {
-        if (this.preferences.repositories_followed.find(x => x === this.repository.id) !== undefined) {
+        if (
+            this.preferences.repositories_followed.find(
+                x => x === this.repository.id,
+            ) !== undefined
+        ) {
             this.isFollower = true;
             this.followerClass = 'fa fa-user-times';
         } else {
@@ -104,29 +118,40 @@ export class RepositoryComponent implements OnInit {
         // Determine repoType: role, apb, multiconent
         this.repositoryView = {} as RepositoryView;
         this.repositoryView.repoType = RepoFormats[this.repository.format];
-        this.repositoryView.iconClass = RepoFormatsIconClasses[this.repository.format];
-        this.repositoryView.tooltip = RepoFormatsTooltips[this.repository.format];
+        this.repositoryView.iconClass =
+            RepoFormatsIconClasses[this.repository.format];
+        this.repositoryView.tooltip =
+            RepoFormatsTooltips[this.repository.format];
         this.repositoryView.name = this.repository.name;
 
         // description for legacy roles
-        if (!this.repository.description && this.repository.summary_fields.content_objects.length === 1) {
+        if (
+            !this.repository.description &&
+            this.repository.summary_fields.content_objects.length === 1
+        ) {
             this.repositoryView.description = this.repository.summary_fields.content_objects[0].description;
         } else {
             this.repositoryView.description = this.repository.description;
         }
 
-        this.repositoryView.namespace = this.repository.summary_fields.namespace['name'];
+        this.repositoryView.namespace = this.repository.summary_fields.namespace[
+            'name'
+        ];
 
         if (this.repository.summary_fields.namespace['is_vendor']) {
             // assuming vendor name in logo img
             this.repositoryView.displayName = '';
         } else {
-            this.repositoryView.displayName = this.repository.summary_fields.namespace['name'];
+            this.repositoryView.displayName = this.repository.summary_fields.namespace[
+                'name'
+            ];
         }
 
         if (!this.namespace.avatar_url) {
             // missing avatar_url
-            this.repositoryView.displayName = this.repository.summary_fields.namespace['name'];
+            this.repositoryView.displayName = this.repository.summary_fields.namespace[
+                'name'
+            ];
             this.repositoryView.avatarUrl = '/assets/avatar.png';
         } else {
             this.repositoryView.avatarUrl = this.namespace.avatar_url;
@@ -138,7 +163,9 @@ export class RepositoryComponent implements OnInit {
         this.repositoryView.forksCount = this.repository.forks_count;
         this.repositoryView.issueTrackerUrl = this.repository.issue_tracker_url;
         this.repositoryView.scmUrl = this.repository.external_url;
-        this.repositoryView.scmName = this.repository.summary_fields.provider['name'];
+        this.repositoryView.scmName = this.repository.summary_fields.provider[
+            'name'
+        ];
 
         switch (this.repository.summary_fields.provider['name'].toLowerCase()) {
             case 'github':

--- a/galaxyui/src/app/exception-pages/exception-pages.module.ts
+++ b/galaxyui/src/app/exception-pages/exception-pages.module.ts
@@ -11,6 +11,12 @@ import { NotFoundComponent } from './not-found/not-found.component';
 
 @NgModule({
     declarations: [AccessDeniedComponent, NotFoundComponent],
-    imports: [ActionModule, CommonModule, SharedModule, ExceptionPagesRoutingModule, EmptyStateModule],
+    imports: [
+        ActionModule,
+        CommonModule,
+        SharedModule,
+        ExceptionPagesRoutingModule,
+        EmptyStateModule,
+    ],
 })
 export class ExceptionPagesModule {}

--- a/galaxyui/src/app/home/home.component.ts
+++ b/galaxyui/src/app/home/home.component.ts
@@ -73,7 +73,9 @@ export class HomeComponent implements OnInit, AfterViewInit {
     }
 
     searchContent(): void {
-        this.router.navigate(['/search'], { queryParams: { keywords: this.searchText } });
+        this.router.navigate(['/search'], {
+            queryParams: { keywords: this.searchText },
+        });
     }
 
     // private

--- a/galaxyui/src/app/home/home.module.ts
+++ b/galaxyui/src/app/home/home.module.ts
@@ -14,7 +14,13 @@ import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
     declarations: [CarouselComponent, PopularComponent, HomeComponent],
-    imports: [CardModule, SharedModule, HomeRoutingModule, FormsModule, CommonModule],
+    imports: [
+        CardModule,
+        SharedModule,
+        HomeRoutingModule,
+        FormsModule,
+        CommonModule,
+    ],
     providers: [],
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })

--- a/galaxyui/src/app/home/home.resolver.service.ts
+++ b/galaxyui/src/app/home/home.resolver.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@angular/core';
 
-import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+import {
+    ActivatedRouteSnapshot,
+    Resolve,
+    RouterStateSnapshot,
+} from '@angular/router';
 
 import { Observable } from 'rxjs';
 
@@ -12,7 +16,10 @@ import { PagedResponse } from '../resources/paged-response';
 @Injectable()
 export class VendorListResolver implements Resolve<PagedResponse> {
     constructor(private namespaceService: NamespaceService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<PagedResponse> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<PagedResponse> {
         return this.namespaceService.pagedQuery({ is_vendor: 'true' });
     }
 }
@@ -20,7 +27,10 @@ export class VendorListResolver implements Resolve<PagedResponse> {
 @Injectable()
 export class ContentBlockResolver implements Resolve<ContentBlock[]> {
     constructor(private blockService: ContentBlocksService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<ContentBlock[]> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<ContentBlock[]> {
         return this.blockService.query();
     }
 }

--- a/galaxyui/src/app/home/home.routing.module.ts
+++ b/galaxyui/src/app/home/home.routing.module.ts
@@ -4,7 +4,10 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { HomeComponent } from './home.component';
 
-import { ContentBlockResolver, VendorListResolver } from './home.resolver.service';
+import {
+    ContentBlockResolver,
+    VendorListResolver,
+} from './home.resolver.service';
 
 const homeRoutes: Routes = [
     {

--- a/galaxyui/src/app/login/login.component.ts
+++ b/galaxyui/src/app/login/login.component.ts
@@ -43,7 +43,10 @@ export class LoginComponent implements OnInit {
     errorParam: Observable<boolean>;
     redirectUrl: string = null;
 
-    constructor(private authService: AuthService, private route: ActivatedRoute) {}
+    constructor(
+        private authService: AuthService,
+        private route: ActivatedRoute,
+    ) {}
 
     ngOnInit() {
         this.config = {
@@ -62,22 +65,27 @@ export class LoginComponent implements OnInit {
         this.errorParam = this.route.paramMap.pipe(
             switchMap((params: ParamMap) => {
                 return new Observable<boolean>(observer => {
-                    return observer.next(params.get('error') === 'true' ? true : false);
+                    return observer.next(
+                        params.get('error') === 'true' ? true : false,
+                    );
                 });
             }),
         );
 
         this.errorParam.subscribe(result => {
             if (result) {
-                this.msgText = 'To view the selected page, you must first log into Galaxy by clicking on one of the above SCMs';
+                this.msgText =
+                    'To view the selected page, you must first log into Galaxy by clicking on one of the above SCMs';
             } else {
-                this.msgText = 'Log into Galaxy by clicking on one of the above SCMs';
+                this.msgText =
+                    'Log into Galaxy by clicking on one of the above SCMs';
             }
         });
     }
 
     login(): void {
         this.connectingMsg = 'Connecting to the mother ship...';
-        window.location.href = '/accounts/github/login/?next=' + this.redirectUrl;
+        window.location.href =
+            '/accounts/github/login/?next=' + this.redirectUrl;
     }
 }

--- a/galaxyui/src/app/my-content/add-repository-modal/add-repository-modal.component.ts
+++ b/galaxyui/src/app/my-content/add-repository-modal/add-repository-modal.component.ts
@@ -105,8 +105,9 @@ export class AddRepositoryModalComponent implements OnInit {
     filterRepos(filterValue: string) {
         if (filterValue) {
             this.filterValue = filterValue;
-            this.selectedPNS.filteredSources = this.selectedPNS.repoSources.filter(repo =>
-                repo.name.toLowerCase().match(filterValue.toLowerCase()),
+            this.selectedPNS.filteredSources = this.selectedPNS.repoSources.filter(
+                repo =>
+                    repo.name.toLowerCase().match(filterValue.toLowerCase()),
             );
         } else {
             this.filterValue = '';
@@ -137,7 +138,9 @@ export class AddRepositoryModalComponent implements OnInit {
         this.repositoriesAdded = true;
         this.saveInProgress = true;
         const saveRequests: Observable<Repository>[] = [];
-        const selected: RepositorySource[] = this.selectedPNS.repoSources.filter(repoSource => repoSource.isSelected);
+        const selected: RepositorySource[] = this.selectedPNS.repoSources.filter(
+            repoSource => repoSource.isSelected,
+        );
 
         if (!selected.length) {
             // nothing was selected
@@ -151,7 +154,9 @@ export class AddRepositoryModalComponent implements OnInit {
             const newRepo = new Repository();
             newRepo.name = repoSource.name;
             newRepo.original_name = repoSource.name;
-            newRepo.description = repoSource.description ? repoSource.description : repoSource.name;
+            newRepo.description = repoSource.description
+                ? repoSource.description
+                : repoSource.name;
             newRepo.provider_namespace = this.selectedPNS.id;
             newRepo.is_enabled = true;
             saveRequests.push(this.repositoryService.save(newRepo));
@@ -178,7 +183,10 @@ export class AddRepositoryModalComponent implements OnInit {
     }
 
     private getRepoSources() {
-        if (!this.selectedPNS['repoSources'] || !this.selectedPNS.repoSources.length) {
+        if (
+            !this.selectedPNS['repoSources'] ||
+            !this.selectedPNS.repoSources.length
+        ) {
             this.setLoadingStateConfig();
             this.selectedPNS.repoSources = [];
             this.selectedPNS.filteredSources = [];
@@ -190,7 +198,9 @@ export class AddRepositoryModalComponent implements OnInit {
                 .subscribe(repoSources => {
                     repoSources.forEach(repoSource => {
                         if (!repoSource.summary_fields.repository) {
-                            this.selectedPNS.repoSources.push(repoSource as RepositorySource);
+                            this.selectedPNS.repoSources.push(
+                                repoSource as RepositorySource,
+                            );
                         }
                     });
                     this.filterRepos(this.filterValue);

--- a/galaxyui/src/app/my-content/my-content.routing.module.ts
+++ b/galaxyui/src/app/my-content/my-content.routing.module.ts
@@ -5,7 +5,10 @@ import { RouterModule, Routes } from '@angular/router';
 import { AuthService } from '../auth/auth.service';
 import { NamespaceDetailComponent } from './namespace-detail/namespace-detail.component';
 
-import { MeResolver, NamespaceDetailResolver } from './namespace-detail/namespace-detail.resolver.service';
+import {
+    MeResolver,
+    NamespaceDetailResolver,
+} from './namespace-detail/namespace-detail.resolver.service';
 
 import { NamespaceListResolver } from './namespace-list/namespace-list-resolver.service';
 import { NamespaceListComponent } from './namespace-list/namespace-list.component';

--- a/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.ts
+++ b/galaxyui/src/app/my-content/namespace-detail/namespace-detail.component.ts
@@ -96,8 +96,12 @@ export class NamespaceDetailComponent implements OnInit {
             if (data['namespace']) {
                 this.namespace = data['namespace'];
                 if (this.namespace && this.namespace['summary_fields']) {
-                    this.selectedUsers = this.namespace.summary_fields['owners'] as Owner[];
-                    this.selectedNamespaces = this.namespace.summary_fields['provider_namespaces'] as Source[];
+                    this.selectedUsers = this.namespace.summary_fields[
+                        'owners'
+                    ] as Owner[];
+                    this.selectedNamespaces = this.namespace.summary_fields[
+                        'provider_namespaces'
+                    ] as Source[];
                     this.pageTitle = 'My Content;/my-content;Edit Namespace';
                 } else {
                     // Requested namespace not found
@@ -191,7 +195,10 @@ export class NamespaceDetailComponent implements OnInit {
         namespace.selected = !namespace.selected;
 
         this.selectedNamespaces.forEach((ns: Source, idx: number) => {
-            if (ns.name === namespace.name && ns.provider === namespace.provider) {
+            if (
+                ns.name === namespace.name &&
+                ns.provider === namespace.provider
+            ) {
                 match = true;
                 matchedIdx = idx;
             }
@@ -261,7 +268,9 @@ export class NamespaceDetailComponent implements OnInit {
             avatar_url: [this.namespace.avatar_url],
             email: [this.namespace.email],
             html_url: [this.namespace.html_url],
-            namespaceType: this.namespace.is_vendor ? ['vendor'] : ['community'],
+            namespaceType: this.namespace.is_vendor
+                ? ['vendor']
+                : ['community'],
         });
         if (!this.me.staff) {
             this.namespaceForm.controls['namespaceType'].disable();
@@ -281,7 +290,9 @@ export class NamespaceDetailComponent implements OnInit {
     private getProviderSources(): void {
         this.namespacesLoading = true;
         this.providerSourceService.query().subscribe(providerSources => {
-            this.providerSources = this.prepProviderSourcesForList(providerSources);
+            this.providerSources = this.prepProviderSourcesForList(
+                providerSources,
+            );
             this.providerSourcesFiltered = this.providerSources;
             this.namespacesLoading = false;
         });
@@ -303,7 +314,9 @@ export class NamespaceDetailComponent implements OnInit {
         return clone;
     }
 
-    private prepProviderSourcesForList(providerSources: ProviderSource[]): ProviderSource[] {
+    private prepProviderSourcesForList(
+        providerSources: ProviderSource[],
+    ): ProviderSource[] {
         const clone = cloneDeep(providerSources);
         clone.forEach(item => {
             if (!item.avatar_url) {
@@ -311,7 +324,10 @@ export class NamespaceDetailComponent implements OnInit {
             }
             item.selected = false;
             this.selectedNamespaces.forEach(selected => {
-                if (selected.provider === item.provider && selected.name === item.name) {
+                if (
+                    selected.provider === item.provider &&
+                    selected.name === item.name
+                ) {
                     item.selected = true;
                 }
             });

--- a/galaxyui/src/app/my-content/namespace-detail/namespace-detail.resolver.service.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-detail/namespace-detail.resolver.service.spec.ts
@@ -9,7 +9,10 @@ describe('NamespaceDetailResolver', () => {
         });
     });
 
-    it('should be created', inject([NamespaceDetailResolver], (service: NamespaceDetailResolver) => {
-        expect(service).toBeTruthy();
-    }));
+    it('should be created', inject(
+        [NamespaceDetailResolver],
+        (service: NamespaceDetailResolver) => {
+            expect(service).toBeTruthy();
+        },
+    ));
 });

--- a/galaxyui/src/app/my-content/namespace-detail/namespace-detail.resolver.service.ts
+++ b/galaxyui/src/app/my-content/namespace-detail/namespace-detail.resolver.service.ts
@@ -2,7 +2,12 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 
-import { ActivatedRouteSnapshot, Resolve, Router, RouterStateSnapshot } from '@angular/router';
+import {
+    ActivatedRouteSnapshot,
+    Resolve,
+    Router,
+    RouterStateSnapshot,
+} from '@angular/router';
 
 import { Namespace } from '../../resources/namespaces/namespace';
 import { NamespaceService } from '../../resources/namespaces/namespace.service';
@@ -11,9 +16,15 @@ import { AuthService, IMe } from '../../auth/auth.service';
 
 @Injectable()
 export class NamespaceDetailResolver implements Resolve<Namespace> {
-    constructor(private namespaceService: NamespaceService, private router: Router) {}
+    constructor(
+        private namespaceService: NamespaceService,
+        private router: Router,
+    ) {}
 
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Namespace> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<Namespace> {
         const id = route.paramMap.get('id');
 
         if (id === null || id === 'new') {
@@ -38,7 +49,10 @@ export class NamespaceDetailResolver implements Resolve<Namespace> {
 export class MeResolver implements Resolve<IMe> {
     constructor(private authService: AuthService) {}
 
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<IMe> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<IMe> {
         return this.authService.me();
     }
 }

--- a/galaxyui/src/app/my-content/namespace-list/action/action.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/action/action.component.ts
@@ -1,4 +1,13 @@
-import { Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import {
+    Component,
+    EventEmitter,
+    Input,
+    OnInit,
+    Output,
+    TemplateRef,
+    ViewChild,
+    ViewEncapsulation,
+} from '@angular/core';
 
 import { Action } from 'patternfly-ng/action/action';
 import { ActionConfig } from 'patternfly-ng/action/action-config';
@@ -37,7 +46,9 @@ export class NamespaceActionComponent implements OnInit {
     constructor(private authService: AuthService) {}
 
     ngOnInit(): void {
-        const provider_namespaces = this.namespace['summary_fields']['provider_namespaces'];
+        const provider_namespaces = this.namespace['summary_fields'][
+            'provider_namespaces'
+        ];
 
         let primaryTooltip = 'Add yor Ansible content repositories';
         if (!this.namespace.active) {
@@ -55,7 +66,8 @@ export class NamespaceActionComponent implements OnInit {
                     styleClass: 'btn-primary',
                     tooltip: primaryTooltip,
                     template: this.buttonTemplate,
-                    disabled: !this.namespace.active || !provider_namespaces.length,
+                    disabled:
+                        !this.namespace.active || !provider_namespaces.length,
                 },
             ] as Action[],
             moreActions: [

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/action/action.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/action/action.component.ts
@@ -1,4 +1,13 @@
-import { Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import {
+    Component,
+    EventEmitter,
+    Input,
+    OnInit,
+    Output,
+    TemplateRef,
+    ViewChild,
+    ViewEncapsulation,
+} from '@angular/core';
 
 import { Action } from 'patternfly-ng/action/action';
 import { ActionConfig } from 'patternfly-ng/action/action-config';
@@ -39,7 +48,8 @@ export class NamespaceRepositoryActionComponent implements OnInit {
         let importing = false;
         if (
             this.repository['latest_import'] &&
-            (this.repository['latest_import']['state'] === 'PENDING' || this.repository['latest_import']['state'] === 'RUNNING')
+            (this.repository['latest_import']['state'] === 'PENDING' ||
+                this.repository['latest_import']['state'] === 'RUNNING')
         ) {
             importing = true;
         }

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/alternate-name-modal/alternate-name-modal.component.ts
@@ -1,6 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 
-import { AbstractControl, FormControl, ValidatorFn, Validators } from '@angular/forms';
+import {
+    AbstractControl,
+    FormControl,
+    ValidatorFn,
+    Validators,
+} from '@angular/forms';
 
 import { BsModalRef } from 'ngx-bootstrap';
 
@@ -20,7 +25,9 @@ export function forbiddenFirstCharValidator(): ValidatorFn {
     const charRE = new RegExp('^[A-Za-z0-9]');
     return (control: AbstractControl): { [key: string]: any } => {
         const forbidden = !charRE.test(control.value);
-        return forbidden ? { forbiddenFirstChar: { value: control.value } } : null;
+        return forbidden
+            ? { forbiddenFirstChar: { value: control.value } }
+            : null;
     };
 }
 
@@ -28,7 +35,9 @@ export function forbiddenLastCharValidator(): ValidatorFn {
     const charRE = new RegExp('[A-Za-z0-9]$');
     return (control: AbstractControl): { [key: string]: any } => {
         const forbidden = !charRE.test(control.value);
-        return forbidden ? { forbiddenLastChar: { value: control.value } } : null;
+        return forbidden
+            ? { forbiddenLastChar: { value: control.value } }
+            : null;
     };
 }
 
@@ -78,12 +87,16 @@ export class AlternateNameModalComponent implements OnInit {
             repo.import_branch = this.repository.import_branch;
             repo.is_enabled = this.repository.is_enabled;
             this.repositoryService.save(repo).subscribe(saveResult => {
-                this.repositoryImportService.save({ repository_id: this.repository.id }).subscribe(importResult => {
-                    console.log(`Started import for ${this.repository.name}`);
-                    this.saveInProgress = true;
-                    this.startedImport = true;
-                    this.bsModalRef.hide();
-                });
+                this.repositoryImportService
+                    .save({ repository_id: this.repository.id })
+                    .subscribe(importResult => {
+                        console.log(
+                            `Started import for ${this.repository.name}`,
+                        );
+                        this.saveInProgress = true;
+                        this.startedImport = true;
+                        this.bsModalRef.hide();
+                    });
             });
         }
     }

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.ts
@@ -1,4 +1,10 @@
-import { Component, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import {
+    Component,
+    Input,
+    OnDestroy,
+    OnInit,
+    ViewEncapsulation,
+} from '@angular/core';
 
 import { ActionConfig } from 'patternfly-ng/action/action-config';
 import { EmptyStateConfig } from 'patternfly-ng/empty-state/empty-state-config';
@@ -93,7 +99,8 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit(): void {
-        const provider_namespaces = this.namespace.summary_fields.provider_namespaces;
+        const provider_namespaces = this.namespace.summary_fields
+            .provider_namespaces;
 
         this.filterConfig = {
             fields: [
@@ -120,7 +127,8 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
             } as ActionConfig,
             iconStyleClass: 'pficon-warning-triangle-o',
             title: 'No Repositories',
-            info: 'Add repositories by clicking the "Add Content" button above.',
+            info:
+                'Add repositories by clicking the "Add Content" button above.',
             helpLink: {},
         } as EmptyStateConfig;
 
@@ -137,7 +145,9 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
 
         this.disabledStateConfig = {
             iconStyleClass: 'pficon-warning-triangle-o',
-            info: `The Namespace ${this.namespace.name} is disabled. You'll need to re-enable it before viewing and modifying its content.`,
+            info: `The Namespace ${
+                this.namespace.name
+            } is disabled. You'll need to re-enable it before viewing and modifying its content.`,
             title: 'Namespace Disabled',
         } as EmptyStateConfig;
 
@@ -253,30 +263,37 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
         if (item.summary_fields.latest_import) {
             item['latest_import'] = item.summary_fields.latest_import;
             if (item['latest_import']['finished']) {
-                item['latest_import']['as_of_dt'] = moment(item['latest_import']['finished']).fromNow();
+                item['latest_import']['as_of_dt'] = moment(
+                    item['latest_import']['finished'],
+                ).fromNow();
             } else {
-                item['latest_import']['as_of_dt'] = moment(item['latest_import']['modified']).fromNow();
+                item['latest_import']['as_of_dt'] = moment(
+                    item['latest_import']['modified'],
+                ).fromNow();
             }
         }
     }
 
     private refreshRepositories() {
         const queries: Observable<PagedResponse>[] = [];
-        this.namespace.summary_fields.provider_namespaces.forEach((pns: ProviderNamespace) => {
-            const query = {
-                provider_namespace__id: pns.id,
-                page_size: this.paginationConfig.pageSize,
-                page: this.paginationConfig.pageNumber,
-            };
+        this.namespace.summary_fields.provider_namespaces.forEach(
+            (pns: ProviderNamespace) => {
+                const query = {
+                    provider_namespace__id: pns.id,
+                    page_size: this.paginationConfig.pageSize,
+                    page: this.paginationConfig.pageNumber,
+                };
 
-            if (this.filterConfig) {
-                for (const filter of this.filterConfig.appliedFilters) {
-                    query[`or__${filter.field.id}__icontains`] = filter.value;
+                if (this.filterConfig) {
+                    for (const filter of this.filterConfig.appliedFilters) {
+                        query[`or__${filter.field.id}__icontains`] =
+                            filter.value;
+                    }
                 }
-            }
 
-            queries.push(this.repositoryService.pagedQuery(query));
-        });
+                queries.push(this.repositoryService.pagedQuery(query));
+            },
+        );
 
         forkJoin(queries).subscribe((results: PagedResponse[]) => {
             let repositories: Repository[] = [];
@@ -284,7 +301,9 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
             let resultCount = 0;
 
             for (const response of results) {
-                repositories = repositories.concat(response.results as Repository[]);
+                repositories = repositories.concat(
+                    response.results as Repository[],
+                );
                 resultCount += response.count;
             }
 
@@ -326,9 +345,11 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
         // Start an import
         repository['latest_import']['state'] = 'PENDING';
         repository['latest_import']['as_of_dt'] = '';
-        this.repositoryImportService.save({ repository_id: repository.id }).subscribe(response => {
-            console.log(`Started import for repository ${repository.id}`);
-        });
+        this.repositoryImportService
+            .save({ repository_id: repository.id })
+            .subscribe(response => {
+                console.log(`Started import for repository ${repository.id}`);
+            });
     }
 
     private deleteRepository(repository: Repository) {

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list-resolver.service.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list-resolver.service.spec.ts
@@ -9,7 +9,10 @@ describe('NamespaceListResolver', () => {
         });
     });
 
-    it('should be created', inject([NamespaceListResolver], (service: NamespaceListResolver) => {
-        expect(service).toBeTruthy();
-    }));
+    it('should be created', inject(
+        [NamespaceListResolver],
+        (service: NamespaceListResolver) => {
+            expect(service).toBeTruthy();
+        },
+    ));
 });

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list-resolver.service.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list-resolver.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@angular/core';
 
-import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+import {
+    ActivatedRouteSnapshot,
+    Resolve,
+    RouterStateSnapshot,
+} from '@angular/router';
 
 import { Observable } from 'rxjs';
 import { AuthService } from '../../auth/auth.service';
@@ -9,13 +13,21 @@ import { PagedResponse } from '../../resources/paged-response';
 
 @Injectable()
 export class NamespaceListResolver implements Resolve<PagedResponse> {
-    constructor(private namespaceService: NamespaceService, private authService: AuthService) {}
+    constructor(
+        private namespaceService: NamespaceService,
+        private authService: AuthService,
+    ) {}
 
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<PagedResponse> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<PagedResponse> {
         if (this.authService.meCache.staff) {
             // staff can view and update all namespaces
             return this.namespaceService.pagedQuery({});
         }
-        return this.namespaceService.pagedQuery({ owners__username: this.authService.meCache.username });
+        return this.namespaceService.pagedQuery({
+            owners__username: this.authService.meCache.username,
+        });
     }
 }

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.ts
@@ -82,7 +82,9 @@ export class NamespaceListComponent implements OnInit {
 
     ngOnInit(): void {
         if (!this.authService.meCache.staff) {
-            this.filterBy['owners__username'] = this.authService.meCache.username;
+            this.filterBy[
+                'owners__username'
+            ] = this.authService.meCache.username;
         }
 
         this.filterConfig = {
@@ -182,15 +184,19 @@ export class NamespaceListComponent implements OnInit {
         if ($event.appliedFilters.length) {
             $event.appliedFilters.forEach(filter => {
                 if (filter.field.type === 'typeahead') {
-                    this.filterBy['or__' + filter.field.id + '__icontains'] = filter.query.id;
+                    this.filterBy['or__' + filter.field.id + '__icontains'] =
+                        filter.query.id;
                 } else {
-                    this.filterBy['or__' + filter.field.id + '__icontains'] = filter.value;
+                    this.filterBy['or__' + filter.field.id + '__icontains'] =
+                        filter.value;
                 }
             });
         } else {
             this.filterBy = {};
             if (!this.authService.meCache.staff) {
-                this.filterBy['owners__username'] = this.authService.meCache.username;
+                this.filterBy[
+                    'owners__username'
+                ] = this.authService.meCache.username;
             }
         }
         this.pageNumber = 1;

--- a/galaxyui/src/app/my-imports/import-detail/import-detail.component.ts
+++ b/galaxyui/src/app/my-imports/import-detail/import-detail.component.ts
@@ -1,4 +1,11 @@
-import { AfterViewInit, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+    AfterViewInit,
+    Component,
+    EventEmitter,
+    Input,
+    OnInit,
+    Output,
+} from '@angular/core';
 
 import { ImportState } from '../../enums/import-state.enum';
 import { Import } from '../../resources/imports/import';
@@ -37,14 +44,17 @@ export class ImportDetailComponent implements OnInit, AfterViewInit {
                 if (me.staff) {
                     this.canImport = true;
                 } else {
-                    this.namespaceService.get(data.summary_fields.namespace.id).subscribe(namespace => {
-                        for (const owner of namespace.summary_fields.owners) {
-                            if (me.username === owner.username) {
-                                this.canImport = true;
-                                break;
+                    this.namespaceService
+                        .get(data.summary_fields.namespace.id)
+                        .subscribe(namespace => {
+                            for (const owner of namespace.summary_fields
+                                .owners) {
+                                if (me.username === owner.username) {
+                                    this.canImport = true;
+                                    break;
+                                }
                             }
-                        }
-                    });
+                        });
                 }
             });
         }
@@ -85,10 +95,18 @@ export class ImportDetailComponent implements OnInit, AfterViewInit {
     ngAfterViewInit() {}
 
     startImport(): void {
-        this.repositoryImportService.save({ repository_id: this.importTask.summary_fields.repository.id }).subscribe(response => {
-            console.log(`Started import for repository ${this.importTask.summary_fields.repository.id}`);
-            this.startedImport.emit(true);
-        });
+        this.repositoryImportService
+            .save({
+                repository_id: this.importTask.summary_fields.repository.id,
+            })
+            .subscribe(response => {
+                console.log(
+                    `Started import for repository ${
+                        this.importTask.summary_fields.repository.id
+                    }`,
+                );
+                this.startedImport.emit(true);
+            });
     }
 
     toggleScroll() {

--- a/galaxyui/src/app/my-imports/import-list/import-list.component.ts
+++ b/galaxyui/src/app/my-imports/import-list/import-list.component.ts
@@ -1,4 +1,11 @@
-import { AfterViewInit, Component, InjectionToken, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import {
+    AfterViewInit,
+    Component,
+    InjectionToken,
+    OnDestroy,
+    OnInit,
+    ViewChild,
+} from '@angular/core';
 
 import { ActivatedRoute } from '@angular/router';
 
@@ -178,7 +185,11 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
 
     selectItem(select: number, deselect?: number): void {
         this.items.forEach(item => {
-            if (deselect !== null && select !== deselect && item.id === deselect) {
+            if (
+                deselect !== null &&
+                select !== deselect &&
+                item.id === deselect
+            ) {
                 this.pfList.selectItem(item, false);
             } else if (item.id === select) {
                 this.pfList.selectItem(item, true);
@@ -207,9 +218,14 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
                 this.selectItem(this.selected.id, deselectId);
             }
             this.cancelPageLoading();
-            if (this.selected.state === ImportState.running || this.selected.state === ImportState.pending) {
+            if (
+                this.selected.state === ImportState.running ||
+                this.selected.state === ImportState.pending
+            ) {
                 // monitor the state of a running import
-                this.polling = interval(5000).subscribe(_ => this.refreshImport());
+                this.polling = interval(5000).subscribe(_ =>
+                    this.refreshImport(),
+                );
             }
         });
     }
@@ -227,11 +243,16 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
                 location += `${filter.field.id}=${filter.value.toLowerCase()}`;
                 if (filter.field.id === 'namespace' && filter.value) {
                     query += `repository__provider_namespace__namespace__name__iexact=${filter.value.toLowerCase()}`;
-                } else if (filter.field.id === 'repository_name' && filter.value) {
+                } else if (
+                    filter.field.id === 'repository_name' &&
+                    filter.value
+                ) {
                     query += `repository__name__icontains=${filter.value.toLowerCase()}`;
                 }
             });
-            this.appliedFilters = JSON.parse(JSON.stringify($event.appliedFilters));
+            this.appliedFilters = JSON.parse(
+                JSON.stringify($event.appliedFilters),
+            );
             this.filterParams = query;
             this.locationParams = location;
         } else {
@@ -260,7 +281,8 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
 
     private scrollDetails() {
         const pgElement = document.getElementById('app-container');
-        const detailHeight = document.getElementById('import-details-container').scrollHeight;
+        const detailHeight = document.getElementById('import-details-container')
+            .scrollHeight;
         const pgHeight = pgElement.scrollHeight;
         const wHeight = window.innerHeight - 110;
         if (detailHeight > wHeight) {
@@ -285,26 +307,37 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
             // TODO: a default value for import branch should be set on the backend
             data.import_branch = 'master';
             if (data.summary_fields.repository.import_branch) {
-                data.import_branch = data.summary_fields.repository.import_branch;
+                data.import_branch =
+                    data.summary_fields.repository.import_branch;
             }
         }
         if (data.state === ImportState.pending) {
             data.last_run = 'Waiting to start...';
         } else if (data.state === ImportState.running) {
             data.last_run = 'Running...';
-        } else if (data.state === ImportState.failed || data.state === ImportState.success) {
-            const state = data.state.charAt(0).toUpperCase() + data.state.slice(1).toLowerCase();
+        } else if (
+            data.state === ImportState.failed ||
+            data.state === ImportState.success
+        ) {
+            const state =
+                data.state.charAt(0).toUpperCase() +
+                data.state.slice(1).toLowerCase();
             data.last_run = state + ' ' + moment(data.finished).fromNow();
         }
     }
 
     private prepareImports(imports: ImportLatest[]): void {
         imports.forEach((item: ImportLatest) => {
-            if (this.selected && this.selected.summary_fields.repository.id === item.id) {
+            if (
+                this.selected &&
+                this.selected.summary_fields.repository.id === item.id
+            ) {
                 item['selected'] = true;
             }
             item.finished = moment(item.modified).fromNow();
-            item.state = item.state.charAt(0).toUpperCase() + item.state.slice(1).toLowerCase();
+            item.state =
+                item.state.charAt(0).toUpperCase() +
+                item.state.slice(1).toLowerCase();
         });
     }
 
@@ -332,7 +365,10 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
                 if (!field) {
                     continue;
                 }
-                const values = typeof params[key] === 'object' ? params[key] : [params[key]];
+                const values =
+                    typeof params[key] === 'object'
+                        ? params[key]
+                        : [params[key]];
                 values.forEach(value => {
                     if (filterParams !== '') {
                         filterParams += '&';
@@ -381,7 +417,10 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
         const selected = this.selectedId ? `&selected=${this.selectedId}` : '';
 
         // Refresh params on location URL
-        const location = (this.locationParams + selected + paging).replace(/^&/, ''); // remove leading &
+        const location = (this.locationParams + selected + paging).replace(
+            /^&/,
+            '',
+        ); // remove leading &
         this.location.replaceState(this.getBasePath(), location);
 
         return query;
@@ -420,9 +459,16 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
                     const import_result: Import = result[0];
                     this.prepareImport(import_result);
                     this.items.forEach((item: ImportLatest) => {
-                        if (item.repository_id === import_result.summary_fields.repository.id) {
-                            item.finished = moment(import_result.modified).fromNow();
-                            item.state = import_result.state.charAt(0).toUpperCase() + import_result.state.slice(1).toLowerCase();
+                        if (
+                            item.repository_id ===
+                            import_result.summary_fields.repository.id
+                        ) {
+                            item.finished = moment(
+                                import_result.modified,
+                            ).fromNow();
+                            item.state =
+                                import_result.state.charAt(0).toUpperCase() +
+                                import_result.state.slice(1).toLowerCase();
                         }
                     });
                     if (this.selected.id === selectedId) {
@@ -432,7 +478,10 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
                         for (const key of keys) {
                             this.selected[key] = import_result[key];
                         }
-                        if (this.selected.state === ImportState.failed || this.selected.state === ImportState.success) {
+                        if (
+                            this.selected.state === ImportState.failed ||
+                            this.selected.state === ImportState.success
+                        ) {
                             // The import finished
                             if (this.polling) {
                                 this.polling.unsubscribe();

--- a/galaxyui/src/app/my-imports/import-list/import-list.resolver.service.ts
+++ b/galaxyui/src/app/my-imports/import-list/import-list.resolver.service.ts
@@ -9,13 +9,19 @@ import { PagedResponse } from '../../resources/paged-response';
 
 @Injectable()
 export class ImportListResolver implements Resolve<PagedResponse> {
-    constructor(private importsService: ImportsService, private authService: AuthService) {}
+    constructor(
+        private importsService: ImportsService,
+        private authService: AuthService,
+    ) {}
 
     resolve(route: ActivatedRouteSnapshot): Observable<PagedResponse> {
         let params = '';
         for (const key in route.queryParams) {
             if (route.queryParams.hasOwnProperty(key)) {
-                const values = typeof route.queryParams[key] === 'object' ? route.queryParams[key] : [route.queryParams[key]];
+                const values =
+                    typeof route.queryParams[key] === 'object'
+                        ? route.queryParams[key]
+                        : [route.queryParams[key]];
                 values.forEach(value => {
                     if (params !== '') {
                         params += '&';

--- a/galaxyui/src/app/preferences/preferences.component.ts
+++ b/galaxyui/src/app/preferences/preferences.component.ts
@@ -47,7 +47,9 @@ export class PreferencesComponent implements OnInit {
     ngOnInit() {
         this.authService.me().subscribe(me => {
             if (!me.authenticated) {
-                this.router.navigate(['/', 'login'], { queryParams: { next: '/preferences' } });
+                this.router.navigate(['/', 'login'], {
+                    queryParams: { next: '/preferences' },
+                });
             } else {
                 this.userId = me.id;
                 this.getEmails();
@@ -74,11 +76,13 @@ export class PreferencesComponent implements OnInit {
             this.notificationSettings = [
                 {
                     key: 'notify_survey',
-                    description: 'someone submits a new survey for one of your roles',
+                    description:
+                        'someone submits a new survey for one of your roles',
                 },
                 {
                     key: 'notify_content_release',
-                    description: 'there is a new release of a collection you follow',
+                    description:
+                        'there is a new release of a collection you follow',
                 },
                 {
                     key: 'notify_author_release',
@@ -113,7 +117,9 @@ export class PreferencesComponent implements OnInit {
 
     private checkVerification(params: Params) {
         this.emailService.verifyEmail(params.verify).subscribe(result => {
-            const updateEmail = this.emails.find(obj => obj.id === result.email_address);
+            const updateEmail = this.emails.find(
+                obj => obj.id === result.email_address,
+            );
             updateEmail.verified = result.verified;
 
             if (result.verified) {
@@ -157,7 +163,9 @@ export class PreferencesComponent implements OnInit {
         });
 
         if (currentPrimary !== -1) {
-            const currentCopy = JSON.parse(JSON.stringify(this.emails[currentPrimary]));
+            const currentCopy = JSON.parse(
+                JSON.stringify(this.emails[currentPrimary]),
+            );
             currentCopy.primary = false;
             this.emailService.save(currentCopy).subscribe(result => {
                 if (result) {
@@ -183,12 +191,20 @@ export class PreferencesComponent implements OnInit {
     }
 
     showApiKey() {
-        this.userService.getToken(this.userId).subscribe(token => (this.apiKey = token));
+        this.userService
+            .getToken(this.userId)
+            .subscribe(token => (this.apiKey = token));
     }
 
     resetApiKey() {
-        if (confirm('Resetting your key will remove access to all applications that might rely on it. Do you wish to continue?')) {
-            this.userService.resetToken(this.userId).subscribe(token => (this.apiKey = token));
+        if (
+            confirm(
+                'Resetting your key will remove access to all applications that might rely on it. Do you wish to continue?',
+            )
+        ) {
+            this.userService
+                .resetToken(this.userId)
+                .subscribe(token => (this.apiKey = token));
         }
     }
 
@@ -208,7 +224,9 @@ export class PreferencesComponent implements OnInit {
 
         this.emailService.save(email).subscribe(response => {
             if (response) {
-                const i = this.emails.findIndex(val => val.email === email.email);
+                const i = this.emails.findIndex(
+                    val => val.email === email.email,
+                );
                 this.emails[i] = response;
                 this.verifyEmail(response);
             }

--- a/galaxyui/src/app/preferences/preferences.module.ts
+++ b/galaxyui/src/app/preferences/preferences.module.ts
@@ -16,7 +16,16 @@ import { ListModule } from 'patternfly-ng/list/basic-list/list.module';
 import { FormsModule } from '@angular/forms';
 
 @NgModule({
-    imports: [CommonModule, PreferencesRoutingModule, SharedModule, CardModule, ListModule, InlineCopyModule, FormsModule, ActionModule],
+    imports: [
+        CommonModule,
+        PreferencesRoutingModule,
+        SharedModule,
+        CardModule,
+        ListModule,
+        InlineCopyModule,
+        FormsModule,
+        ActionModule,
+    ],
     declarations: [PreferencesComponent, EmailActionComponent],
 })
 export class PreferencesModule {}

--- a/galaxyui/src/app/resources/api-root/api-root.service.spec.ts
+++ b/galaxyui/src/app/resources/api-root/api-root.service.spec.ts
@@ -9,7 +9,10 @@ describe('ContentSearchService', () => {
         });
     });
 
-    it('should be created', inject([ApiRootService], (service: ApiRootService) => {
-        expect(service).toBeTruthy();
-    }));
+    it('should be created', inject(
+        [ApiRootService],
+        (service: ApiRootService) => {
+            expect(service).toBeTruthy();
+        },
+    ));
 });

--- a/galaxyui/src/app/resources/api-root/api-root.service.ts
+++ b/galaxyui/src/app/resources/api-root/api-root.service.ts
@@ -9,7 +9,10 @@ import { ApiRoot } from './api-root';
 export class ApiRootService {
     private url = '/api/';
 
-    constructor(private http: HttpClient, private notificationService: NotificationService) {}
+    constructor(
+        private http: HttpClient,
+        private notificationService: NotificationService,
+    ) {}
 
     get(): Observable<ApiRoot> {
         return this.http.get<ApiRoot>(this.url).pipe(
@@ -22,7 +25,9 @@ export class ApiRootService {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} user error: ${error.message}`);
-            this.notificationService.httpError(`${operation} user failed:`, { data: error });
+            this.notificationService.httpError(`${operation} user failed:`, {
+                data: error,
+            });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/base/generic-query-save.ts
+++ b/galaxyui/src/app/resources/base/generic-query-save.ts
@@ -9,21 +9,38 @@ import { BaseType } from './base-type';
 
 import { GenericQuery } from './generic-query';
 
-export class GenericQuerySave<ServiceType extends BaseType> extends GenericQuery<ServiceType> {
-    constructor(http: HttpClient, notificationService: NotificationService, url, serviceName) {
+export class GenericQuerySave<
+    ServiceType extends BaseType
+> extends GenericQuery<ServiceType> {
+    constructor(
+        http: HttpClient,
+        notificationService: NotificationService,
+        url,
+        serviceName,
+    ) {
         super(http, notificationService, url, serviceName);
     }
 
     save(object: ServiceType): Observable<ServiceType> {
         let httpResult: Observable<Object>;
         if (object.id) {
-            httpResult = this.http.put<ServiceType>(`${this.url}/${object.id}/`, object, this.httpOptions);
+            httpResult = this.http.put<ServiceType>(
+                `${this.url}/${object.id}/`,
+                object,
+                this.httpOptions,
+            );
         } else {
-            httpResult = this.http.post<ServiceType>(`${this.url}/`, object, this.httpOptions);
+            httpResult = this.http.post<ServiceType>(
+                `${this.url}/`,
+                object,
+                this.httpOptions,
+            );
         }
 
         return httpResult.pipe(
-            tap((newObject: ServiceType) => this.log(`Saved ${this.serviceName} w/ id=${newObject.id}`)),
+            tap((newObject: ServiceType) =>
+                this.log(`Saved ${this.serviceName} w/ id=${newObject.id}`),
+            ),
             catchError(this.handleError<ServiceType>('Save')),
         );
     }

--- a/galaxyui/src/app/resources/base/generic-query.ts
+++ b/galaxyui/src/app/resources/base/generic-query.ts
@@ -11,7 +11,12 @@ import { ServiceBase } from './service-base';
 export class GenericQuery<ServiceType> extends ServiceBase {
     protected ObjectType: any;
 
-    constructor(http: HttpClient, notificationService: NotificationService, url, serviceName) {
+    constructor(
+        http: HttpClient,
+        notificationService: NotificationService,
+        url,
+        serviceName,
+    ) {
         super(http, notificationService, url, serviceName);
     }
 
@@ -25,11 +30,13 @@ export class GenericQuery<ServiceType> extends ServiceBase {
                 objectParams = params;
             }
         }
-        return this.http.get<PagedResponse>(objectUrl + '/', { params: objectParams }).pipe(
-            map(response => response.results),
-            tap(_ => this.log(`fetched ${this.serviceName}`)),
-            catchError(this.handleError('Query', [] as ServiceType[])),
-        );
+        return this.http
+            .get<PagedResponse>(objectUrl + '/', { params: objectParams })
+            .pipe(
+                map(response => response.results),
+                tap(_ => this.log(`fetched ${this.serviceName}`)),
+                catchError(this.handleError('Query', [] as ServiceType[])),
+            );
     }
 
     get(id: number): Observable<ServiceType> {

--- a/galaxyui/src/app/resources/base/service-base.ts
+++ b/galaxyui/src/app/resources/base/service-base.ts
@@ -8,7 +8,12 @@ import { NotificationType } from 'patternfly-ng/notification/notification-type';
 export class ServiceBase {
     protected ObjectType: any;
 
-    constructor(protected http: HttpClient, protected notificationService: NotificationService, protected url, protected serviceName) {}
+    constructor(
+        protected http: HttpClient,
+        protected notificationService: NotificationService,
+        protected url,
+        protected serviceName,
+    ) {}
 
     httpOptions = {
         headers: new HttpHeaders({
@@ -19,13 +24,18 @@ export class ServiceBase {
     handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
-            this.log(`${operation} ${this.serviceName} error: ${error.message}`);
+            this.log(
+                `${operation} ${this.serviceName} error: ${error.message}`,
+            );
             const apiResponse = error.error;
 
             // If we are saving data, we expect the error message to have the following shape
             // {field_name: ['Message 1', 'Message 2']}
             // because this is the error format that Django Rest serializer return
-            if (typeof apiResponse === 'object' && Object.keys(apiResponse).length > 0) {
+            if (
+                typeof apiResponse === 'object' &&
+                Object.keys(apiResponse).length > 0
+            ) {
                 for (const field of Object.keys(apiResponse)) {
                     let errorMessage = '';
                     if (typeof apiResponse[field] === 'string') {
@@ -33,12 +43,25 @@ export class ServiceBase {
                     } else {
                         errorMessage = apiResponse[field].join(' ');
                     }
-                    this.notificationService.message(NotificationType.DANGER, field, errorMessage, false, null, null);
+                    this.notificationService.message(
+                        NotificationType.DANGER,
+                        field,
+                        errorMessage,
+                        false,
+                        null,
+                        null,
+                    );
                 }
             } else if (typeof apiResponse === 'string') {
-                this.notificationService.httpError(`${operation} ${this.serviceName} failed: ${apiResponse}`, { data: error });
+                this.notificationService.httpError(
+                    `${operation} ${this.serviceName} failed: ${apiResponse}`,
+                    { data: error },
+                );
             } else {
-                this.notificationService.httpError(`${operation} ${this.serviceName} failed:`, { data: error });
+                this.notificationService.httpError(
+                    `${operation} ${this.serviceName} failed:`,
+                    { data: error },
+                );
             }
 
             // Let the app keep running by returning an empty result.

--- a/galaxyui/src/app/resources/cloud-platforms/cloud-platform.service.spec.ts
+++ b/galaxyui/src/app/resources/cloud-platforms/cloud-platform.service.spec.ts
@@ -9,7 +9,10 @@ describe('CloudPlatformService', () => {
         });
     });
 
-    it('should be created', inject([CloudPlatformService], (service: CloudPlatformService) => {
-        expect(service).toBeTruthy();
-    }));
+    it('should be created', inject(
+        [CloudPlatformService],
+        (service: CloudPlatformService) => {
+            expect(service).toBeTruthy();
+        },
+    ));
 });

--- a/galaxyui/src/app/resources/cloud-platforms/cloud-platform.service.ts
+++ b/galaxyui/src/app/resources/cloud-platforms/cloud-platform.service.ts
@@ -14,29 +14,39 @@ export class CloudPlatformService {
     private url = '/api/v1/cloud_platforms';
     private searchUrl = '/api/v1/search/cloud_platforms';
 
-    constructor(private http: HttpClient, private notificationService: NotificationService) {}
+    constructor(
+        private http: HttpClient,
+        private notificationService: NotificationService,
+    ) {}
 
     query(params?: any): Observable<CloudPlatform[]> {
-        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
-            map(response => response.results),
-            tap(_ => this.log('fetched content types')),
-            catchError(this.handleError('Query', [] as CloudPlatform[])),
-        );
+        return this.http
+            .get<PagedResponse>(this.url + '/', { params: params })
+            .pipe(
+                map(response => response.results),
+                tap(_ => this.log('fetched content types')),
+                catchError(this.handleError('Query', [] as CloudPlatform[])),
+            );
     }
 
     search(params?: any): Observable<CloudPlatform[]> {
-        return this.http.get<PagedResponse>(this.searchUrl + '/', { params: params }).pipe(
-            map(response => response.results),
-            tap(_ => this.log('fetched content types')),
-            catchError(this.handleError('Query', [] as CloudPlatform[])),
-        );
+        return this.http
+            .get<PagedResponse>(this.searchUrl + '/', { params: params })
+            .pipe(
+                map(response => response.results),
+                tap(_ => this.log('fetched content types')),
+                catchError(this.handleError('Query', [] as CloudPlatform[])),
+            );
     }
 
     private handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} repository error: ${error.message}`);
-            this.notificationService.httpError(`${operation} repository failed:`, { data: error });
+            this.notificationService.httpError(
+                `${operation} repository failed:`,
+                { data: error },
+            );
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/content-blocks/content-blocks.service.ts
+++ b/galaxyui/src/app/resources/content-blocks/content-blocks.service.ts
@@ -10,7 +10,10 @@ import { ContentBlock } from './content-block';
 export class ContentBlocksService {
     private url = '/api/v1/content_blocks/';
 
-    constructor(private http: HttpClient, private notificationService: NotificationService) {}
+    constructor(
+        private http: HttpClient,
+        private notificationService: NotificationService,
+    ) {}
 
     query(): Observable<ContentBlock[]> {
         return this.http.get<PagedResponse>(this.url).pipe(
@@ -24,7 +27,9 @@ export class ContentBlocksService {
         const url = `${this.url}${name}/`;
         return this.http.get<ContentBlock>(url).pipe(
             tap(_ => this.log('fetched content block')),
-            catchError(this.handleError<ContentBlock>(`Get content block ${name}`)),
+            catchError(
+                this.handleError<ContentBlock>(`Get content block ${name}`),
+            ),
         );
     }
 
@@ -32,7 +37,9 @@ export class ContentBlocksService {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} user error: ${error.message}`);
-            this.notificationService.httpError(`${operation} user failed:`, { data: error });
+            this.notificationService.httpError(`${operation} user failed:`, {
+                data: error,
+            });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/content-search/content-search.service.spec.ts
+++ b/galaxyui/src/app/resources/content-search/content-search.service.spec.ts
@@ -9,7 +9,10 @@ describe('ContentSearchService', () => {
         });
     });
 
-    it('should be created', inject([ContentSearchService], (service: ContentSearchService) => {
-        expect(service).toBeTruthy();
-    }));
+    it('should be created', inject(
+        [ContentSearchService],
+        (service: ContentSearchService) => {
+            expect(service).toBeTruthy();
+        },
+    ));
 });

--- a/galaxyui/src/app/resources/content-search/content-search.service.ts
+++ b/galaxyui/src/app/resources/content-search/content-search.service.ts
@@ -12,27 +12,33 @@ import { EventLoggerService } from '../logger/event-logger.service';
 
 @Injectable()
 export class ContentSearchService {
-    constructor(private http: HttpClient, private notificationService: NotificationService, private eventLogger: EventLoggerService) {}
+    constructor(
+        private http: HttpClient,
+        private notificationService: NotificationService,
+        private eventLogger: EventLoggerService,
+    ) {}
 
     private url = '/api/v1/search/content/';
 
     query(params?: any): Observable<ContentResponse> {
-        return this.http.get<ContentResponse>(this.url, { params: params }).pipe(
-            tap(result => {
-                this.log('fetched content');
-                if (
-                    params['keywords'] ||
-                    params['cloudPlatforms'] ||
-                    params['tags'] ||
-                    params['namespace'] ||
-                    params['platforms'] ||
-                    params['content_type']
-                ) {
-                    this.eventLogger.logSearchQuery(params, result.count);
-                }
-            }),
-            catchError(this.handleError('Query', {} as ContentResponse)),
-        );
+        return this.http
+            .get<ContentResponse>(this.url, { params: params })
+            .pipe(
+                tap(result => {
+                    this.log('fetched content');
+                    if (
+                        params['keywords'] ||
+                        params['cloudPlatforms'] ||
+                        params['tags'] ||
+                        params['namespace'] ||
+                        params['platforms'] ||
+                        params['content_type']
+                    ) {
+                        this.eventLogger.logSearchQuery(params, result.count);
+                    }
+                }),
+                catchError(this.handleError('Query', {} as ContentResponse)),
+            );
     }
 
     get(id: number): Observable<any> {
@@ -46,7 +52,9 @@ export class ContentSearchService {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} provider source error: ${error.message}`);
-            this.notificationService.httpError(`${operation} user failed:`, { data: error });
+            this.notificationService.httpError(`${operation} user failed:`, {
+                data: error,
+            });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/content-types/content-type.service.spec.ts
+++ b/galaxyui/src/app/resources/content-types/content-type.service.spec.ts
@@ -9,7 +9,10 @@ describe('PlatformService', () => {
         });
     });
 
-    it('should be created', inject([PlatformService], (service: PlatformService) => {
-        expect(service).toBeTruthy();
-    }));
+    it('should be created', inject(
+        [PlatformService],
+        (service: PlatformService) => {
+            expect(service).toBeTruthy();
+        },
+    ));
 });

--- a/galaxyui/src/app/resources/content-types/content-type.service.ts
+++ b/galaxyui/src/app/resources/content-types/content-type.service.ts
@@ -13,21 +13,29 @@ import { ContentType } from './content-type';
 export class ContentTypeService {
     private url = '/api/v1/content_types';
 
-    constructor(private http: HttpClient, private notificationService: NotificationService) {}
+    constructor(
+        private http: HttpClient,
+        private notificationService: NotificationService,
+    ) {}
 
     query(params?: any): Observable<ContentType[]> {
-        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
-            map(response => response.results),
-            tap(_ => this.log('fetched content types')),
-            catchError(this.handleError('Query', [] as ContentType[])),
-        );
+        return this.http
+            .get<PagedResponse>(this.url + '/', { params: params })
+            .pipe(
+                map(response => response.results),
+                tap(_ => this.log('fetched content types')),
+                catchError(this.handleError('Query', [] as ContentType[])),
+            );
     }
 
     private handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} repository error: ${error.message}`);
-            this.notificationService.httpError(`${operation} repository failed:`, { data: error });
+            this.notificationService.httpError(
+                `${operation} repository failed:`,
+                { data: error },
+            );
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/content/content.service.spec.ts
+++ b/galaxyui/src/app/resources/content/content.service.spec.ts
@@ -9,7 +9,10 @@ describe('ContentSearchService', () => {
         });
     });
 
-    it('should be created', inject([ContentService], (service: ContentService) => {
-        expect(service).toBeTruthy();
-    }));
+    it('should be created', inject(
+        [ContentService],
+        (service: ContentService) => {
+            expect(service).toBeTruthy();
+        },
+    ));
 });

--- a/galaxyui/src/app/resources/content/content.service.ts
+++ b/galaxyui/src/app/resources/content/content.service.ts
@@ -12,7 +12,10 @@ import { Content } from './content';
 
 @Injectable()
 export class ContentService {
-    constructor(private http: HttpClient, private notificationService: NotificationService) {}
+    constructor(
+        private http: HttpClient,
+        private notificationService: NotificationService,
+    ) {}
 
     private url = '/api/v1/content/';
 
@@ -26,10 +29,12 @@ export class ContentService {
 
     pagedQuery(params?: any): Observable<PagedResponse> {
         if (params && typeof params === 'object') {
-            return this.http.get<PagedResponse>(this.url, { params: params }).pipe(
-                tap(_ => this.log('fetched paged content')),
-                catchError(this.handleError('Query', {} as PagedResponse)),
-            );
+            return this.http
+                .get<PagedResponse>(this.url, { params: params })
+                .pipe(
+                    tap(_ => this.log('fetched paged content')),
+                    catchError(this.handleError('Query', {} as PagedResponse)),
+                );
         }
         if (params && typeof params === 'string') {
             return this.http.get<PagedResponse>(this.url + params).pipe(
@@ -54,7 +59,9 @@ export class ContentService {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} provider source error: ${error.message}`);
-            this.notificationService.httpError(`${operation} user failed:`, { data: error });
+            this.notificationService.httpError(`${operation} user failed:`, {
+                data: error,
+            });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/emails/email.service.ts
+++ b/galaxyui/src/app/resources/emails/email.service.ts
@@ -19,7 +19,11 @@ export class EmailService extends GenericQuerySave<Email> {
         const url = `${this.url}/verification/`;
         let httpResult: Observable<Email>;
 
-        httpResult = this.http.post<any>(url, { email_address: email.id }, this.httpOptions);
+        httpResult = this.http.post<any>(
+            url,
+            { email_address: email.id },
+            this.httpOptions,
+        );
 
         return httpResult.pipe(catchError(this.handleError<any>('Verify')));
     }
@@ -33,6 +37,8 @@ export class EmailService extends GenericQuerySave<Email> {
     }
 
     deleteEmail(email: Email): Observable<any> {
-        return this.http.delete<any>(`${this.url}/${email.id}/`).pipe(catchError(this.handleError('Delete')));
+        return this.http
+            .delete<any>(`${this.url}/${email.id}/`)
+            .pipe(catchError(this.handleError('Delete')));
     }
 }

--- a/galaxyui/src/app/resources/imports/imports.service.spec.ts
+++ b/galaxyui/src/app/resources/imports/imports.service.spec.ts
@@ -9,7 +9,10 @@ describe('ImportsService', () => {
         });
     });
 
-    it('should be created', inject([ImportsService], (service: ImportsService) => {
-        expect(service).toBeTruthy();
-    }));
+    it('should be created', inject(
+        [ImportsService],
+        (service: ImportsService) => {
+            expect(service).toBeTruthy();
+        },
+    ));
 });

--- a/galaxyui/src/app/resources/imports/imports.service.ts
+++ b/galaxyui/src/app/resources/imports/imports.service.ts
@@ -39,7 +39,10 @@ const httpOptions = {
 
 @Injectable()
 export class ImportsService {
-    constructor(private http: HttpClient, private notificationService: NotificationService) {}
+    constructor(
+        private http: HttpClient,
+        private notificationService: NotificationService,
+    ) {}
 
     private url = '/api/v1/imports';
 
@@ -55,11 +58,13 @@ export class ImportsService {
     }
 
     query(params?: any): Observable<Import[]> {
-        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
-            map(response => response.results),
-            tap(_ => this.log('fetched imports')),
-            catchError(this.handleError('Query', [] as Import[])),
-        );
+        return this.http
+            .get<PagedResponse>(this.url + '/', { params: params })
+            .pipe(
+                map(response => response.results),
+                tap(_ => this.log('fetched imports')),
+                catchError(this.handleError('Query', [] as Import[])),
+            );
     }
 
     get(id: number): Observable<Import> {
@@ -73,7 +78,9 @@ export class ImportsService {
         let httpResult: Observable<Object>;
         httpResult = this.http.post<Import>(this.url, params, httpOptions);
         return httpResult.pipe(
-            tap((newImport: Import) => this.log(`Saved import w/ id=${newImport.id}`)),
+            tap((newImport: Import) =>
+                this.log(`Saved import w/ id=${newImport.id}`),
+            ),
             catchError(this.handleError<Import>('Save')),
         );
     }
@@ -82,7 +89,9 @@ export class ImportsService {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} provider source error: ${error.message}`);
-            this.notificationService.httpError(`${operation} user failed:`, { data: error });
+            this.notificationService.httpError(`${operation} user failed:`, {
+                data: error,
+            });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/logger/event-logger.service.ts
+++ b/galaxyui/src/app/resources/logger/event-logger.service.ts
@@ -10,14 +10,26 @@ import { InfluxSession } from './influx-session';
 
 @Injectable()
 export class EventLoggerService {
-    constructor(private http: HttpClient, private router: Router, private activatedRoute: ActivatedRoute) {
-        const session = document.cookie.match(new RegExp('(^| )influx_session=([^;]+)'));
+    constructor(
+        private http: HttpClient,
+        private router: Router,
+        private activatedRoute: ActivatedRoute,
+    ) {
+        const session = document.cookie.match(
+            new RegExp('(^| )influx_session=([^;]+)'),
+        );
         if (session) {
             this.sessionId = session[2];
         } else {
             let httpResult: Observable<InfluxSession>;
-            httpResult = this.http.post<InfluxSession>('/api/internal/events/influx_session/', {}, this.httpOptions);
-            httpResult.subscribe(response => (this.sessionId = response.session_id));
+            httpResult = this.http.post<InfluxSession>(
+                '/api/internal/events/influx_session/',
+                {},
+                this.httpOptions,
+            );
+            httpResult.subscribe(
+                response => (this.sessionId = response.session_id),
+            );
         }
     }
     httpOptions = {
@@ -108,7 +120,11 @@ export class EventLoggerService {
 
     private postData(data: any) {
         let httpResult: Observable<Event>;
-        httpResult = this.http.post<Event>('/api/internal/events/', data, this.httpOptions);
+        httpResult = this.http.post<Event>(
+            '/api/internal/events/',
+            data,
+            this.httpOptions,
+        );
         httpResult.subscribe();
     }
 

--- a/galaxyui/src/app/resources/namespaces/namespace.service.spec.ts
+++ b/galaxyui/src/app/resources/namespaces/namespace.service.spec.ts
@@ -9,7 +9,10 @@ describe('NamespaceService', () => {
         });
     });
 
-    it('should be created', inject([NamespaceService], (service: NamespaceService) => {
-        expect(service).toBeTruthy();
-    }));
+    it('should be created', inject(
+        [NamespaceService],
+        (service: NamespaceService) => {
+            expect(service).toBeTruthy();
+        },
+    ));
 });

--- a/galaxyui/src/app/resources/namespaces/namespace.service.ts
+++ b/galaxyui/src/app/resources/namespaces/namespace.service.ts
@@ -19,24 +19,31 @@ const httpOptions = {
 export class NamespaceService {
     private url = '/api/v1/namespaces';
 
-    constructor(private http: HttpClient, private notificationService: NotificationService) {}
+    constructor(
+        private http: HttpClient,
+        private notificationService: NotificationService,
+    ) {}
 
     encounteredErrors = false;
 
     query(params?: any): Observable<Namespace[]> {
-        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
-            map(response => response.results),
-            tap(_ => this.log('fetched namespaces')),
-            catchError(this.handleError('Query', [])),
-        );
+        return this.http
+            .get<PagedResponse>(this.url + '/', { params: params })
+            .pipe(
+                map(response => response.results),
+                tap(_ => this.log('fetched namespaces')),
+                catchError(this.handleError('Query', [])),
+            );
     }
 
     pagedQuery(params: any): Observable<PagedResponse> {
         if (params && typeof params === 'object') {
-            return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
-                tap(_ => this.log('fetched paged content')),
-                catchError(this.handleError('Query', {} as PagedResponse)),
-            );
+            return this.http
+                .get<PagedResponse>(this.url + '/', { params: params })
+                .pipe(
+                    tap(_ => this.log('fetched paged content')),
+                    catchError(this.handleError('Query', {} as PagedResponse)),
+                );
         }
         if (params && typeof params === 'string') {
             return this.http.get<PagedResponse>(this.url + '/' + params).pipe(
@@ -61,12 +68,22 @@ export class NamespaceService {
     save(namespace: Namespace): Observable<Namespace> {
         let httpResult: Observable<Object>;
         if (namespace.id) {
-            httpResult = this.http.put<Namespace>(`${this.url}/${namespace.id}/`, namespace, httpOptions);
+            httpResult = this.http.put<Namespace>(
+                `${this.url}/${namespace.id}/`,
+                namespace,
+                httpOptions,
+            );
         } else {
-            httpResult = this.http.post<Namespace>(`${this.url}/`, namespace, httpOptions);
+            httpResult = this.http.post<Namespace>(
+                `${this.url}/`,
+                namespace,
+                httpOptions,
+            );
         }
         return httpResult.pipe(
-            tap((newNamespace: Namespace) => this.log(`Saved namespace w/ id=${newNamespace.id}`)),
+            tap((newNamespace: Namespace) =>
+                this.log(`Saved namespace w/ id=${newNamespace.id}`),
+            ),
             catchError(this.handleError<Namespace>('Save', namespace)),
         );
     }
@@ -86,19 +103,33 @@ export class NamespaceService {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} namespace error: ${error.message}`);
-            if (typeof error === 'object' && 'error' in error && typeof error['error'] === 'object' && result !== undefined) {
+            if (
+                typeof error === 'object' &&
+                'error' in error &&
+                typeof error['error'] === 'object' &&
+                result !== undefined
+            ) {
                 // Unpack error messages, sending each to the notification service
                 for (const fld in error['error']) {
                     if (error['error'].hasOwnProperty(fld)) {
                         if (typeof error['error'][fld] !== 'object') {
                             const msg = result[fld];
-                            this.notificationService.httpError(error['error'][fld], { data: { message: msg } });
+                            this.notificationService.httpError(
+                                error['error'][fld],
+                                { data: { message: msg } },
+                            );
                         } else {
                             for (const idx in error['error'][fld]) {
                                 if (result[fld]) {
-                                    if (Array.isArray(result[fld]) && idx < result[fld].length) {
+                                    if (
+                                        Array.isArray(result[fld]) &&
+                                        idx < result[fld].length
+                                    ) {
                                         const msg = result[fld][idx]['name'];
-                                        this.notificationService.httpError(error['error'][fld][idx], { data: { message: msg } });
+                                        this.notificationService.httpError(
+                                            error['error'][fld][idx],
+                                            { data: { message: msg } },
+                                        );
                                     }
                                 }
                             }
@@ -107,7 +138,10 @@ export class NamespaceService {
                 }
             } else {
                 // Nothing to unpack. Raise the raw error to the notification service.
-                this.notificationService.httpError(`${operation} namespace failed:`, { data: error });
+                this.notificationService.httpError(
+                    `${operation} namespace failed:`,
+                    { data: error },
+                );
             }
             // Let the app keep running by returning an empty result.
             this.encounteredErrors = true;

--- a/galaxyui/src/app/resources/platforms/platform.service.spec.ts
+++ b/galaxyui/src/app/resources/platforms/platform.service.spec.ts
@@ -9,7 +9,10 @@ describe('PlatformService', () => {
         });
     });
 
-    it('should be created', inject([PlatformService], (service: PlatformService) => {
-        expect(service).toBeTruthy();
-    }));
+    it('should be created', inject(
+        [PlatformService],
+        (service: PlatformService) => {
+            expect(service).toBeTruthy();
+        },
+    ));
 });

--- a/galaxyui/src/app/resources/platforms/platform.service.ts
+++ b/galaxyui/src/app/resources/platforms/platform.service.ts
@@ -13,29 +13,39 @@ export class PlatformService {
     private url = '/api/v1/platforms';
     private searchUrl = '/api/v1/search/platforms';
 
-    constructor(private http: HttpClient, private notificationService: NotificationService) {}
+    constructor(
+        private http: HttpClient,
+        private notificationService: NotificationService,
+    ) {}
 
     query(params?: any): Observable<Platform[]> {
-        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
-            map(response => response.results),
-            tap(_ => this.log('fetched repositories')),
-            catchError(this.handleError('Query', [] as Platform[])),
-        );
+        return this.http
+            .get<PagedResponse>(this.url + '/', { params: params })
+            .pipe(
+                map(response => response.results),
+                tap(_ => this.log('fetched repositories')),
+                catchError(this.handleError('Query', [] as Platform[])),
+            );
     }
 
     search(params?: any): Observable<Platform[]> {
-        return this.http.get<PagedResponse>(this.searchUrl + '/', { params: params }).pipe(
-            map(response => response.results),
-            tap(_ => this.log('fetched repositories')),
-            catchError(this.handleError('Query', [] as Platform[])),
-        );
+        return this.http
+            .get<PagedResponse>(this.searchUrl + '/', { params: params })
+            .pipe(
+                map(response => response.results),
+                tap(_ => this.log('fetched repositories')),
+                catchError(this.handleError('Query', [] as Platform[])),
+            );
     }
 
     private handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} repository error: ${error.message}`);
-            this.notificationService.httpError(`${operation} repository failed:`, { data: error });
+            this.notificationService.httpError(
+                `${operation} repository failed:`,
+                { data: error },
+            );
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/preferences/preferences.service.spec.ts
+++ b/galaxyui/src/app/resources/preferences/preferences.service.spec.ts
@@ -9,7 +9,10 @@ describe('PreferencesService', () => {
         });
     });
 
-    it('should be created', inject([PreferencesService], (service: PreferencesService) => {
-        expect(service).toBeTruthy();
-    }));
+    it('should be created', inject(
+        [PreferencesService],
+        (service: PreferencesService) => {
+            expect(service).toBeTruthy();
+        },
+    ));
 });

--- a/galaxyui/src/app/resources/preferences/preferences.service.ts
+++ b/galaxyui/src/app/resources/preferences/preferences.service.ts
@@ -14,7 +14,12 @@ import { UserPreferences } from './user-preferences';
 })
 export class PreferencesService extends ServiceBase {
     constructor(http: HttpClient, notificationService: NotificationService) {
-        super(http, notificationService, '/api/internal/preferences', 'preferences');
+        super(
+            http,
+            notificationService,
+            '/api/internal/preferences',
+            'preferences',
+        );
     }
 
     preferences: UserPreferences = null;
@@ -35,7 +40,11 @@ export class PreferencesService extends ServiceBase {
 
     save(preferences: UserPreferences) {
         let httpResult: Observable<UserPreferences>;
-        httpResult = this.http.put<UserPreferences>(`${this.url}/`, preferences, this.httpOptions);
+        httpResult = this.http.put<UserPreferences>(
+            `${this.url}/`,
+            preferences,
+            this.httpOptions,
+        );
 
         return httpResult.pipe(
             tap(_ => this.log(`Saved ${this.serviceName}`)),

--- a/galaxyui/src/app/resources/provider-namespaces/provider-source.service.spec.ts
+++ b/galaxyui/src/app/resources/provider-namespaces/provider-source.service.spec.ts
@@ -9,7 +9,10 @@ describe('ProviderSourceService', () => {
         });
     });
 
-    it('should be created', inject([ProviderSourceService], (service: ProviderSourceService) => {
-        expect(service).toBeTruthy();
-    }));
+    it('should be created', inject(
+        [ProviderSourceService],
+        (service: ProviderSourceService) => {
+            expect(service).toBeTruthy();
+        },
+    ));
 });

--- a/galaxyui/src/app/resources/provider-namespaces/provider-source.service.ts
+++ b/galaxyui/src/app/resources/provider-namespaces/provider-source.service.ts
@@ -10,7 +10,10 @@ import { ProviderSource } from './provider-source';
 export class ProviderSourceService {
     private url = '/api/v1/providers/sources';
 
-    constructor(private http: HttpClient, private notificationService: NotificationService) {}
+    constructor(
+        private http: HttpClient,
+        private notificationService: NotificationService,
+    ) {}
 
     query(): Observable<ProviderSource[]> {
         return this.http.get<ProviderSource[]>(this.url + '/').pipe(
@@ -20,17 +23,25 @@ export class ProviderSourceService {
     }
 
     getRepoSources(params): Observable<RepositorySource[]> {
-        return this.http.get<RepositorySource[]>(`${this.url}/${params.providerName}/${params.name}/`).pipe(
-            tap(providerNamespaces => this.log('fetched source repositories')),
-            catchError(this.handleError('Query', [])),
-        );
+        return this.http
+            .get<RepositorySource[]>(
+                `${this.url}/${params.providerName}/${params.name}/`,
+            )
+            .pipe(
+                tap(providerNamespaces =>
+                    this.log('fetched source repositories'),
+                ),
+                catchError(this.handleError('Query', [])),
+            );
     }
 
     private handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} provider source error: ${error.message}`);
-            this.notificationService.httpError(`${operation} user failed:`, { data: error });
+            this.notificationService.httpError(`${operation} user failed:`, {
+                data: error,
+            });
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/repositories/repository.service.spec.ts
+++ b/galaxyui/src/app/resources/repositories/repository.service.spec.ts
@@ -9,7 +9,10 @@ describe('RepositoryService', () => {
         });
     });
 
-    it('should be created', inject([RepositoryService], (service: RepositoryService) => {
-        expect(service).toBeTruthy();
-    }));
+    it('should be created', inject(
+        [RepositoryService],
+        (service: RepositoryService) => {
+            expect(service).toBeTruthy();
+        },
+    ));
 });

--- a/galaxyui/src/app/resources/repositories/repository.service.ts
+++ b/galaxyui/src/app/resources/repositories/repository.service.ts
@@ -19,22 +19,29 @@ const httpOptions = {
 export class RepositoryService {
     private url = '/api/v1/repositories';
 
-    constructor(private http: HttpClient, private notificationService: NotificationService) {}
+    constructor(
+        private http: HttpClient,
+        private notificationService: NotificationService,
+    ) {}
 
     query(params?: any): Observable<Repository[]> {
-        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
-            map(response => response.results as Repository[]),
-            tap(_ => this.log('fetched repositories')),
-            catchError(this.handleError('Query', [] as Repository[])),
-        );
+        return this.http
+            .get<PagedResponse>(this.url + '/', { params: params })
+            .pipe(
+                map(response => response.results as Repository[]),
+                tap(_ => this.log('fetched repositories')),
+                catchError(this.handleError('Query', [] as Repository[])),
+            );
     }
 
     pagedQuery(params?: any): Observable<PagedResponse> {
         if (params && typeof params === 'object') {
-            return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
-                tap(_ => this.log('fetched repositories')),
-                catchError(this.handleError('Query', {} as PagedResponse)),
-            );
+            return this.http
+                .get<PagedResponse>(this.url + '/', { params: params })
+                .pipe(
+                    tap(_ => this.log('fetched repositories')),
+                    catchError(this.handleError('Query', {} as PagedResponse)),
+                );
         }
         if (params && typeof params === 'string') {
             return this.http.get<PagedResponse>(this.url + '/' + params).pipe(
@@ -56,22 +63,36 @@ export class RepositoryService {
     }
 
     getVersions(id: number, params?: any): Observable<PagedResponse> {
-        return this.http.get<PagedResponse>(`${this.url}/${id.toString()}/versions/`, { params: params }).pipe(
-            tap(_ => this.log('Fetched repository versions')),
-            catchError(this.handleError('Get', {} as PagedResponse)),
-        );
+        return this.http
+            .get<PagedResponse>(`${this.url}/${id.toString()}/versions/`, {
+                params: params,
+            })
+            .pipe(
+                tap(_ => this.log('Fetched repository versions')),
+                catchError(this.handleError('Get', {} as PagedResponse)),
+            );
     }
 
     save(repository: Repository): Observable<Repository> {
         let httpResult: Observable<Object>;
         if (repository.id) {
-            httpResult = this.http.put<Repository>(`${this.url}/${repository.id}/`, repository, httpOptions);
+            httpResult = this.http.put<Repository>(
+                `${this.url}/${repository.id}/`,
+                repository,
+                httpOptions,
+            );
         } else {
-            httpResult = this.http.post<Repository>(`${this.url}/`, repository, httpOptions);
+            httpResult = this.http.post<Repository>(
+                `${this.url}/`,
+                repository,
+                httpOptions,
+            );
         }
 
         return httpResult.pipe(
-            tap((newRepo: Repository) => this.log(`Saved repository w/ id=${newRepo.id}`)),
+            tap((newRepo: Repository) =>
+                this.log(`Saved repository w/ id=${newRepo.id}`),
+            ),
             catchError(this.handleError<Repository>('Save')),
         );
     }
@@ -100,7 +121,10 @@ export class RepositoryService {
                 }
             }
             this.log(`${operation} repository error: ${error.message}`);
-            this.notificationService.httpError(`${operation} repository failed:`, { data: data });
+            this.notificationService.httpError(
+                `${operation} repository failed:`,
+                { data: data },
+            );
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/repository-imports/repository-import.service.spec.ts
+++ b/galaxyui/src/app/resources/repository-imports/repository-import.service.spec.ts
@@ -9,7 +9,10 @@ describe('RepositoryImportService', () => {
         });
     });
 
-    it('should be created', inject([RepositoryImportService], (service: RepositoryImportService) => {
-        expect(service).toBeTruthy();
-    }));
+    it('should be created', inject(
+        [RepositoryImportService],
+        (service: RepositoryImportService) => {
+            expect(service).toBeTruthy();
+        },
+    ));
 });

--- a/galaxyui/src/app/resources/repository-imports/repository-import.service.ts
+++ b/galaxyui/src/app/resources/repository-imports/repository-import.service.ts
@@ -16,7 +16,10 @@ const httpOptions = {
 export class RepositoryImportService {
     private url = '/api/v1/imports';
 
-    constructor(private http: HttpClient, private notificationService: NotificationService) {}
+    constructor(
+        private http: HttpClient,
+        private notificationService: NotificationService,
+    ) {}
 
     query(params): Observable<RepositoryImport[]> {
         return this.http.get<PagedResponse>(this.url, { params: params }).pipe(
@@ -27,17 +30,24 @@ export class RepositoryImportService {
     }
 
     save(params: any): Observable<RepositoryImport> {
-        return this.http.post<RepositoryImport>(`${this.url}/`, params, httpOptions).pipe(
-            tap((newImport: RepositoryImport) => this.log(`Saved repository import`)),
-            catchError(this.handleError<RepositoryImport>('Save')),
-        );
+        return this.http
+            .post<RepositoryImport>(`${this.url}/`, params, httpOptions)
+            .pipe(
+                tap((newImport: RepositoryImport) =>
+                    this.log(`Saved repository import`),
+                ),
+                catchError(this.handleError<RepositoryImport>('Save')),
+            );
     }
 
     private handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} repository import error: ${error.message}`);
-            this.notificationService.httpError(`${operation} repository import failed:`, { data: error });
+            this.notificationService.httpError(
+                `${operation} repository import failed:`,
+                { data: error },
+            );
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/resources/tags/tags.service.ts
+++ b/galaxyui/src/app/resources/tags/tags.service.ts
@@ -14,29 +14,39 @@ export class TagsService {
     private url = '/api/v1/tags';
     private searchUrl = '/api/v1/search/tags';
 
-    constructor(private http: HttpClient, private notificationService: NotificationService) {}
+    constructor(
+        private http: HttpClient,
+        private notificationService: NotificationService,
+    ) {}
 
     query(params?: any): Observable<Tag[]> {
-        return this.http.get<PagedResponse>(this.url + '/', { params: params }).pipe(
-            map(response => response.results),
-            tap(_ => this.log('fetched content types')),
-            catchError(this.handleError('Query', [] as Tag[])),
-        );
+        return this.http
+            .get<PagedResponse>(this.url + '/', { params: params })
+            .pipe(
+                map(response => response.results),
+                tap(_ => this.log('fetched content types')),
+                catchError(this.handleError('Query', [] as Tag[])),
+            );
     }
 
     search(params?: any): Observable<Tag[]> {
-        return this.http.get<PagedResponse>(this.searchUrl + '/', { params: params }).pipe(
-            map(response => response.results),
-            tap(_ => this.log('fetched content types')),
-            catchError(this.handleError('Query', [] as Tag[])),
-        );
+        return this.http
+            .get<PagedResponse>(this.searchUrl + '/', { params: params })
+            .pipe(
+                map(response => response.results),
+                tap(_ => this.log('fetched content types')),
+                catchError(this.handleError('Query', [] as Tag[])),
+            );
     }
 
     private handleError<T>(operation = '', result?: T) {
         return (error: any): Observable<T> => {
             console.error(`${operation} failed, error:`, error);
             this.log(`${operation} repository error: ${error.message}`);
-            this.notificationService.httpError(`${operation} repository failed:`, { data: error });
+            this.notificationService.httpError(
+                `${operation} repository failed:`,
+                { data: error },
+            );
 
             // Let the app keep running by returning an empty result.
             return of(result as T);

--- a/galaxyui/src/app/search/search.component.ts
+++ b/galaxyui/src/app/search/search.component.ts
@@ -37,7 +37,10 @@ import { ContentTypesIconClasses } from '../enums/content-types.enum';
 
 import { RepoFormats } from '../enums/repo-types.enum';
 
-import { ContributorTypes, ContributorTypesIconClasses } from '../enums/contributor-types.enum';
+import {
+    ContributorTypes,
+    ContributorTypesIconClasses,
+} from '../enums/contributor-types.enum';
 
 import { PopularEvent } from './popular/popular.component';
 
@@ -118,7 +121,8 @@ export class SearchComponent implements OnInit, AfterViewInit {
                         {
                             id: ContributorTypes.community,
                             value: ContributorTypes.community,
-                            iconStyleClass: ContributorTypesIconClasses.community,
+                            iconStyleClass:
+                                ContributorTypesIconClasses.community,
                         },
                         {
                             id: ContributorTypes.vendor,
@@ -226,11 +230,21 @@ export class SearchComponent implements OnInit, AfterViewInit {
                     this.setSortConfig(this.queryParams);
                     this.setPageSize(this.queryParams);
                     this.setAppliedFilters(this.queryParams);
-                    this.prepareContent(data.content.results, data.content.count);
+                    this.prepareContent(
+                        data.content.results,
+                        data.content.count,
+                    );
                     this.setUrlParams(this.queryParams);
                     this.pageLoading = false;
                 } else {
-                    this.notificationService.message(NotificationType.WARNING, 'Error', 'Invalid search query', false, null, null);
+                    this.notificationService.message(
+                        NotificationType.WARNING,
+                        'Error',
+                        'Invalid search query',
+                        false,
+                        null,
+                        null,
+                    );
 
                     this.setSortConfig(this.queryParams);
                     this.setPageSize(this.queryParams);
@@ -295,11 +309,15 @@ export class SearchComponent implements OnInit, AfterViewInit {
                             }
                         }
                     } else {
-                        params[key] = encodeURIComponent(filterby[key].join(' '));
+                        params[key] = encodeURIComponent(
+                            filterby[key].join(' '),
+                        );
                     }
                 }
             }
-            this.appliedFilters = JSON.parse(JSON.stringify($event.appliedFilters));
+            this.appliedFilters = JSON.parse(
+                JSON.stringify($event.appliedFilters),
+            );
 
             // Apply new filters to queryParams
             for (const key of Object.keys(params)) {
@@ -313,7 +331,9 @@ export class SearchComponent implements OnInit, AfterViewInit {
     }
 
     getToolbarConfig(): ToolbarConfig {
-        this.toolbarConfig.filterConfig.appliedFilters = JSON.parse(JSON.stringify(this.appliedFilters));
+        this.toolbarConfig.filterConfig.appliedFilters = JSON.parse(
+            JSON.stringify(this.appliedFilters),
+        );
         return this.toolbarConfig;
     }
 
@@ -344,7 +364,9 @@ export class SearchComponent implements OnInit, AfterViewInit {
             this.queryParams[$event.itemType] = $event.item['name'];
             update = true;
         } else {
-            if (!this.queryParams[$event.itemType].includes($event.item['name'])) {
+            if (
+                !this.queryParams[$event.itemType].includes($event.item['name'])
+            ) {
                 update = true;
                 this.queryParams[$event.itemType] += ' ' + $event.item['name'];
             }
@@ -429,10 +451,16 @@ export class SearchComponent implements OnInit, AfterViewInit {
                     const ffield: Filter = {} as Filter;
                     ffield.field = field;
                     field.queries.forEach((query: FilterQuery) => {
-                        if (query.id === ContributorTypes.community && params[key] === 'false') {
+                        if (
+                            query.id === ContributorTypes.community &&
+                            params[key] === 'false'
+                        ) {
                             ffield.query = query;
                             ffield.value = query.value;
-                        } else if (query.id === ContributorTypes.vendor && params[key] === 'true') {
+                        } else if (
+                            query.id === ContributorTypes.vendor &&
+                            params[key] === 'true'
+                        ) {
                             ffield.query = query;
                             ffield.value = query.value;
                         }
@@ -488,7 +516,10 @@ export class SearchComponent implements OnInit, AfterViewInit {
         return result;
     }
 
-    private getFilterFieldQuery(field: FilterField, value: string): FilterQuery {
+    private getFilterFieldQuery(
+        field: FilterField,
+        value: string,
+    ): FilterQuery {
         let result: FilterQuery = null;
         field.queries.forEach((item: FilterQuery) => {
             if (item.id === value) {
@@ -501,7 +532,10 @@ export class SearchComponent implements OnInit, AfterViewInit {
     private addToFilter(filter: Filter) {
         let filterExists = false;
         this.appliedFilters.forEach((item: Filter) => {
-            if (item.field.id === filter.field.id && item.value === filter.value) {
+            if (
+                item.field.id === filter.field.id &&
+                item.value === filter.value
+            ) {
                 filterExists = true;
             }
         });
@@ -530,24 +564,39 @@ export class SearchComponent implements OnInit, AfterViewInit {
             } else if (datePattern.exec(item.imported) !== null) {
                 item.imported = moment(item.imported).fromNow();
             }
-            item['repository_format'] = item.summary_fields['repository']['format'];
-            item['avatar_url'] = item.summary_fields['namespace']['avatar_url'] || '/assets/avatar.png';
+            item['repository_format'] =
+                item.summary_fields['repository']['format'];
+            item['avatar_url'] =
+                item.summary_fields['namespace']['avatar_url'] ||
+                '/assets/avatar.png';
             if (!item.summary_fields['namespace']['is_vendor']) {
                 // always show namespace name for community contributors
-                item['namespace_name'] = item.summary_fields['namespace']['name'];
+                item['namespace_name'] =
+                    item.summary_fields['namespace']['name'];
             } else {
                 // for vendors, assume name is in logo
-                item['namespace_name'] = item.summary_fields['namespace']['avatar_url'] ? '' : item.summary_fields['namespace']['name'];
+                item['namespace_name'] = item.summary_fields['namespace'][
+                    'avatar_url'
+                ]
+                    ? ''
+                    : item.summary_fields['namespace']['name'];
             }
             item['displayNamespace'] = item.summary_fields['namespace']['name'];
             if (PluginTypes[item.summary_fields['content_type']['name']]) {
                 item['iconClass'] = ContentTypesIconClasses.plugin;
             } else {
-                item['iconClass'] = ContentTypesIconClasses[item.summary_fields['content_type']['name']];
+                item['iconClass'] =
+                    ContentTypesIconClasses[
+                        item.summary_fields['content_type']['name']
+                    ];
             }
             // Determine navigation for item click
-            const namespace = item.summary_fields['namespace']['name'].toLowerCase();
-            const repository = item.summary_fields['repository']['name'].toLowerCase();
+            const namespace = item.summary_fields['namespace'][
+                'name'
+            ].toLowerCase();
+            const repository = item.summary_fields['repository'][
+                'name'
+            ].toLowerCase();
             const name = item.name.toLowerCase();
             item['contentLink'] = `/${namespace}/${repository}`;
             if (item['repository_format'] === RepoFormats.multi) {

--- a/galaxyui/src/app/search/search.resolver.service.ts
+++ b/galaxyui/src/app/search/search.resolver.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@angular/core';
 
-import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+import {
+    ActivatedRouteSnapshot,
+    Resolve,
+    RouterStateSnapshot,
+} from '@angular/router';
 
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -34,7 +38,8 @@ export class DefaultParams {
     static getParamString(): string {
         let paramString = '';
         for (const key of Object.keys(this.params)) {
-            paramString += key + '=' + encodeURIComponent(this.params[key]) + '&';
+            paramString +=
+                key + '=' + encodeURIComponent(this.params[key]) + '&';
         }
 
         // Remove trailing '&'
@@ -45,7 +50,10 @@ export class DefaultParams {
 @Injectable()
 export class SearchContentResolver implements Resolve<ContentResponse> {
     constructor(private contentService: ContentSearchService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<ContentResponse> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<ContentResponse> {
         let params = {};
         for (const key in route.queryParams) {
             if (route.queryParams.hasOwnProperty(key)) {
@@ -76,7 +84,10 @@ export class SearchContentResolver implements Resolve<ContentResponse> {
 @Injectable()
 export class SearchPlatformResolver implements Resolve<Platform[]> {
     constructor(private platformService: PlatformService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Platform[]> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<Platform[]> {
         return this.platformService.query({ page_size: 1000 });
     }
 }
@@ -84,15 +95,24 @@ export class SearchPlatformResolver implements Resolve<Platform[]> {
 @Injectable()
 export class SearchContentTypeResolver implements Resolve<ContentType[]> {
     constructor(private contentTypeService: ContentTypeService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<ContentType[]> {
-        return this.contentTypeService.query({ page_size: 1000, order: 'description' });
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<ContentType[]> {
+        return this.contentTypeService.query({
+            page_size: 1000,
+            order: 'description',
+        });
     }
 }
 
 @Injectable()
 export class SearchCloudPlatformResolver implements Resolve<CloudPlatform[]> {
     constructor(private contentTypeService: CloudPlatformService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<CloudPlatform[]> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<CloudPlatform[]> {
         return this.contentTypeService.query({ page_size: 1000 });
     }
 }
@@ -100,7 +120,10 @@ export class SearchCloudPlatformResolver implements Resolve<CloudPlatform[]> {
 @Injectable()
 export class PopularTagsResolver implements Resolve<Tag[]> {
     constructor(private tagsService: TagsService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Tag[]> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<Tag[]> {
         return this.tagsService.search({ order_by: '-roles_count,name' });
     }
 }
@@ -108,36 +131,46 @@ export class PopularTagsResolver implements Resolve<Tag[]> {
 @Injectable()
 export class PopularPlatformsResolver implements Resolve<Platform[]> {
     constructor(private platformService: PlatformService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Platform[]> {
-        return this.platformService.search({ page_size: 1000, order_by: '-roles_count,name' }).pipe(
-            map(result => {
-                // Sum roles_count per platforms, sans release
-                const summary = {};
-                const platforms: Platform[] = [];
-                result.forEach((item: Platform) => {
-                    if (summary[item.name] === undefined) {
-                        summary[item.name] = 0;
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<Platform[]> {
+        return this.platformService
+            .search({ page_size: 1000, order_by: '-roles_count,name' })
+            .pipe(
+                map(result => {
+                    // Sum roles_count per platforms, sans release
+                    const summary = {};
+                    const platforms: Platform[] = [];
+                    result.forEach((item: Platform) => {
+                        if (summary[item.name] === undefined) {
+                            summary[item.name] = 0;
+                        }
+                        summary[item.name] += item.roles_count;
+                    });
+                    for (const key in summary) {
+                        if (summary.hasOwnProperty(key)) {
+                            platforms.push({
+                                name: key,
+                                roles_count: summary[key],
+                            } as Platform);
+                        }
                     }
-                    summary[item.name] += item.roles_count;
-                });
-                for (const key in summary) {
-                    if (summary.hasOwnProperty(key)) {
-                        platforms.push({
-                            name: key,
-                            roles_count: summary[key],
-                        } as Platform);
-                    }
-                }
-                return platforms;
-            }),
-        );
+                    return platforms;
+                }),
+            );
     }
 }
 
 @Injectable()
 export class PopularCloudPlatformsResolver implements Resolve<CloudPlatform[]> {
     constructor(private cloudPlatformService: CloudPlatformService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<CloudPlatform[]> {
-        return this.cloudPlatformService.search({ order_by: '-roles_count,name' });
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<CloudPlatform[]> {
+        return this.cloudPlatformService.search({
+            order_by: '-roles_count,name',
+        });
     }
 }

--- a/galaxyui/src/app/shared/directives/log-event.directive.ts
+++ b/galaxyui/src/app/shared/directives/log-event.directive.ts
@@ -6,7 +6,10 @@ import { EventLoggerService } from '../../resources/logger/event-logger.service'
     selector: '[appLogEvent]',
 })
 export class LogButtonLinkDirective {
-    constructor(private el: ElementRef, private eventLoggerService: EventLoggerService) {}
+    constructor(
+        private el: ElementRef,
+        private eventLoggerService: EventLoggerService,
+    ) {}
 
     @Input()
     appLogEvent: any;
@@ -17,7 +20,10 @@ export class LogButtonLinkDirective {
         let name: string;
 
         if (typeof this.appLogEvent === 'string') {
-            name = this.appLogEvent || this.el.nativeElement.text || this.el.nativeElement.innerText;
+            name =
+                this.appLogEvent ||
+                this.el.nativeElement.text ||
+                this.el.nativeElement.innerText;
             if (this.el.nativeElement.nodeName === 'A') {
                 elementType = 'link';
             } else if (this.el.nativeElement.nodeName === 'BUTTON') {
@@ -29,7 +35,8 @@ export class LogButtonLinkDirective {
         }
 
         if (elementType === 'link') {
-            const link = this.appLogEvent.href || this.el.nativeElement.pathname;
+            const link =
+                this.appLogEvent.href || this.el.nativeElement.pathname;
             this.eventLoggerService.logLink(name, link);
         } else if (elementType === 'button') {
             this.eventLoggerService.logButton(name);

--- a/galaxyui/src/app/shared/shared.module.ts
+++ b/galaxyui/src/app/shared/shared.module.ts
@@ -12,8 +12,18 @@ import { PageLoadingComponent } from './components/page-loading/page-loading.com
 
 @NgModule({
     imports: [CommonModule, RouterModule],
-    declarations: [LogButtonLinkDirective, PageHeaderComponent, PageLoadingComponent, MiddleclickDirective],
-    exports: [LogButtonLinkDirective, PageHeaderComponent, PageLoadingComponent, MiddleclickDirective],
+    declarations: [
+        LogButtonLinkDirective,
+        PageHeaderComponent,
+        PageLoadingComponent,
+        MiddleclickDirective,
+    ],
+    exports: [
+        LogButtonLinkDirective,
+        PageHeaderComponent,
+        PageLoadingComponent,
+        MiddleclickDirective,
+    ],
 })
 export class SharedModule {
     constructor() {}

--- a/galaxyui/src/app/user-notifications/user-notifications.component.ts
+++ b/galaxyui/src/app/user-notifications/user-notifications.component.ts
@@ -33,6 +33,9 @@ export class UserNotificationsComponent implements OnInit {
     }
 
     handleViewingChange($event: NotificationEvent): void {
-        this.notificationService.setViewing($event.notification, $event.isViewing);
+        this.notificationService.setViewing(
+            $event.notification,
+            $event.isViewing,
+        );
     }
 }

--- a/galaxyui/src/app/utilities/clipboard/clipboard.component.ts
+++ b/galaxyui/src/app/utilities/clipboard/clipboard.component.ts
@@ -33,7 +33,20 @@ export class ClipboardComponent implements OnInit {
     }
 
     calcGuid(): string {
-        return this.s4() + this.s4() + '-' + this.s4() + '-' + this.s4() + '-' + this.s4() + '-' + this.s4() + this.s4() + this.s4();
+        return (
+            this.s4() +
+            this.s4() +
+            '-' +
+            this.s4() +
+            '-' +
+            this.s4() +
+            '-' +
+            this.s4() +
+            '-' +
+            this.s4() +
+            this.s4() +
+            this.s4()
+        );
     }
 
     copyToClipboard() {

--- a/galaxyui/src/app/vendors/card/vendor-card.component.ts
+++ b/galaxyui/src/app/vendors/card/vendor-card.component.ts
@@ -36,9 +36,17 @@ export class VendorCardComponent implements OnInit {
             }
             this.vendor['contentCount'] = 0;
             if (this.vendor['summary_fields']['content_counts']) {
-                for (const key in this.vendor['summary_fields']['content_counts']) {
-                    if (this.vendor['summary_fields']['content_counts'].hasOwnProperty(key)) {
-                        this.vendor['contentCount'] += this.vendor['summary_fields']['content_counts'][key];
+                for (const key in this.vendor['summary_fields'][
+                    'content_counts'
+                ]) {
+                    if (
+                        this.vendor['summary_fields'][
+                            'content_counts'
+                        ].hasOwnProperty(key)
+                    ) {
+                        this.vendor['contentCount'] += this.vendor[
+                            'summary_fields'
+                        ]['content_counts'][key];
                     }
                 }
             }

--- a/galaxyui/src/app/vendors/vendors.component.ts
+++ b/galaxyui/src/app/vendors/vendors.component.ts
@@ -18,7 +18,11 @@ import { ToolbarConfig } from 'patternfly-ng/toolbar/toolbar-config';
 import { Namespace } from '../resources/namespaces/namespace';
 import { NamespaceService } from '../resources/namespaces/namespace.service';
 
-import { ContentTypes, ContentTypesIconClasses, ContentTypesPluralChoices } from '../enums/content-types.enum';
+import {
+    ContentTypes,
+    ContentTypesIconClasses,
+    ContentTypesPluralChoices,
+} from '../enums/content-types.enum';
 
 @Component({
     selector: 'app-vendors',
@@ -29,7 +33,11 @@ export class VendorsComponent implements OnInit {
     // Used to track which component is being loaded
     componentName = 'VendorsComponent';
 
-    constructor(private router: Router, private route: ActivatedRoute, private namespaceService: NamespaceService) {}
+    constructor(
+        private router: Router,
+        private route: ActivatedRoute,
+        private namespaceService: NamespaceService,
+    ) {}
 
     pageTitle = 'Partners';
     headerIcon = 'fa fa-star';
@@ -124,9 +132,11 @@ export class VendorsComponent implements OnInit {
         if ($event.appliedFilters.length) {
             $event.appliedFilters.forEach(filter => {
                 if (filter.field.type === 'typeahead') {
-                    this.filterBy['or__' + filter.field.id + '__icontains'] = filter.query.id;
+                    this.filterBy['or__' + filter.field.id + '__icontains'] =
+                        filter.query.id;
                 } else {
-                    this.filterBy['or__' + filter.field.id + '__icontains'] = filter.value;
+                    this.filterBy['or__' + filter.field.id + '__icontains'] =
+                        filter.value;
                 }
             });
         } else {
@@ -178,23 +188,41 @@ export class VendorsComponent implements OnInit {
                             // summarize plugins
                             let count = 0;
                             const countObj = {};
-                            for (const count_key in item['summary_fields']['content_counts']) {
-                                if (item['summary_fields']['content_counts'].hasOwnProperty(count_key)) {
+                            for (const count_key in item['summary_fields'][
+                                'content_counts'
+                            ]) {
+                                if (
+                                    item['summary_fields'][
+                                        'content_counts'
+                                    ].hasOwnProperty(count_key)
+                                ) {
                                     if (count_key.indexOf('plugin') > -1) {
-                                        count += item['summary_fields']['content_counts'][count_key];
+                                        count +=
+                                            item['summary_fields'][
+                                                'content_counts'
+                                            ][count_key];
                                     }
                                 }
                             }
                             if (count > 0) {
-                                countObj['title'] = ContentTypesPluralChoices[ct];
+                                countObj['title'] =
+                                    ContentTypesPluralChoices[ct];
                                 countObj['count'] = count;
-                                countObj['iconClass'] = ContentTypesIconClasses[ct];
+                                countObj['iconClass'] =
+                                    ContentTypesIconClasses[ct];
                                 contentCounts.push(countObj);
                             }
-                        } else if (item['summary_fields']['content_counts'][ContentTypes[ct]] > 0) {
+                        } else if (
+                            item['summary_fields']['content_counts'][
+                                ContentTypes[ct]
+                            ] > 0
+                        ) {
                             const countObj = {};
                             countObj['title'] = ContentTypesPluralChoices[ct];
-                            countObj['count'] = item['summary_fields']['content_counts'][ContentTypes[ct]];
+                            countObj['count'] =
+                                item['summary_fields']['content_counts'][
+                                    ContentTypes[ct]
+                                ];
                             countObj['iconClass'] = ContentTypesIconClasses[ct];
                             contentCounts.push(countObj);
                         }

--- a/galaxyui/src/app/vendors/vendors.resolver.service.ts
+++ b/galaxyui/src/app/vendors/vendors.resolver.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@angular/core';
 
-import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+import {
+    ActivatedRouteSnapshot,
+    Resolve,
+    RouterStateSnapshot,
+} from '@angular/router';
 
 import { Observable } from 'rxjs';
 
@@ -10,7 +14,10 @@ import { PagedResponse } from '../resources/paged-response';
 @Injectable()
 export class VendorListResolver implements Resolve<PagedResponse> {
     constructor(private namespaceService: NamespaceService) {}
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<PagedResponse> {
+    resolve(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot,
+    ): Observable<PagedResponse> {
         return this.namespaceService.pagedQuery({ is_vendor: 'true' });
     }
 }

--- a/galaxyui/src/test.ts
+++ b/galaxyui/src/test.ts
@@ -1,13 +1,19 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
 import { getTestBed } from '@angular/core/testing';
-import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+import {
+    BrowserDynamicTestingModule,
+    platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import 'zone.js/dist/zone-testing';
 
 declare const require: any;
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+getTestBed().initTestEnvironment(
+    BrowserDynamicTestingModule,
+    platformBrowserDynamicTesting(),
+);
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.

--- a/galaxyui/tslint.json
+++ b/galaxyui/tslint.json
@@ -1,132 +1,68 @@
 {
-  "extends": [
-    "tslint:recommended"
-  ],
-  "rulesDirectory": [
-    "node_modules/codelyzer"
-  ],
-  "rules": {
-    "align": false,
-    "array-type": false,
-    "arrow-parens": false,
-    "ban-types": false,
-    "jsdoc-format": false,
-    "max-classes-per-file": false,
-    "object-literal-key-quotes": false,
-    "object-literal-shorthand": false,
-    "trailing-comma": false,
-    "class-name": true,
-    "ordered-imports": false,
-    "comment-format": [
-      true,
-      "check-space"
-    ],
-    "deprecation": {
-      "severity": "warn"
-    },
-    "import-blacklist": [
-      true,
-      "rxjs/Rx"
-    ],
-    "import-spacing": false,
-    "indent": [
-      true,
-      "spaces",
-      4
-    ],
-    "max-line-length": [
-      true,
-      140
-    ],
-    "member-access": false,
-    "member-ordering": [
-      true,
-      {
-        "order": [
-          "static-field",
-          "instance-field",
-          "static-method",
-          "instance-method"
-        ]
-      }
-    ],
-    "no-console": [
-      true,
-      "debug",
-      "info",
-      "time",
-      "timeEnd",
-      "trace"
-    ],
-    "no-empty": false,
-    "no-inferrable-types": [
-      true,
-      "ignore-params"
-    ],
-    "no-non-null-assertion": true,
-    "no-string-literal": false,
-    "no-switch-case-fall-through": true,
-    "no-use-before-declare": true,
-    "object-literal-sort-keys": false,
-    "one-line": [
-      true,
-      "check-open-brace",
-      "check-catch",
-      "check-else",
-      "check-whitespace"
-    ],
-    "quotemark": [
-      true,
-      "single"
-    ],
-    "semicolon": [
-      true,
-      "always"
-    ],
-    "triple-equals": [
-      true,
-      "allow-null-check"
-    ],
-    "typedef-whitespace": [
-      true,
-      {
-        "call-signature": "nospace",
-        "index-signature": "nospace",
-        "parameter": "nospace",
-        "property-declaration": "nospace",
-        "variable-declaration": "nospace"
-      }
-    ],
-    "variable-name": false,
-    "whitespace": [
-      true,
-      "check-branch",
-      "check-decl",
-      "check-operator",
-      "check-separator",
-      "check-type"
-    ],
-    "directive-selector": [
-      true,
-      "attribute",
-      "app",
-      "camelCase"
-    ],
-    "component-selector": [
-      false,
-      "element",
-      "app",
-      "kebab-case"
-    ],
-    "no-output-on-prefix": true,
-    "use-input-property-decorator": true,
-    "use-output-property-decorator": true,
-    "use-host-property-decorator": true,
-    "no-input-rename": true,
-    "no-output-rename": true,
-    "use-life-cycle-interface": true,
-    "use-pipe-transform-interface": true,
-    "component-class-suffix": true,
-    "directive-class-suffix": true
-  }
+    "extends": ["tslint:recommended"],
+    "rulesDirectory": ["node_modules/codelyzer"],
+    "rules": {
+        "align": false,
+        "array-type": false,
+        "arrow-parens": false,
+        "ban-types": false,
+        "jsdoc-format": false,
+        "max-classes-per-file": false,
+        "object-literal-key-quotes": false,
+        "object-literal-shorthand": false,
+        "trailing-comma": false,
+        "class-name": true,
+        "ordered-imports": false,
+        "comment-format": [true, "check-space"],
+        "deprecation": {
+            "severity": "warn"
+        },
+        "import-blacklist": [true, "rxjs/Rx"],
+        "import-spacing": false,
+        "indent": [true, "spaces", 4],
+        "max-line-length": false,
+        "member-access": false,
+        "member-ordering": [
+            true,
+            {
+                "order": ["static-field", "instance-field", "static-method", "instance-method"]
+            }
+        ],
+        "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
+        "no-empty": false,
+        "no-inferrable-types": [true, "ignore-params"],
+        "no-non-null-assertion": true,
+        "no-string-literal": false,
+        "no-switch-case-fall-through": true,
+        "no-use-before-declare": true,
+        "object-literal-sort-keys": false,
+        "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],
+        "quotemark": [true, "single"],
+        "semicolon": [true, "always"],
+        "triple-equals": [true, "allow-null-check"],
+        "typedef-whitespace": [
+            true,
+            {
+                "call-signature": "nospace",
+                "index-signature": "nospace",
+                "parameter": "nospace",
+                "property-declaration": "nospace",
+                "variable-declaration": "nospace"
+            }
+        ],
+        "variable-name": false,
+        "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"],
+        "directive-selector": [true, "attribute", "app", "camelCase"],
+        "component-selector": [false, "element", "app", "kebab-case"],
+        "no-output-on-prefix": true,
+        "use-input-property-decorator": true,
+        "use-output-property-decorator": true,
+        "use-host-property-decorator": true,
+        "no-input-rename": true,
+        "no-output-rename": true,
+        "use-life-cycle-interface": true,
+        "use-pipe-transform-interface": true,
+        "component-class-suffix": true,
+        "directive-class-suffix": true
+    }
 }


### PR DESCRIPTION
This patch does two main things:
- Configures prettier to format code so that the max line length is 80
- Prevents TSLint from checking max line lengths.

The rationale behind this change is as follows:
1. 140 characters is unwieldy and makes viewing two pieces of code side by side very difficult
2. Prettier can handle line length formatting, but not for all cases. For example it doesn't try to format imports or strings that exceed 80 characters. This causes TSLint to fail in those cases. There are two possible solutions to this. One is to disable TSLint on a line by line basis when lines need to be longer than 80 char. The second is to just disable TSLint line checking entirely and rely on prettier. Since the second option is easier and more reliable, I've decided to just let Prettier handle max line checking.