### PR TITLE
Fix BaseException.message attribute removed

### DIFF
--- a/galaxy/api/views/namespace.py
+++ b/galaxy/api/views/namespace.py
@@ -161,7 +161,7 @@ def update_provider_namespaces(namespace, provider_namespaces):
             except Exception as exc:
                 raise APIException(
                     'Error creating or updating provider namespaces: {}'
-                    .format(exc.message)
+                    .format(exc)
                 )
     # Disassociate provider namespaces not in the list
     for id in [
@@ -258,7 +258,7 @@ class NamespaceList(base_views.ListCreateAPIView):
             namespace = models.Namespace.objects.create(**namespace_attributes)
         except Exception as exc:
             raise APIException(
-                'Error creating namespace: {0}'.format(exc.message)
+                'Error creating namespace: {0}'.format(exc)
             )
 
         update_owners(namespace, owners)

--- a/galaxy/api/views/notification.py
+++ b/galaxy/api/views/notification.py
@@ -298,7 +298,7 @@ class NotificationList(base_views.ListCreateAPIView):
             raise APIException(msg)
         except requests.RequestException as e:
             msg = '{0}: Failed to retrieve public key for {1}: {2}'.format(
-                notification_error, travis_host, e.message)
+                notification_error, travis_host, e)
             logger.error(msg)
             raise APIException(msg)
         try:

--- a/galaxy/api/views/repository.py
+++ b/galaxy/api/views/repository.py
@@ -142,7 +142,7 @@ class RepositoryList(views.ListCreateAPIView):
             repository = models.Repository.objects.create(**data)
         except Exception as exc:
             raise APIException('Error creating repository: {0}'
-                               .format(exc.message))
+                               .format(exc))
 
         for owner_pk in owners:
             try:
@@ -222,8 +222,7 @@ class RepositoryDetail(views.RetrieveUpdateDestroyAPIView):
                     updated.append(k)
             instance.save()
         except Exception as exc:
-            raise APIException('Error updating repository: {0}'
-                               .format(exc.message))
+            raise APIException('Error updating repository: {0}'.format(exc))
 
         for owner_pk in owners:
             try:

--- a/galaxy/api/views/views.py
+++ b/galaxy/api/views/views.py
@@ -979,13 +979,13 @@ class RefreshUserRepos(base_views.APIView):
         try:
             celerytasks.refresh_existing_user_repos(token.token, ghu)
         except Exception as exc:
-            logger.error("Error: refresh_user_repos - {0}".format(exc.message))
+            logger.error("Error: refresh_user_repos - {0}".format(exc))
             raise
 
         try:
             celerytasks.update_user_repos(user_repos, request.user)
         except Exception as exc:
-            logger.error("Error: update_user_repos - {0}".format(exc.message))
+            logger.error("Error: update_user_repos - {0}".format(exc))
             raise
 
         qs = request.user.repositories.all()

--- a/galaxy/importer/tests/test_apb_loader.py
+++ b/galaxy/importer/tests/test_apb_loader.py
@@ -261,7 +261,7 @@ class TestAPBMetaParser(unittest.TestCase):
         with pytest.raises(exc.APBContentLoadError) as excinfo:
             parser.check_data()
         msg = 'Expecting "metadata" in metadata to be a dictionary'
-        assert msg in excinfo.value.message
+        assert msg in str(excinfo.value)
 
     def test_invalid_bindable(self):
         self.data['bindable'] = 'foo'
@@ -269,7 +269,7 @@ class TestAPBMetaParser(unittest.TestCase):
         with pytest.raises(exc.APBContentLoadError) as excinfo:
             parser.check_data()
         msg = 'Expecting "bindable" in metadata to be a boolean'
-        assert msg in excinfo.value.message
+        assert msg in str(excinfo.value)
 
     def test_invalid_plans(self):
         self.data['plans'] = 'foo'
@@ -277,7 +277,7 @@ class TestAPBMetaParser(unittest.TestCase):
         with pytest.raises(exc.APBContentLoadError) as excinfo:
             parser.check_data()
         msg = 'Expecting "plans" in metadata to be a list'
-        assert msg in excinfo.value.message
+        assert msg in str(excinfo.value)
 
     def test_invalid_plan_name(self):
         del self.data['plans'][0]['name']
@@ -285,7 +285,7 @@ class TestAPBMetaParser(unittest.TestCase):
         with pytest.raises(exc.APBContentLoadError) as excinfo:
             parser.check_data()
         msg = 'Expecting "name" to be defined for each plan'
-        assert msg in excinfo.value.message
+        assert msg in str(excinfo.value)
 
     def test_plan_parameters_type(self):
         self.data['plans'][0]['parameters'] = 'foo'
@@ -293,7 +293,7 @@ class TestAPBMetaParser(unittest.TestCase):
         with pytest.raises(exc.APBContentLoadError) as excinfo:
             parser.check_data()
         msg = 'Expecting "parameters" in "plans[0]" of'
-        assert msg in excinfo.value.message
+        assert msg in str(excinfo.value)
 
     def test_plan_parameters_item_type(self):
         self.data['plans'][0]['parameters'] = ['foo']
@@ -301,7 +301,7 @@ class TestAPBMetaParser(unittest.TestCase):
         with pytest.raises(exc.APBContentLoadError) as excinfo:
             parser.check_data()
         msg = 'Expecting "parameters[0]" in "plans[0]" of'
-        assert msg in excinfo.value.message
+        assert msg in str(excinfo.value)
 
     def test_missing_async(self):
         del self.data['async']
@@ -309,7 +309,7 @@ class TestAPBMetaParser(unittest.TestCase):
         with pytest.raises(exc.APBContentLoadError) as excinfo:
             parser.check_data()
         msg = 'Missing "async" field in metadata.'
-        assert msg in excinfo.value.message
+        assert msg in str(excinfo.value)
 
     def test_async_bad_value(self):
         self.data['async'] = 'foo'
@@ -317,7 +317,7 @@ class TestAPBMetaParser(unittest.TestCase):
         with pytest.raises(exc.APBContentLoadError) as excinfo:
             parser.check_data()
         msg = 'Expecting "async" in metadata to be one of'
-        assert msg in excinfo.value.message
+        assert msg in str(excinfo.value)
 
     def test_missing_version(self):
         del self.data['version']
@@ -325,7 +325,7 @@ class TestAPBMetaParser(unittest.TestCase):
         with pytest.raises(exc.APBContentLoadError) as excinfo:
             parser.check_data()
         msg = 'Missing "version" field in metadata.'
-        assert msg in excinfo.value.message
+        assert msg in str(excinfo.value)
 
     def test_param_keys(self):
         parser = apb_loader.APBMetaParser(self.data, self.log)

--- a/galaxy/main/celerytasks/tasks.py
+++ b/galaxy/main/celerytasks/tasks.py
@@ -110,7 +110,7 @@ def refresh_existing_user_repos(token, github_user):
                 db_repo.save()
         except Exception as e:
             LOG.error(u"Error: refresh_existing_user_repos {0} - {1}"
-                      .format(old_name, e.message))
+                      .format(old_name, e))
     LOG.info("Finished refresh_existing_user_repos for GitHub user {0}"
              .format(github_user.login))
 


### PR DESCRIPTION
BaseExcepption.message attribute is deprecated since python 2.6
and was removed in python 3.