### PR TITLE
add documentation guidelines for Galaxy roles

### DIFF
--- a/docs/docsite/rst/contributing/documenting_content.rst
+++ b/docs/docsite/rst/contributing/documenting_content.rst
@@ -4,7 +4,7 @@
 Documenting Galaxy content
 **************************
 
-.. contents:: Topics
+.. contents::
    :local:
 
 This topic describes how to document Ansible content that can be imported into Galaxy.
@@ -14,7 +14,7 @@ This topic describes how to document Ansible content that can be imported into G
 Documenting with README.md
 ===========================
 
-Each Galaxy content type, such as roles and multi-role repositories, includes a ``README.md`` file in the top-level directory, such as:
+When you look at a role or a repository on `Galaxy <https://galaxy.ansible.com/home>`_, the first thing you see is the README page. For simple projects, this may be all the documentation you need. When you used the ``ansible-galaxy init``  or ``mazer init`` command to create the shell of your content, it placed a sample ``README.md`` file in the top-level directory of your project.
 
 .. code-block:: bash
 
@@ -24,33 +24,25 @@ Each Galaxy content type, such as roles and multi-role repositories, includes a 
         main.yml
         ...
 
-Galaxy displays this ``README.md`` file to users when they select this content on `Galaxy <https://galaxy.ansible.com/>`_. This file should have the following sections:
+This file has the following sections by default:
 
-* Introduction
+* Role name (with installation instructions)
 * Requirements
+* Role variables (if applicable)
 * Dependencies (if applicable)
-* Functions
-* Examples
 * License
 * Author
 
-See `config_manager <https://galaxy.ansible.com/ansible-network/config_manager>`_ for an example of documentation for a role.
-
-You can optionally include examples within the Functions section. See :ref:`Extending documentation <extending_documentation>` for details.
+You can add other sections, such as a Functions section to document the functions that your Galaxy content provides. See `config_manager <https://galaxy.ansible.com/ansible-network/config_manager>`_ for an example of documentation for a role.
 
 .. _extending_documentation:
 
 Extending documentation beyond README.md
 ========================================
 
-Depending on the complexity of your Galaxy content, you may need to extend the documentation beyond a single ``README.md`` file. Any functions included in your Galaxy content should have separate documentation to cover the following sections per function:
+If your Galaxy content is more complex, you may need to extend the documentation beyond a single ``README.md`` file. To extend documentation, create a ``docs/`` subdirectory in your main Galaxy content top-level directory and add individual ``.md`` files there.
 
-* Introduction
-* Examples
-* Arguments
-* Notes (if applicable)
-
-To document functions or other extentions to the main ``README.md`` file, create a ``docs/`` subdirectory in your main Galaxy content top-level directory and add individual ``.md`` files there.  See `config_manager/docs <https://github.com/ansible-network/config_manager/tree/devel/docs>`_ for an example of this.
+See `config_manager/docs <https://github.com/ansible-network/config_manager/tree/devel/docs>`_ for an example of this.
 
 You can then link to those files from the main ``README.md`` file:
 
@@ -60,5 +52,13 @@ You can then link to those files from the main ``README.md`` file:
     in this role.
 
     * get [[source]](https://github.com/ansible-network/config_manager/blob/devel/tasks/get.yaml) [[docs]](https://github.com/ansible-network/config_manager/blob/devel/docs/get.md)
+
+
+You should have separate documentation for functions or embedded plugins included in your Galaxy content that documents the following:
+
+* Introduction
+* Examples
+* Arguments
+* Notes (if applicable)
 
 See the `config_manager get function <https://github.com/ansible-network/config_manager/blob/devel/docs/get.md>`_ for an example of function-based documentation.

--- a/docs/docsite/rst/contributing/documenting_content.rst
+++ b/docs/docsite/rst/contributing/documenting_content.rst
@@ -1,0 +1,18 @@
+.. _documenting_content:
+
+**************************
+Documenting Galaxy Content
+**************************
+
+.. contents:: Topics
+   :local:
+
+This topic describes how to document Ansible content that can be imported into Galaxy.
+
+.. _documenting_readme:
+
+Documenting with README.md
+===========================
+
+Extending documentation beyond README.md
+========================================

--- a/docs/docsite/rst/contributing/documenting_content.rst
+++ b/docs/docsite/rst/contributing/documenting_content.rst
@@ -1,7 +1,7 @@
 .. _documenting_content:
 
 **************************
-Documenting Galaxy Content
+Documenting Galaxy content
 **************************
 
 .. contents:: Topics
@@ -14,5 +14,51 @@ This topic describes how to document Ansible content that can be imported into G
 Documenting with README.md
 ===========================
 
+Each Galaxy content type, such as roles and multi-role repositories, includes a ``README.md`` file in the top-level directory, such as:
+
+.. code-block:: bash
+
+    .travis.yml
+    README.md
+    defaults/
+        main.yml
+        ...
+
+Galaxy displays this ``README.md`` file to users when they select this content on `Galaxy <https://galaxy.ansible.com/>`_. This file should have the following sections:
+
+* Introduction
+* Requirements
+* Dependencies (if applicable)
+* Functions
+* Examples
+* License
+* Author
+
+See `config_manager <https://galaxy.ansible.com/ansible-network/config_manager>`_ for an example of documentation for a role.
+
+You can optionally include examples within the Functions section. See :ref:`Extending documentation <extending_documentation>` for details.
+
+.. _extending_documentation:
+
 Extending documentation beyond README.md
 ========================================
+
+Depending on the complexity of your Galaxy content, you may need to extend the documentation beyond a single ``README.md`` file. Any functions included in your Galaxy content should have separate documentation to cover the following sections per function:
+
+* Introduction
+* Examples
+* Arguments
+* Notes (if applicable)
+
+To document functions or other extentions to the main ``README.md`` file, create a ``docs/`` subdirectory in your main Galaxy content top-level directory and add individual ``.md`` files there.  See `config_manager/docs <https://github.com/ansible-network/config_manager/tree/devel/docs>`_ for an example of this.
+
+You can then link to those files from the main ``README.md`` file:
+
+.. code-block:: bash
+
+    This section provides a list of the available functions that are including
+    in this role.
+
+    * get [[source]](https://github.com/ansible-network/config_manager/blob/devel/tasks/get.yaml) [[docs]](https://github.com/ansible-network/config_manager/blob/devel/docs/get.md)
+
+See the `config_manager get function <https://github.com/ansible-network/config_manager/blob/devel/docs/get.md>`_ for an example of function-based documentation.

--- a/docs/docsite/rst/contributing/index.rst
+++ b/docs/docsite/rst/contributing/index.rst
@@ -10,6 +10,7 @@ Contributing Content
    creating_role
    creating_multi
    creating_apb
+   documenting_content
    version
    importing
    deprecate


### PR DESCRIPTION
Fixes https://github.com/ansible/galaxy/issues/1234

Add a section to the Galaxy contributor docs to cover how to document a role, with some examples.