### PR TITLE
Renamed ui quality piece to syntax score (#1256)

### DIFF
--- a/galaxyui/src/app/content-detail/cards/quality-details/quality-details.component.html
+++ b/galaxyui/src/app/content-detail/cards/quality-details/quality-details.component.html
@@ -1,7 +1,7 @@
 <div class="details-expanded">
     <div>
         <div class="title">
-            Content Score:
+            Syntax Score:
         </div>
         <div class="score">
             {{ content.content_score }}


### PR DESCRIPTION
Backport: #1256 

(cherry picked from commit 46c8cd691d2a795fbf42a63ada484511ffb0bc54)