### PR TITLE
Move search metadata from influxdb tags to fields.

### DIFF
--- a/galaxy/api/serializers/influx.py
+++ b/galaxy/api/serializers/influx.py
@@ -132,7 +132,9 @@ class PageLoadMeasurementSerializer(BaseMeasurement):
 
 # Search
 class SearchQueryMeasurementSerializer(BaseMeasurement):
-    class Tags(BaseTags):
+    # This doen't use any tags becase the number of possible combinations of
+    # search parameters exceeds influxdb's ability to index them
+    class Fields(BaseFields):
         cloud_platforms = drf_serializers.CharField(
             required=False, allow_blank=True
         )
@@ -145,8 +147,6 @@ class SearchQueryMeasurementSerializer(BaseMeasurement):
         platforms = drf_serializers.CharField(required=False, allow_blank=True)
         tags = drf_serializers.CharField(required=False, allow_blank=True)
         order_by = drf_serializers.CharField(required=False, allow_blank=True)
-
-    class Fields(BaseFields):
         keywords = drf_serializers.CharField(required=False, allow_blank=True)
         namespaces = drf_serializers.CharField(
             required=False,
@@ -154,12 +154,13 @@ class SearchQueryMeasurementSerializer(BaseMeasurement):
         )
         number_of_results = drf_serializers.IntegerField()
 
-    tags = Tags()
     fields = Fields()
 
 
 class SearchLinkMeasurementSerializer(BaseMeasurement):
-    class Tags(BaseTags):
+    # This doen't use any tags becase the number of possible combinations of
+    # search parameters exceeds influxdb's ability to index them
+    class Fields(BaseFields):
         cloud_platforms = drf_serializers.CharField(
             required=False, allow_blank=True
         )
@@ -172,8 +173,6 @@ class SearchLinkMeasurementSerializer(BaseMeasurement):
         platforms = drf_serializers.CharField(required=False, allow_blank=True)
         tags = drf_serializers.CharField(required=False, allow_blank=True)
         order_by = drf_serializers.CharField(required=False, allow_blank=True)
-
-    class Fields(BaseFields):
         content_clicked = drf_serializers.CharField()
         content_clicked_id = drf_serializers.IntegerField()
         position_in_results = drf_serializers.IntegerField()
@@ -182,7 +181,6 @@ class SearchLinkMeasurementSerializer(BaseMeasurement):
         relevance = drf_serializers.FloatField()
         keywords = drf_serializers.CharField(required=False, allow_blank=True)
 
-    tags = Tags()
     fields = Fields()
 
 

--- a/galaxyui/src/app/resources/logger/event-logger.service.ts
+++ b/galaxyui/src/app/resources/logger/event-logger.service.ts
@@ -10,11 +10,7 @@ import { InfluxSession } from './influx-session';
 
 @Injectable()
 export class EventLoggerService {
-    constructor(
-        private http: HttpClient,
-        private router: Router,
-        private activatedRoute: ActivatedRoute,
-    ) {
+    constructor(private http: HttpClient, private router: Router) {
         const session = document.cookie.match(
             new RegExp('(^| )influx_session=([^;]+)'),
         );
@@ -68,14 +64,13 @@ export class EventLoggerService {
 
     logSearchQuery(searchParams: Object, numberOfResults: number) {
         const measurement = this.getBaseMeasurement('search_query');
+
+        delete measurement.tags;
+
         measurement.fields['number_of_results'] = numberOfResults;
 
         for (const key of Object.keys(searchParams)) {
-            if (key === 'keywords' || key === 'namespaces') {
-                measurement.fields[key] = searchParams[key];
-            } else {
-                measurement.tags[key] = searchParams[key];
-            }
+            measurement.fields[key] = searchParams[key];
         }
 
         this.postData(measurement);
@@ -91,6 +86,9 @@ export class EventLoggerService {
         contentID: number,
     ) {
         const measurement = this.getBaseMeasurement('search_click');
+
+        delete measurement.tags;
+
         measurement.fields['content_clicked'] = contentClicked;
         measurement.fields['position_in_results'] = position;
         measurement.fields['download_rank'] = downloadRank;
@@ -99,11 +97,7 @@ export class EventLoggerService {
         measurement.fields['content_clicked_id'] = contentID;
 
         for (const key of Object.keys(searchParams)) {
-            if (key === 'keywords' || key === 'namespaces') {
-                measurement.fields[key] = searchParams[key];
-            } else {
-                measurement.tags[key] = searchParams[key];
-            }
+            measurement.fields[key] = searchParams[key];
         }
         this.postData(measurement);
     }


### PR DESCRIPTION
InfluxDB can handle up to 10 million unique series. The number of unique series is determined by the number of possible values that a tag can be. By storing all our search metadata as tags we were inadvertently creating measurements that could have up to 2 billion unique series.


Search Clicks:

Tags  | Possible Discrete Values
-- | --
cloud_platforms | 8
tags | 4582
deprecated | 2
content_type | 17
platforms | 132
order_by | 12
  |  
Possible Unique Series | 1,974,145,536

