### PR TITLE
Add extra metrics for tracking content (#1271)

### DIFF
--- a/galaxy/api/views/influx.py
+++ b/galaxy/api/views/influx.py
@@ -104,8 +104,8 @@ class InfluxMetrics(views.APIView):
     def load_serializer(self, request):
         if 'measurement' not in request.data:
             return None
-        if request.data['measurement'] in serializers.InfluxTypes:
-            serializer_type = serializers.InfluxTypes[
+        if request.data['measurement'] in serializers.InfluxAPITypes:
+            serializer_type = serializers.InfluxAPITypes[
                 request.data['measurement']
             ]
             return serializer_type(data=request.data)

--- a/galaxy/api/views/roles.py
+++ b/galaxy/api/views/roles.py
@@ -24,8 +24,8 @@ from galaxy.main.models import Content
 
 from .views import filter_role_queryset
 from .base_views import ListAPIView, RetrieveAPIView
-from ..serializers import RoleListSerializer, RoleDetailSerializer
-
+# from ..serializers import RoleListSerializer, RoleDetailSerializer
+from galaxy.api import serializers
 
 __all__ = [
     'RoleList',
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 class RoleList(ListAPIView):
     model = Content
-    serializer_class = RoleListSerializer
+    serializer_class = serializers.RoleListSerializer
     throttle_scope = 'download_count'
 
     def list(self, request, *args, **kwargs):
@@ -62,6 +62,22 @@ class RoleList(ListAPIView):
                     content.repository.download_count += 1
                     content.repository.save()
 
+                    name = '{}.{}'.format(
+                        content.namespace.name,
+                        content.repository.name
+                    )
+
+                    data = {
+                        'measurement': 'content_download',
+                        'fields': {
+                            'content_name': name,
+                            'content_id': content.repository.id,
+                            'download_count': content.repository.download_count
+                        }
+                    }
+
+                    serializers.influx_insert_internal(data)
+
             if page is not None:
                 serializer = self.get_serializer(page, many=True)
                 return self.get_paginated_response(serializer.data)
@@ -78,7 +94,7 @@ class RoleList(ListAPIView):
 
 class RoleDetail(RetrieveAPIView):
     model = Content
-    serializer_class = RoleDetailSerializer
+    serializer_class = serializers.RoleDetailSerializer
 
     def get_object(self, qs=None):
         obj = super(RoleDetail, self).get_object()

--- a/galaxy/api/views/survey.py
+++ b/galaxy/api/views/survey.py
@@ -106,3 +106,17 @@ def update_community_score(repo):
 
     repo.community_score = score
     repo.save()
+
+    namespace = repo.provider_namespace.namespace.name
+
+    fields = {
+        'content_name': '{}.{}'.format(namespace, repo.name),
+        'content_id': repo.id,
+        'community_score': repo.community_score,
+        'quality_score': repo.quality_score,
+    }
+
+    serializers.influx_insert_internal({
+        'measurement': 'content_score',
+        'fields': fields
+    })

--- a/galaxy/main/celerytasks/user_notifications.py
+++ b/galaxy/main/celerytasks/user_notifications.py
@@ -173,7 +173,7 @@ def author_release(repo_id):
         subject='Ansible Galaxy: {} has released a new collection'.format(
             author
         ),
-        db_message='New release from {author}: {name}'.format(
+        db_message='New release from {}: {}'.format(
             author, repo.name
         ),
         repo=repo

--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -416,7 +416,7 @@ INFLUX_DB_UI_EVENTS_DB_NAME = 'galaxy_metrics'
 # Number of data points to buffer before galaxy writes them to influx.
 # Higher numbers mean more efficient influx inserts, but it also means that
 # more data will potentially be lost when galaxy restarts.
-INFLUX_INSERT_BUFFER_COUNT = 5
+INFLUX_INSERT_BUFFER_COUNT = 1
 
 GALAXY_METRICS_ENABLED = True
 


### PR DESCRIPTION
Backport: #1271 

* Add content download count metric

* Add follower and score metrics.

* Save score metric on import.

* Added error logging.

(cherry picked from commit 75c8d723d82ebaa16f8ff437fcbbe32f50c381c8)