### PR TITLE
Fix double logging in celery console

### DIFF
--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -386,7 +386,6 @@ LOGGING = {
             'propagate': True,
         },
         'galaxy.worker': {
-            'handlers': ['console'],
             'level': 'DEBUG',
             'propagate': True,
         },

--- a/galaxy/worker/importers/base.py
+++ b/galaxy/worker/importers/base.py
@@ -26,6 +26,7 @@ from galaxy.worker import exceptions as exc, utils
 
 
 LOG = logging.getLogger(__name__)
+LOG.setLevel('DEBUG')
 
 
 class ContentImporter(object):

--- a/galaxy/worker/tasks.py
+++ b/galaxy/worker/tasks.py
@@ -40,6 +40,7 @@ from galaxy.main.celerytasks import user_notifications
 from galaxy.api import serializers
 
 LOG = logging.getLogger(__name__)
+LOG.setLevel('DEBUG')
 
 
 @celery.task


### PR DESCRIPTION
The `galaxy/worker/tasks.py` log messages from `getLogger(__name__)` get logged twice into celery, once by `‘galaxy.worker’` logger and once by the automatically added celery `ProcessAwareLogger`

This PR removes the `‘galaxy.worker’` logging config `['console']` handler. The only other `.getLogger(__name__)` call under `galaxy.worker.*` is in `galaxy.worker.importers.base`, which also gets the ProcessAwareLogger
