### PR TITLE
Change the preferences path to /me/preferences

### DIFF
--- a/galaxy/main/celerytasks/user_notifications.py
+++ b/galaxy/main/celerytasks/user_notifications.py
@@ -50,7 +50,7 @@ class NotificationManger(object):
     def render_email(self, context):
         text = self.email_template.format(**context)
         footer = email_footer_template.format(
-            preferences_link='{}/preferences/'.format(self.url)
+            preferences_link='{}/me/preferences/'.format(self.url)
         )
 
         return text + footer

--- a/galaxy/templates/account/email/email_confirmation_message.txt
+++ b/galaxy/templates/account/email/email_confirmation_message.txt
@@ -2,7 +2,7 @@
 
 You're receiving this e-mail because user {{ user_display }} has given yours as an e-mail address to connect their account.
 
-To confirm this is correct, go to {{ current_site }}/preferences/?verify={{ key }}
+To confirm this is correct, go to {{ current_site }}/me/preferences/?verify={{ key }}
 {% endblocktrans %}{% endautoescape %}
 {% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Thank you from {{ site_name }}!
 {{ site_domain }}{% endblocktrans %}

--- a/galaxyui/src/app/app.component.html
+++ b/galaxyui/src/app/app.component.html
@@ -55,7 +55,7 @@
                         <span class="fa fa-user"></span> {{ username }} <span class="caret"></span>
                     </a>
                     <ul *dropdownMenu class="dropdown-menu" aria-labelledby="dropdownMenu2">
-                        <li><a appLogEvent routerLink="/preferences">Preferences</a></li>
+                        <li><a appLogEvent routerLink="/me/preferences">Preferences</a></li>
                         <li><a [routerLink]="" (click)="logout()">Logout</a></li>
                     </ul>
                 </li>

--- a/galaxyui/src/app/preferences/preferences.component.ts
+++ b/galaxyui/src/app/preferences/preferences.component.ts
@@ -51,7 +51,7 @@ export class PreferencesComponent implements OnInit {
         this.authService.me().subscribe(me => {
             if (!me.authenticated) {
                 this.router.navigate(['/', 'login'], {
-                    queryParams: { next: '/preferences' },
+                    queryParams: { next: '/me/preferences' },
                 });
             } else {
                 this.userId = me.id;

--- a/galaxyui/src/app/preferences/preferences.routing.module.ts
+++ b/galaxyui/src/app/preferences/preferences.routing.module.ts
@@ -6,7 +6,7 @@ import { PreferencesComponent } from './preferences.component';
 
 const preferencesRoutes: Routes = [
     {
-        path: 'preferences',
+        path: 'me/preferences',
         component: PreferencesComponent,
     },
 ];


### PR DESCRIPTION
Most galaxy paths are dynamically created as `galaxy.ansible.com/{namespace}/{content}`. This means that whenever we create a static route on galaxy such as `galaxy.ansible.com/my-content` there is a potential for collisions with dynamic namespaces. To minimize the potential of namespace/path collisions we can reduce the number of static routes by putting all user related routes under the `/me` path. 