### PR TITLE
Fix comparing dict repr in unit tests

### DIFF
--- a/galaxy/accounts/tests/test_custom_user_model.py
+++ b/galaxy/accounts/tests/test_custom_user_model.py
@@ -154,9 +154,9 @@ class CustomUserModelTest(TestCase):
                 password=self.VALID_PASSWORD,
                 email=self.VALID_EMAIL).full_clean()
 
-        assert str(excinfo.value) == (
-            "{'username': [u'This field cannot be blank.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'username': ['This field cannot be blank.']
+        }
 
         with pytest.raises(ValidationError) as excinfo:
             CustomUser(
@@ -165,9 +165,9 @@ class CustomUserModelTest(TestCase):
                 email=self.VALID_EMAIL
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{'username': [u'Enter a valid username.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'username': ['Enter a valid username.']
+        }
 
         with pytest.raises(ValidationError) as excinfo:
             CustomUser(
@@ -176,9 +176,9 @@ class CustomUserModelTest(TestCase):
                 email=self.VALID_EMAIL
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{'username': [u'Enter a valid username.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'username': ['Enter a valid username.']
+        }
 
         with pytest.raises(ValidationError) as excinfo:
             CustomUser(
@@ -187,30 +187,31 @@ class CustomUserModelTest(TestCase):
                 email=self.VALID_EMAIL
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{'username': [u'Enter a valid username.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'username': ['Enter a valid username.']
+        }
 
         with pytest.raises(ValidationError) as excinfo:
             CustomUser(
-                username=u'юникод',
+                username='юникод',
                 password=self.VALID_PASSWORD,
                 email=self.VALID_EMAIL
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{'username': [u'Enter a valid username.']}")
+        assert excinfo.value.message_dict == {
+            'username': ['Enter a valid username.']
+        }
 
         with pytest.raises(ValidationError) as excinfo:
             CustomUser(
-                username=u'юникод',
+                username='юникод',
                 password=self.VALID_PASSWORD,
                 email=self.VALID_EMAIL
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{'username': [u'Enter a valid username.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'username': ['Enter a valid username.']
+        }
 
     @pytest.mark.database_integrity
     def test_full_name_length_is_limited_in_db(self):
@@ -247,13 +248,14 @@ class CustomUserModelTest(TestCase):
                 full_name='*' * (self.EMAIL_MAX_LENGTH + 1)
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{{'full_name': [u'Ensure this value has at most {valid} "
-            "characters (it has {given}).']}}"
-        ).format(
-            valid=self.FULL_NAME_MAX_LENGTH,
-            given=self.FULL_NAME_MAX_LENGTH + 1
-        )
+        assert excinfo.value.message_dict == {
+            'full_name': [
+                'Ensure this value has at most {valid} '
+                'characters (it has {given}).'.format(
+                    valid=self.FULL_NAME_MAX_LENGTH,
+                    given=self.FULL_NAME_MAX_LENGTH + 1)
+            ]
+        }
 
     @pytest.mark.database_integrity
     def test_short_name_length_is_limited_in_db(self):

--- a/galaxy/common/tests/test_version.py
+++ b/galaxy/common/tests/test_version.py
@@ -31,25 +31,25 @@ class TestGetVersion(unittest.TestCase):
             'subprocess.check_output').start()
 
     def test_release_version(self):
-        self.git_describe_mock.return_value = 'v1.0.0'
+        self.git_describe_mock.return_value = b'v1.0.0'
         version_ = version.get_git_version()
         self.assertEqual(version_, '1.0.0')
 
-        self.git_describe_mock.return_value = 'v2.3rc0'
+        self.git_describe_mock.return_value = b'v2.3rc0'
         version_ = version.get_git_version()
         self.assertEqual(version_, '2.3rc0')
 
     def test_dev_version(self):
-        self.git_describe_mock.return_value = 'v1.0.0'
+        self.git_describe_mock.return_value = b'v1.0.0'
         version_ = version.get_git_version()
         self.assertEqual(version_, '1.0.0')
 
-        self.git_describe_mock.return_value = 'v2.3rc0'
+        self.git_describe_mock.return_value = b'v2.3rc0'
         version_ = version.get_git_version()
         self.assertEqual(version_, '2.3rc0')
 
     def test_no_git_tag_fallback(self):
-        self.git_describe_mock.return_value = 'ef14bf1'
+        self.git_describe_mock.return_value = b'ef14bf1'
         self.assertEqual(version.get_git_version(),
                          '0.0.0.dev0+ef14bf1')
         self.git_describe_mock.assert_called_once()
@@ -62,7 +62,7 @@ class TestGetVersion(unittest.TestCase):
     def test_package_version_fallback(self):
         self.get_distribution_mock.side_effect = \
             pkg_resources.DistributionNotFound()
-        self.git_describe_mock.return_value = '1.0.0'
+        self.git_describe_mock.return_value = b'1.0.0'
 
         self.assertEqual(version.get_package_version('test'), '1.0.0')
         self.git_describe_mock.assert_called_once()

--- a/galaxy/main/tests/test_category_model.py
+++ b/galaxy/main/tests/test_category_model.py
@@ -64,9 +64,9 @@ class CategoryModelTest(TestCase):
         with pytest.raises(ValidationError) as excinfo:
             Category().full_clean()
 
-        assert str(excinfo.value) == (
-            "{'name': [u'This field cannot be blank.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'name': ['This field cannot be blank.']
+        }
 
     @pytest.mark.database_integrity
     def test_name_must_be_unique_in_db(self):
@@ -104,13 +104,15 @@ class CategoryModelTest(TestCase):
         with pytest.raises(ValidationError) as excinfo:
             Category(name='*' * (self.NAME_MAX_LENGTH + 1)).full_clean()
 
-        assert str(excinfo.value) == (
-            "{{'name': [u'Ensure this value has at most {valid} "
-            "characters (it has {current}).']}}"
-        ).format(
-            valid=self.NAME_MAX_LENGTH,
-            current=self.NAME_MAX_LENGTH + 1
-        )
+        assert excinfo.value.message_dict == {
+            'name': [
+                'Ensure this value has at most {valid} '
+                'characters (it has {current}).'.format(
+                    valid=self.NAME_MAX_LENGTH,
+                    current=self.NAME_MAX_LENGTH + 1
+                )
+            ]
+        }
 
     # testing custom methods
 

--- a/galaxy/main/tests/test_cloud_platform_model.py
+++ b/galaxy/main/tests/test_cloud_platform_model.py
@@ -63,9 +63,9 @@ class CloudPlatformModelTest(TestCase):
 
         with pytest.raises(ValidationError) as excinfo:
             CloudPlatform().full_clean()
-        assert str(excinfo.value) == (
-            "{'name': [u'This field cannot be blank.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'name': ['This field cannot be blank.']
+        }
 
     @pytest.mark.database_integrity
     def test_name_must_be_unique_in_db(self):
@@ -105,13 +105,14 @@ class CloudPlatformModelTest(TestCase):
         with pytest.raises(ValidationError) as excinfo:
             CloudPlatform(name='*' * (self.NAME_MAX_LENGTH + 1)).full_clean()
 
-        assert str(excinfo.value) == (
-            "{{'name': [u'Ensure this value has at most {valid} "
-            "characters (it has {given}).']}}"
-        ).format(
-            valid=self.NAME_MAX_LENGTH,
-            given=self.NAME_MAX_LENGTH + 1
-        )
+        assert excinfo.value.message_dict == {
+            'name': [
+                'Ensure this value has at most {valid} characters '
+                '(it has {given}).'.format(
+                    valid=self.NAME_MAX_LENGTH,
+                    given=self.NAME_MAX_LENGTH + 1)
+             ]
+        }
 
     # testing custom methods
 

--- a/galaxy/main/tests/test_content_block_model.py
+++ b/galaxy/main/tests/test_content_block_model.py
@@ -68,9 +68,9 @@ class ContentBlockModelTest(TestCase):
         with pytest.raises(ValidationError) as excinfo:
             ContentBlock().full_clean()
 
-        assert str(excinfo.value) == (
-            "{'name': [u'This field cannot be blank.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'name': ['This field cannot be blank.']
+        }
 
     @pytest.mark.database_integrity
     def test_name_must_be_unique_in_db(self):
@@ -113,17 +113,15 @@ class ContentBlockModelTest(TestCase):
         with pytest.raises(ValidationError) as excinfo:
             ContentBlock(name='a' * (self.NAME_MAX_LENGTH + 1)).full_clean()
 
-        assert str(excinfo.value) == str({
+        assert excinfo.value.message_dict == {
             "name": [
-                (
-                    u"Ensure this value has at most {valid} characters "
-                    "(it has {given})."
-                ).format(
+                "Ensure this value has at most {valid} characters "
+                "(it has {given}).".format(
                     valid=self.NAME_MAX_LENGTH,
                     given=self.NAME_MAX_LENGTH + 1
                 )
             ]
-        })
+        }
 
     @pytest.mark.model_fields_validation
     def test_name_must_be_slug(self):
@@ -139,22 +137,22 @@ class ContentBlockModelTest(TestCase):
         with pytest.raises(ValidationError) as excinfo:
             ContentBlock(name='with spaces').full_clean()
 
-        assert str(excinfo.value) == str({
+        assert excinfo.value.message_dict == {
             "name": [
-                u"Enter a valid 'slug' consisting of letters, "
+                "Enter a valid 'slug' consisting of letters, "
                 "numbers, underscores or hyphens."
             ]
-        })
+        }
 
         with pytest.raises(ValidationError) as excinfo:
             ContentBlock(name='with spaces').full_clean()
 
-        assert str(excinfo.value) == str({
+        assert excinfo.value.message_dict == {
             "name": [
-                u"Enter a valid 'slug' consisting of letters, "
+                "Enter a valid 'slug' consisting of letters, "
                 "numbers, underscores or hyphens."
             ]
-        })
+        }
 
     @pytest.mark.model_fields_validation
     def test_content_is_unlimited(self):

--- a/galaxy/main/tests/test_content_type_model.py
+++ b/galaxy/main/tests/test_content_type_model.py
@@ -69,14 +69,12 @@ class ContentTypeModelTest(TestCase):
         with pytest.raises(ValidationError) as excinfo:
             ContentType().full_clean()
 
-        assert str(excinfo.value) == (
-            "{'name': [u'This field cannot be blank.']}"
-        )
-        assert str(excinfo.value) == str({
-            "name": [
-                u"This field cannot be blank."
-            ]
-        })
+        assert excinfo.value.message_dict == {
+            'name': ['This field cannot be blank.']
+        }
+        assert excinfo.value.message_dict == {
+            "name": ["This field cannot be blank."]
+        }
 
     @pytest.mark.database_integrity
     def test_name_must_be_unique_in_db(self):
@@ -122,15 +120,12 @@ class ContentTypeModelTest(TestCase):
         with pytest.raises(ValidationError) as excinfo:
             ContentType(name=invald_name).full_clean()
 
-        assert str(excinfo.value) == str({
+        assert excinfo.value.message_dict == {
             "name": [
-                (
-                    u"Value \'{given}\' is not a valid choice."
-                ).format(
-                    given=invald_name
-                )
+                "Value '{given}' is not a valid choice.".format(
+                    given=invald_name)
             ]
-        })
+        }
 
     @pytest.mark.model_fields_validation
     def test_description_is_not_required(self):
@@ -186,17 +181,15 @@ class ContentTypeModelTest(TestCase):
                 description='a' * (self.DESCRIPTION_MAX_LENGTH + 1)
             ).full_clean()
 
-        assert str(excinfo.value) == str({
+        assert excinfo.value.message_dict == {
             "description": [
-                (
-                    u"Ensure this value has at most {valid} characters "
-                    "(it has {given})."
-                ).format(
+                "Ensure this value has at most {valid} characters "
+                "(it has {given}).".format(
                     valid=self.DESCRIPTION_MAX_LENGTH,
                     given=self.DESCRIPTION_MAX_LENGTH + 1
                 )
             ]
-        })
+        }
 
     # testing custom methods
 

--- a/galaxy/main/tests/test_platform_model.py
+++ b/galaxy/main/tests/test_platform_model.py
@@ -71,10 +71,10 @@ class PlatformModelTest(TestCase):
         with pytest.raises(ValidationError) as excinfo:
             Platform().full_clean()
 
-        assert str(excinfo.value) == (
-            "{'release': [u'This field cannot be blank.'], "
-            "'name': [u'This field cannot be blank.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'release': ['This field cannot be blank.'],
+            'name': ['This field cannot be blank.']
+        }
 
     # FIXME: This behaviour looks like a bug
     @pytest.mark.database_integrity
@@ -124,13 +124,15 @@ class PlatformModelTest(TestCase):
                 release=self.VALID_RELEASE
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{{'name': [u'Ensure this value has at most {valid} "
-            "characters (it has {given}).']}}"
-        ).format(
-            valid=self.NAME_MAX_LENGTH,
-            given=self.NAME_MAX_LENGTH + 1
-        )
+        assert excinfo.value.message_dict == {
+            'name': [
+                'Ensure this value has at most {valid} '
+                'characters (it has {given}).'.format(
+                    valid=self.NAME_MAX_LENGTH,
+                    given=self.NAME_MAX_LENGTH + 1
+                )
+            ]
+        }
 
     @pytest.mark.database_integrity
     def test_release_length_is_limited_in_db(self):
@@ -163,13 +165,15 @@ class PlatformModelTest(TestCase):
             Platform(
                 name=self.VALID_NAME,
                 release='*' * (self.RELEASE_MAX_LENGTH + 1)).full_clean()
-        assert str(excinfo.value) == (
-            "{{'release': [u'Ensure this value has at most {valid} "
-            "characters (it has {given}).']}}"
-        ).format(
-            valid=self.RELEASE_MAX_LENGTH,
-            given=self.RELEASE_MAX_LENGTH + 1
-        )
+        assert excinfo.value.message_dict == {
+            'release': [
+                "Ensure this value has at most {valid} "
+                "characters (it has {given}).".format(
+                    valid=self.RELEASE_MAX_LENGTH,
+                    given=self.RELEASE_MAX_LENGTH + 1
+                )
+            ]
+        }
 
     @pytest.mark.database_integrity
     def test_alias_length_is_limited_in_db(self):
@@ -206,13 +210,15 @@ class PlatformModelTest(TestCase):
                 name=self.VALID_NAME,
                 release=self.VALID_RELEASE,
                 alias='*' * (self.ALIAS_MAX_LENGTH + 1)).full_clean()
-        assert str(excinfo.value) == (
-            "{{'alias': [u'Ensure this value has at most {valid} "
-            "characters (it has {given}).']}}"
-        ).format(
-            valid=self.ALIAS_MAX_LENGTH,
-            given=self.ALIAS_MAX_LENGTH + 1
-        )
+        assert excinfo.value.message_dict == {
+            'alias': [
+                'Ensure this value has at most {valid} '
+                'characters (it has {given}).'.format(
+                    valid=self.ALIAS_MAX_LENGTH,
+                    given=self.ALIAS_MAX_LENGTH + 1
+                )
+            ]
+        }
 
     # testing custom methods
 

--- a/galaxy/main/tests/test_provider_model.py
+++ b/galaxy/main/tests/test_provider_model.py
@@ -73,9 +73,9 @@ class ProviderModelTest(TestCase):
                 download_url=self.VALID_DOWNLOAD_URL
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{'name': [u'This field cannot be blank.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'name': ['This field cannot be blank.']
+        }
 
     @pytest.mark.database_integrity
     def test_name_must_be_unique_in_db(self):
@@ -138,13 +138,15 @@ class ProviderModelTest(TestCase):
                 download_url=self.VALID_DOWNLOAD_URL
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{{'name': [u'Ensure this value has at most {valid} "
-            "characters (it has {current}).']}}"
-        ).format(
-            valid=self.NAME_MAX_LENGTH,
-            current=self.NAME_MAX_LENGTH + 1
-        )
+        assert excinfo.value.message_dict == {
+            'name': [
+                'Ensure this value has at most {valid} '
+                'characters (it has {current}).'.format(
+                    valid=self.NAME_MAX_LENGTH,
+                    current=self.NAME_MAX_LENGTH + 1
+                )
+            ]
+        }
 
     @pytest.mark.model_fields_validation
     def test_name_is_not_validated(self):
@@ -186,13 +188,15 @@ class ProviderModelTest(TestCase):
                 download_url='*' * (self.DOWNLOAD_URL_MAX_LENGTH + 1)
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{{'download_url': [u'Ensure this value has at most {valid} "
-            "characters (it has {current}).']}}"
-        ).format(
-            valid=self.DOWNLOAD_URL_MAX_LENGTH,
-            current=self.DOWNLOAD_URL_MAX_LENGTH + 1
-        )
+        assert excinfo.value.message_dict == {
+            'download_url': [
+                'Ensure this value has at most {valid} '
+                'characters (it has {current}).'.format(
+                    valid=self.DOWNLOAD_URL_MAX_LENGTH,
+                    current=self.DOWNLOAD_URL_MAX_LENGTH + 1
+                )
+            ]
+        }
 
     @pytest.mark.model_fields_validation
     def test_download_url_is_not_validated(self):

--- a/galaxy/main/tests/test_subscription_model.py
+++ b/galaxy/main/tests/test_subscription_model.py
@@ -105,9 +105,9 @@ class SubscriptionModelTest(TestCase):
                 github_user=self.VALID_GITHUB_USER
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{'owner': [u'This field cannot be null.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'owner': ['This field cannot be null.']
+        }
 
     @pytest.mark.model_fields_validation
     def test_github_user_is_required(self):
@@ -124,9 +124,9 @@ class SubscriptionModelTest(TestCase):
                 github_repo=self.VALID_GITHUB_REPO,
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{'github_user': [u'This field cannot be blank.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'github_user': ['This field cannot be blank.']
+        }
 
     @pytest.mark.model_fields_validation
     def test_github_user_length_is_limited(self):
@@ -144,13 +144,15 @@ class SubscriptionModelTest(TestCase):
                 github_user='A' * (self.GITHUB_USER_MAX_LENGTH + 1)
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{{'github_user': [u'Ensure this value has at most {valid} "
-            "characters (it has {current}).']}}"
-        ).format(
-            valid=self.GITHUB_USER_MAX_LENGTH,
-            current=self.GITHUB_USER_MAX_LENGTH + 1
-        )
+        assert excinfo.value.message_dict == {
+            'github_user': [
+                'Ensure this value has at most {valid} '
+                'characters (it has {current}).'.format(
+                    valid=self.GITHUB_USER_MAX_LENGTH,
+                    current=self.GITHUB_USER_MAX_LENGTH + 1
+                )
+            ]
+        }
 
     @pytest.mark.database_integrity
     def test_github_user_length_is_limited_in_db(self):
@@ -187,9 +189,9 @@ class SubscriptionModelTest(TestCase):
                 github_user=self.VALID_GITHUB_USER
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{'github_repo': [u'This field cannot be blank.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'github_repo': ['This field cannot be blank.']
+        }
 
     @pytest.mark.model_fields_validation
     def test_github_repo_length_is_limited(self):
@@ -207,13 +209,15 @@ class SubscriptionModelTest(TestCase):
                 github_user=self.VALID_GITHUB_USER,
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{{'github_repo': [u'Ensure this value has at most {valid} "
-            "characters (it has {current}).']}}"
-        ).format(
-            valid=self.GITHUB_REPO_MAX_LENGTH,
-            current=self.GITHUB_REPO_MAX_LENGTH + 1
-        )
+        assert excinfo.value.message_dict == {
+            'github_repo': [
+                'Ensure this value has at most {valid} '
+                'characters (it has {current}).'.format(
+                    valid=self.GITHUB_REPO_MAX_LENGTH,
+                    current=self.GITHUB_REPO_MAX_LENGTH + 1
+                )
+            ]
+        }
 
     @pytest.mark.database_integrity
     def test_github_repo_length_is_limited_in_db(self):

--- a/galaxy/main/tests/test_tag_model.py
+++ b/galaxy/main/tests/test_tag_model.py
@@ -64,9 +64,9 @@ class TagModelTest(TestCase):
         with pytest.raises(ValidationError) as excinfo:
             Tag().full_clean()
 
-        assert str(excinfo.value) == (
-            "{'name': [u'This field cannot be blank.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'name': ['This field cannot be blank.']
+        }
 
     @pytest.mark.database_integrity
     def test_name_must_be_unique_in_db(self):
@@ -108,13 +108,15 @@ class TagModelTest(TestCase):
         with pytest.raises(ValidationError) as excinfo:
             Tag(name='*' * (self.NAME_MAX_LENGTH + 1)).full_clean()
 
-        assert str(excinfo.value) == (
-            "{{'name': [u'Ensure this value has at most {valid} "
-            "characters (it has {given}).']}}"
-        ).format(
-            valid=self.NAME_MAX_LENGTH,
-            given=self.NAME_MAX_LENGTH + 1
-        )
+        assert excinfo.value.message_dict == {
+            'name': [
+                'Ensure this value has at most {valid} '
+                'characters (it has {given}).'.format(
+                    valid=self.NAME_MAX_LENGTH,
+                    given=self.NAME_MAX_LENGTH + 1
+                )
+            ]
+        }
 
     # testing custom methods
 

--- a/galaxy/main/tests/test_user_alias_model.py
+++ b/galaxy/main/tests/test_user_alias_model.py
@@ -71,9 +71,9 @@ class UserAliasModelTest(TestCase):
                 alias_of=self.default_user
             ).full_clean()
 
-        assert str(excinfo.value) == (
-            "{'alias_name': [u'This field cannot be blank.']}"
-        )
+        assert excinfo.value.message_dict == {
+            'alias_name': ['This field cannot be blank.']
+        }
 
     @pytest.mark.skip
     @pytest.mark.database_integrity


### PR DESCRIPTION
* Eliminates problem with u'' prefix in Python 3.
* Removes dependency on dict items order.