### PR TITLE
Use MIDDLEWARE instead of MIDDLEWARE_CLASSES

### DIFF
--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -80,7 +80,7 @@ INSTALLED_APPS = (
 
 # FIXME(cutwater): Deprecated from Django 1.10, use MIDDLEWARE setting
 # instead.
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = [
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'log_request_id.middleware.RequestIDMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -90,7 +90,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django_prometheus.middleware.PrometheusAfterMiddleware',
-)
+]
 
 ROOT_URLCONF = 'galaxy.urls'
 

--- a/galaxy/settings/development.py
+++ b/galaxy/settings/development.py
@@ -37,9 +37,9 @@ INSTALLED_APPS += (  # noqa: F405
     'debug_toolbar',
 )
 
-MIDDLEWARE_CLASSES += (  # noqa: F405
+MIDDLEWARE += [  # noqa: F405
     'debug_toolbar.middleware.DebugToolbarMiddleware',
-)
+]
 
 # Database
 # ---------------------------------------------------------


### PR DESCRIPTION
MIDDLEWARE_CLASSES setting is deprecated since Django 1.10 and
was removed in Django 2.0.