### PR TITLE
Add list of followed items to preferences page

### DIFF
--- a/galaxy/api/serializers/user_preferences.py
+++ b/galaxy/api/serializers/user_preferences.py
@@ -24,4 +24,26 @@ class ActiveUserPreferencesSerializer(BaseSerializer):
         )
 
     def get_summary_fields(self, obj):
-        return {}
+        followed_repos = []
+        for repo in obj.repositories_followed.all():
+            followed_repos.append({
+                'id': repo.id,
+                'name': repo.name,
+                'namespace': repo.provider_namespace.namespace.name,
+                'description': repo.description,
+                'avatar': repo.provider_namespace.namespace.avatar_url
+            })
+
+        followed_ns = []
+        for ns in obj.namespaces_followed.all():
+            followed_ns.append({
+                'id': ns.id,
+                'name': ns.name,
+                'description': ns.description,
+                'avatar': ns.avatar_url
+            })
+
+        return {
+            'repositories_followed': followed_repos,
+            'namespaces_followed': followed_ns
+        }

--- a/galaxyui/src/app/authors/detail/author-detail.component.ts
+++ b/galaxyui/src/app/authors/detail/author-detail.component.ts
@@ -290,7 +290,7 @@ export class AuthorDetailComponent implements OnInit {
             this.followerClass = 'fa fa-user-times';
         } else {
             this.isFollower = false;
-            this.followerClass = 'fa fa-user-times';
+            this.followerClass = 'fa fa-user-plus';
         }
     }
 

--- a/galaxyui/src/app/content-detail/repository/repository.component.ts
+++ b/galaxyui/src/app/content-detail/repository/repository.component.ts
@@ -110,7 +110,7 @@ export class RepositoryComponent implements OnInit {
             this.followerClass = 'fa fa-user-times';
         } else {
             this.isFollower = false;
-            this.followerClass = 'fa fa-user-times';
+            this.followerClass = 'fa fa-user-plus';
         }
     }
 

--- a/galaxyui/src/app/preferences/preferences.component.html
+++ b/galaxyui/src/app/preferences/preferences.component.html
@@ -1,98 +1,186 @@
 <app-page-header headerIcon="fa fa-gear" headerTitle="Preferences"></app-page-header>
+<div class="row">
+    <pfng-card [config]="emailCard" id="emailCard" class="col-md-12">
+        <div class="card-content">
+            <pfng-list
+                [items]="emails"
+                [itemTemplate]="emailsListTemplate"
+            >
+                <ng-template #emailsListTemplate let-item="item" let-index="index">
+                    <div class="list-pf-content-wrapper">
+                        <div class="list-pf-main-content">
+                            <div class="list-pf-title">
+                                <div *ngIf="!item.summary_fields.new">
+                                    {{ item.email }}
+                                    <span *ngIf="item.primary" class="label label-primary">Primary</span>
+                                </div>
 
-<pfng-card [config]="emailCard" id="emailCard">
-    <div class="card-content">
-        <pfng-list
-            [items]="emails"
-            [itemTemplate]="emailsListTemplate"
-        >
-            <ng-template #emailsListTemplate let-item="item" let-index="index">
-                <div class="list-pf-content-wrapper">
-                    <div class="list-pf-main-content">
-                        <div class="list-pf-title">
-                            <div *ngIf="!item.summary_fields.new">
-                                {{ item.email }}
-                                <span *ngIf="item.primary" class="label label-primary">Primary</span>
+                                <div *ngIf="item.summary_fields.new">
+                                    <span class="no-bold">New Email: </span> &nbsp;
+                                    <input  class="no-bold" [(ngModel)]="item.email" required type="email" (keyup.enter)="saveEmail(item)">
+                                </div>
                             </div>
-
-                            <div *ngIf="item.summary_fields.new">
-                                <span class="no-bold">New Email: </span> &nbsp;
-                                <input  class="no-bold" [(ngModel)]="item.email" required type="email" (keyup.enter)="saveEmail(item)">
+                        </div>
+                        <div class="list-pf-additional-content">
+                            <div>
+                                <span *ngIf="item.verified" class="verified">
+                                    <span class="fa fa-check-circle"></span> Verified
+                                </span>
+                                <span *ngIf="!item.verified" class="unverified">
+                                    <span class="fa fa-times-circle"></span> Unverified
+                                </span>
                             </div>
                         </div>
                     </div>
-                    <div class="list-pf-additional-content">
-                        <div>
-                            <span *ngIf="item.verified" class="verified">
-                                <span class="fa fa-check-circle"></span> Verified
-                            </span>
-                            <span *ngIf="!item.verified" class="unverified">
-                                <span class="fa fa-times-circle"></span> Unverified
-                            </span>
+
+
+
+                    <div *ngIf="!item.summary_fields.new" class="action list-pf-actions">
+                        <div *ngIf="!item.verified" class="btn btn-primary action-button" (click)="verifyEmail(item)">
+                            Resend Verification
+                        </div>
+                        <div *ngIf="item.verified" class="btn btn-primary action-button" disabled tooltip="Email already Verified">
+                            Resend Verification
+                        </div>
+                        <div *ngIf="!item.primary && item.verified" class="btn btn-primary action-button" (click)="setPrimary(item)">
+                            Make Primary
+                        </div>
+                        <div *ngIf="item.primary || !item.verified" class="btn btn-primary action-button" disabled tooltip="Already Primary">
+                            Make Primary
+                        </div>
+
+                        <app-email-action
+                            [email]="item"
+                            (handleAction)="handleEmailAction($event)"
+                        >
+
+                        </app-email-action>
+
+                    </div>
+
+                    <div *ngIf="item.summary_fields.new" class="action list-pf-actions">
+                        <div class="btn btn-primary action-button" (click)="saveEmail(item)">
+                            Save
+                        </div>
+
+                        <div class="btn btn-default action-button" (click)="cancelAddEmail(index)">
+                            Cancel
                         </div>
                     </div>
-                </div>
 
+                </ng-template>
+            </pfng-list>
 
-
-                <div *ngIf="!item.summary_fields.new" class="action list-pf-actions">
-                    <div *ngIf="!item.verified" class="btn btn-primary action-button" (click)="verifyEmail(item)">
-                        Resend Verification
-                    </div>
-                    <div *ngIf="item.verified" class="btn btn-primary action-button" disabled tooltip="Email already Verified">
-                        Resend Verification
-                    </div>
-                    <div *ngIf="!item.primary && item.verified" class="btn btn-primary action-button" (click)="setPrimary(item)">
-                        Make Primary
-                    </div>
-                    <div *ngIf="item.primary || !item.verified" class="btn btn-primary action-button" disabled tooltip="Already Primary">
-                        Make Primary
-                    </div>
-
-                    <app-email-action
-                        [email]="item"
-                        (handleAction)="handleEmailAction($event)"
-                    >
-
-                    </app-email-action>
-
-                </div>
-
-                <div *ngIf="item.summary_fields.new" class="action list-pf-actions">
-                    <div class="btn btn-primary action-button" (click)="saveEmail(item)">
-                        Save
-                    </div>
-
-                    <div class="btn btn-default action-button" (click)="cancelAddEmail(index)">
-                        Cancel
-                    </div>
-                </div>
-
-            </ng-template>
-        </pfng-list>
-
-        <div class="email-options">
-            <div (click)="addNewEmail()" class="btn btn-default"><span class="fa fa-plus"></span> Add Email</div>
+            <div class="email-options">
+                <div (click)="addNewEmail()" class="btn btn-default"><span class="fa fa-plus"></span> Add Email</div>
+            </div>
         </div>
-    </div>
-</pfng-card>
+    </pfng-card>
+</div>
 
-<pfng-card [config]="notificationsCard" id="notificationCard">
-    <div class="card-content">
-        Would you like to receive a notification when...
-        <div *ngFor="let item of notificationSettings" class="notification-settings">
-            <input type="checkbox" [(ngModel)]="preferences.preferences[item.key]" (click)="updateNotifications()">
-            {{ item.description }}
+<div class="row">
+    <pfng-card [config]="apiKeyCard" id="apiTokenCard" class="col-md-12">
+        <div class="card-content middle-align">
+            <div *ngIf="!apiKey" class="btn btn-primary" (click)="showApiKey()">Show API Key</div>
+            <div *ngIf="apiKey" class="btn btn-xs btn-default" (click)="resetApiKey()"><span class="fa fa-refresh"></span> Reset</div>
+            <div>
+                <pfng-inline-copy *ngIf="apiKey" [value]="apiKey" tooltipText="Copy API Key"></pfng-inline-copy>
+            </div>
         </div>
-    </div>
-</pfng-card>
+    </pfng-card>
+</div>
 
-<pfng-card [config]="apiKeyCard" id="apiTokenCard">
-    <div class="card-content middle-align">
-        <div *ngIf="!apiKey" class="btn btn-primary" (click)="showApiKey()">Show API Key</div>
-        <div *ngIf="apiKey" class="btn btn-xs btn-default" (click)="resetApiKey()"><span class="fa fa-refresh"></span> Reset</div>
-        <div>
-            <pfng-inline-copy *ngIf="apiKey" [value]="apiKey" tooltipText="Copy API Key"></pfng-inline-copy>
+<div class="row">
+    <pfng-card [config]="notificationsCard" id="notificationCard" class="col-md-12">
+        <div class="card-content">
+            Would you like to receive a notification when...
+            <div *ngFor="let item of notificationSettings" class="notification-settings">
+                <input type="checkbox" [(ngModel)]="preferences.preferences[item.key]" (click)="updateNotifications()">
+                {{ item.description }}
+            </div>
         </div>
-    </div>
-</pfng-card>
+    </pfng-card>
+</div>
+
+<div class="row" id="followersCards">
+    <pfng-card [config]="authorsFollowedCard" id="authorsFollowedCard" class="col-md-6">
+        <div class="card-content">
+            <pfng-list
+                [items]="followed.namespaces_followed"
+                [itemTemplate]="authorsFollowedListTemplate"
+                *ngIf="preferences"
+            >
+                <ng-template #authorsFollowedListTemplate let-item="item" let-index="index">
+                    <div class="list-pf-content-wrapper">
+                        <div class="list-pf-main-content">
+                            <div class="list-pf-title">
+                                <div [ngClass]="{'unfollowed': !item.hasFollowed}">
+                                    <div class="avatar-container">
+                                        <a [routerLink]="['/', item.name]">
+                                            <img class="avatar" src="{{ item.avatar }}" alt="">
+                                        </a>
+                                    </div>
+                                    <div class="name">
+                                        <a [routerLink]="['/', item.name]">
+                                            {{ item.name }}
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="list-pf-additional-content" [ngClass]="{'unfollowed': !item.hasFollowed}">
+                            {{ item.description }}
+                        </div>
+                        <div class="action list-pf-actions">
+                            <div class="action list-pf-actions">
+                                <div class="btn btn-default" (click)="followToggle('namespaces_followed', index)">
+                                    <span class="{{item.iconClass}}"></span> {{ item.hasFollowed ? 'Unfollow' : 'Follow'}}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </ng-template>
+            </pfng-list>
+        </div>
+    </pfng-card>
+
+    <pfng-card [config]="collectionsFollowedCard" id="collectionsFollowedCard" class="col-md-6">
+        <div class="card-content">
+            <pfng-list
+                [items]="followed.repositories_followed"
+                [itemTemplate]="collectionsFollowedListTemplate"
+                *ngIf="preferences"
+            >
+                <ng-template #collectionsFollowedListTemplate let-item="item" let-index="index">
+                    <div class="list-pf-content-wrapper">
+                        <div class="list-pf-main-content">
+                            <div class="list-pf-title">
+                                <div [ngClass]="{'unfollowed': !item.hasFollowed}">
+                                    <div class="avatar-container">
+                                        <a [routerLink]="['/', item.namespace]">
+                                            <img class="avatar" src="{{ item.avatar }}" alt="">
+                                        </a>
+                                    </div>
+                                    <div class="name">
+                                        <a [routerLink]="['/', item.namespace, item.name]">
+                                            {{ item.namespace }}.{{ item.name }}
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="list-pf-additional-content" [ngClass]="{'unfollowed': !item.hasFollowed}">
+                            {{ item.description }}
+                        </div>
+
+                        <div class="action list-pf-actions">
+                            <div class="btn btn-default" (click)="followToggle('repositories_followed', index)">
+                                <span class="{{item.iconClass}}"></span> {{ item.hasFollowed ? 'Unfollow' : 'Follow'}}
+                            </div>
+                        </div>
+                    </div>
+                </ng-template>
+            </pfng-list>
+        </div>
+    </pfng-card>
+</div>

--- a/galaxyui/src/app/preferences/preferences.component.html
+++ b/galaxyui/src/app/preferences/preferences.component.html
@@ -103,7 +103,7 @@
 </div>
 
 <div class="row" id="followersCards">
-    <pfng-card [config]="authorsFollowedCard" id="authorsFollowedCard" class="col-md-6">
+    <pfng-card [config]="authorsFollowedCard" id="authorsFollowedCard" class="col-lg-6">
         <div class="card-content">
             <pfng-list
                 [items]="followed.namespaces_followed"
@@ -111,15 +111,17 @@
                 *ngIf="preferences"
             >
                 <ng-template #authorsFollowedListTemplate let-item="item" let-index="index">
+                    <div class="list-pf-left">
+                        <div class="avatar-container" [ngClass]="{'unfollowed': !item.hasFollowed}">
+                            <a [routerLink]="['/', item.name]">
+                                <img class="avatar" src="{{ item.avatar }}" alt="">
+                            </a>
+                        </div>
+                    </div>
                     <div class="list-pf-content-wrapper">
                         <div class="list-pf-main-content">
                             <div class="list-pf-title">
                                 <div [ngClass]="{'unfollowed': !item.hasFollowed}">
-                                    <div class="avatar-container">
-                                        <a [routerLink]="['/', item.name]">
-                                            <img class="avatar" src="{{ item.avatar }}" alt="">
-                                        </a>
-                                    </div>
                                     <div class="name">
                                         <a [routerLink]="['/', item.name]">
                                             {{ item.name }}
@@ -144,7 +146,7 @@
         </div>
     </pfng-card>
 
-    <pfng-card [config]="collectionsFollowedCard" id="collectionsFollowedCard" class="col-md-6">
+    <pfng-card [config]="collectionsFollowedCard" id="collectionsFollowedCard" class="col-lg-6">
         <div class="card-content">
             <pfng-list
                 [items]="followed.repositories_followed"
@@ -152,15 +154,17 @@
                 *ngIf="preferences"
             >
                 <ng-template #collectionsFollowedListTemplate let-item="item" let-index="index">
+                    <div class="list-pf-left">
+                        <div class="avatar-container" [ngClass]="{'unfollowed': !item.hasFollowed}">
+                            <a [routerLink]="['/', item.name]">
+                                <img class="avatar" src="{{ item.avatar }}" alt="">
+                            </a>
+                        </div>
+                    </div>
                     <div class="list-pf-content-wrapper">
                         <div class="list-pf-main-content">
                             <div class="list-pf-title">
                                 <div [ngClass]="{'unfollowed': !item.hasFollowed}">
-                                    <div class="avatar-container">
-                                        <a [routerLink]="['/', item.namespace]">
-                                            <img class="avatar" src="{{ item.avatar }}" alt="">
-                                        </a>
-                                    </div>
                                     <div class="name">
                                         <a [routerLink]="['/', item.namespace, item.name]">
                                             {{ item.namespace }}.{{ item.name }}

--- a/galaxyui/src/app/preferences/preferences.component.less
+++ b/galaxyui/src/app/preferences/preferences.component.less
@@ -45,3 +45,29 @@
         align-items: center;
     }
 }
+
+#followersCards {
+    .avatar-container {
+        height: 50px;
+        width: 50px;
+        object-fit: contain;
+        display: inline-block;
+
+        .avatar {
+            height: 50px;
+        }
+    }
+
+    .name {
+        display: inline-block;
+        max-width: 180px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin-left: 10px;
+    }
+
+    .unfollowed {
+        opacity: 0.5;
+    }
+}

--- a/galaxyui/src/app/resources/preferences/user-preferences.ts
+++ b/galaxyui/src/app/resources/preferences/user-preferences.ts
@@ -8,6 +8,7 @@ export class UserPreferences {
         notify_galaxy_announce: boolean;
     };
 
-    namespaces_followed: any;
-    repositories_followed: any;
+    namespaces_followed: number[];
+    repositories_followed: number[];
+    summary_fields: any;
 }


### PR DESCRIPTION
This adds a list of followed collections and authors to the user preferences page with the goal of making a user's subscriptions easier to handle.

Followed items on the preferences pages:
![screen shot 2018-10-22 at 4 49 12 pm](https://user-images.githubusercontent.com/6063371/47318748-dec8de80-d61a-11e8-8dec-91dc03bb44a0.png)

Unfollowing an item greys it out and gives the user the chance to undo and re-follow until they navigate away from the preferences page.
![screen shot 2018-10-22 at 4 49 31 pm](https://user-images.githubusercontent.com/6063371/47318747-dec8de80-d61a-11e8-8f6b-1eea902366e4.png)
