### PR TITLE
Use explicit character set instead of "\w" character class

### DIFF
--- a/galaxy/accounts/forms.py
+++ b/galaxy/accounts/forms.py
@@ -34,7 +34,7 @@ class CustomUserCreationForm(forms.ModelForm):
     username = forms.RegexField(
         label=_("Username"),
         max_length=30,
-        regex=r'^[\w.@+-]+$',
+        regex=r'^[a-zA-Z0-9_.@+-]+$',
         help_text=_("Required. 30 characters or fewer. Letters, digits and "
                     "@/./+/-/_ only."),
         error_messages={
@@ -86,7 +86,7 @@ class CustomUserChangeForm(forms.ModelForm):
     username = forms.RegexField(
         label=_("Username"),
         max_length=30,
-        regex=r"^[\w.@+-]+$",
+        regex=r"^[a-zA-Z0-9_.@+-]+$",
         help_text=_("Required. 30 characters or fewer. Letters, digits and "
                     "@/./+/-/_ only."),
         error_messages={

--- a/galaxy/accounts/migrations/0001_initial.py
+++ b/galaxy/accounts/migrations/0001_initial.py
@@ -56,7 +56,7 @@ class Migration(migrations.Migration):
                         verbose_name='username',
                         validators=[
                             django.core.validators.RegexValidator(
-                                re.compile('^[\\w.@+-]+$'),
+                                re.compile(r'^[a-zA-Z0-9_.@+-]+$'),
                                 'Enter a valid username.',
                                 'invalid',
                             )

--- a/galaxy/accounts/models.py
+++ b/galaxy/accounts/models.py
@@ -16,7 +16,6 @@
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
 from __future__ import unicode_literals
-import re
 
 from django.contrib.auth import models as auth_models
 
@@ -48,7 +47,7 @@ class CustomUser(auth_models.AbstractBaseUser,
         help_text=_('Required. 30 characters or fewer. Letters, numbers and '
                     '@/./+/-/_ characters'),
         validators=[
-            validators.RegexValidator(re.compile(r'^[\w.@+-]+$'),
+            validators.RegexValidator(r'^[a-zA-Z0-9_.@+-]+$',
                                       _('Enter a valid username.'),
                                       'invalid')
         ])

--- a/galaxy/api/views/namespace.py
+++ b/galaxy/api/views/namespace.py
@@ -51,7 +51,7 @@ def check_basic(data, errors):
     name = data.get('name')
     if not name:
         errors['name'] = "Attribute 'name' is required"
-    elif not re.match(r'^[\w]+$', name):
+    elif not re.match(r'^[a-zA-Z0-9_]+$', name):
         # Allow only names containing word chars
         errors['name'] = "Name can only contain [A-Za-z0-9_]"
     elif(len(name) <= 2):

--- a/galaxy/api/views/repository.py
+++ b/galaxy/api/views/repository.py
@@ -65,7 +65,7 @@ def get_repo(provider_namespace, user, repo_name):
 def check_name(name):
     if not name:
         raise ValidationError(detail={'name': 'Name is required'})
-    if not re.match(r'^[\.\w-]+$', name):
+    if not re.match(r'^[a-zA-Z0-9_.-]+$', name):
         # Allow only names containing word chars
         raise ValidationError(detail={
             'name': "Name can only contain [A-Za-z0-9_]"})

--- a/galaxy/main/migrations/0089_delete_invalid_contents.py
+++ b/galaxy/main/migrations/0089_delete_invalid_contents.py
@@ -11,7 +11,8 @@ def delete_contents_invalid_name(apps, schema_editor):
     db_alias = schema_editor.connection.alias
     Content = apps.get_model('main', 'Content')
 
-    qs = Content.objects.using(db_alias).exclude(name__iregex=r'^[\w-]+$')
+    qs = Content.objects.using(db_alias).exclude(
+        name__iregex=r'^[a-zA-Z0-9_-]+$')
 
     count = qs.count()
     LOG.info('Deleting {0} Content records'.format(count))

--- a/galaxy/worker/importers/base.py
+++ b/galaxy/worker/importers/base.py
@@ -63,7 +63,7 @@ class ContentImporter(object):
             original_name = self.data.original_name
 
         # Check name
-        if not re.match(r'^[\w-]+$', name):
+        if not re.match(r'^[a-zA-Z0-9_-]+$', name):
             raise exc.TaskError('Invalid name, only aplhanumeric characters, '
                                 '"-" and "_" symbols are allowed.')
 


### PR DESCRIPTION
In python 2 "\w" character class refered to ascii set of characters
expressed as "[a-zA-Z0-9_]". In Python 3 it started including
unicode word characters, which is not desirable for expressions
uses in Galaxy.
In Python 3 this behavir can be disabled by using `re.ASCII` flag,
but it is not available in Python 2.
Therefore we replace usage "\w" class with explicit character set
"[a-zA-Z0-9_]" in the project.