### PR TITLE
Fix querying using string parameters.

### DIFF
--- a/galaxyui/src/app/resources/base/generic-query.ts
+++ b/galaxyui/src/app/resources/base/generic-query.ts
@@ -25,13 +25,13 @@ export class GenericQuery<ServiceType> extends ServiceBase {
         let objectParams = null;
         if (params) {
             if (typeof params === 'string') {
-                objectUrl += `?${params}`;
+                objectUrl += `/?${params}`;
             } else {
                 objectParams = params;
             }
         }
         return this.http
-            .get<PagedResponse>(objectUrl + '/', { params: objectParams })
+            .get<PagedResponse>(objectUrl, { params: objectParams })
             .pipe(
                 map(response => response.results),
                 tap(_ => this.log(`fetched ${this.serviceName}`)),


### PR DESCRIPTION
The GenericQuery service was incorrectly generating urls with a `/` appended to the end which was causing some queries (ie galaxy.ansible.com/api/v1/users/?or__username__icontains=newswan/) to return nothing.

Fixes #1225