### PR TITLE
Allow users to specify where they want to recieve notifications. (#1291)

### DIFF
--- a/galaxy/main/celerytasks/user_notifications.py
+++ b/galaxy/main/celerytasks/user_notifications.py
@@ -57,16 +57,17 @@ class NotificationManger(object):
 
     def send(self, email_message):
         for user in self.preferences_list:
-            models.UserNotification.objects.create(
-                user=user.user,
-                type=self.preferences_name,
-                message=self.db_message,
-                repository=self.repo
-            )
 
-            if self.preferences_name not in user.preferences:
-                continue
+            # Create in app notification
+            if user.preferences['ui_' + self.preferences_name]:
+                models.UserNotification.objects.create(
+                    user=user.user,
+                    type=self.preferences_name,
+                    message=self.db_message,
+                    repository=self.repo
+                )
 
+            # Create email notification
             if user.preferences[self.preferences_name]:
                 email = EmailAddress.objects.filter(
                     primary=True,

--- a/galaxy/main/models.py
+++ b/galaxy/main/models.py
@@ -1253,21 +1253,27 @@ class UserPreferences(BaseModel):
     DEFAULT_PREFERENCES = {
         # Notify me when a user adds a survey for my content.
         'notify_survey': False,
+        'ui_notify_survey': True,
 
         # Notify me when an import fails.
         'notify_import_fail': True,
+        'ui_notify_import_fail': True,
 
         # Notify me when an import succeeds.
         'notify_import_success': False,
+        'ui_notify_import_success': True,
 
         # Notify me when a new release is available for content I'm following.
         'notify_content_release': True,
+        'ui_notify_content_release': True,
 
         # Notify me when an author I'm following creates new content.
         'notify_author_release': True,
+        'ui_notify_author_release': True,
 
         # Notify me when there is a Galaxy announcement.
-        'notify_galaxy_announce': True
+        'notify_galaxy_announce': True,
+        'ui_notify_galaxy_announce': True,
     }
 
     user = models.OneToOneField(

--- a/galaxyui/src/app/preferences/preferences.component.html
+++ b/galaxyui/src/app/preferences/preferences.component.html
@@ -94,9 +94,39 @@
     <pfng-card [config]="notificationsCard" id="notificationCard" class="col-md-12">
         <div class="card-content">
             Would you like to receive a notification when...
+
+            <div class="notification-settings">
+
+                <div class="notification-row">
+                    <div class="notification-col description">
+
+                    </div>
+                    <div class="notification-col check">
+                        Email
+                    </div>
+
+                    <div class="notification-col check">
+                        In App
+                    </div>
+                </div>
+
+            </div>
+
             <div *ngFor="let item of notificationSettings" class="notification-settings">
-                <input type="checkbox" [(ngModel)]="preferences.preferences[item.key]" (click)="updateNotifications()">
-                {{ item.description }}
+
+                <div class="notification-row">
+                    <div class="notification-col description">
+                        {{ item.description }}
+                    </div>
+                    <div class="notification-col check">
+                        <input type="checkbox" [(ngModel)]="preferences.preferences[item.key]" (click)="updateNotifications()">
+                    </div>
+
+                    <div class="notification-col check">
+                        <input type="checkbox"[(ngModel)]="preferences.preferences['ui_' + item.key]" (click)="updateNotifications()">
+                    </div>
+                </div>
+
             </div>
         </div>
     </pfng-card>

--- a/galaxyui/src/app/preferences/preferences.component.less
+++ b/galaxyui/src/app/preferences/preferences.component.less
@@ -36,6 +36,26 @@
     .notification-settings {
         margin-left: 20px;
     }
+
+    .notification-row {
+        display: flex;
+        margin-top: 5px;
+
+        .description {
+            width: 350px;
+        }
+
+        .check {
+            text-align: center;
+            align-items: center;
+            align-content: center;
+            min-width: 60px;
+        }
+
+        .notification-col {
+            display: inline-block;
+        }
+    }
 }
 
 #apiTokenCard {

--- a/galaxyui/src/app/preferences/preferences.component.ts
+++ b/galaxyui/src/app/preferences/preferences.component.ts
@@ -106,28 +106,28 @@ export class PreferencesComponent implements OnInit {
                 {
                     key: 'notify_survey',
                     description:
-                        'someone submits a new survey for one of your roles',
+                        'Someone submits a new survey for one of your roles',
                 },
                 {
                     key: 'notify_content_release',
                     description:
-                        'there is a new release of a collection you follow',
+                        'There is a new release of a collection you follow',
                 },
                 {
                     key: 'notify_author_release',
-                    description: 'an author you follow releases a new role',
+                    description: 'An author you follow releases a new role',
                 },
                 {
                     key: 'notify_import_fail',
-                    description: 'one of your imports fails',
+                    description: 'One of your imports fails',
                 },
                 {
                     key: 'notify_import_success',
-                    description: 'one of your imports succeeds',
+                    description: 'One of your imports succeeds',
                 },
                 {
                     key: 'notify_galaxy_announce',
-                    description: 'there is an anouncement from the galaxy team',
+                    description: 'There is an anouncement from the galaxy team',
                 },
             ];
         });

--- a/galaxyui/src/app/resources/preferences/user-preferences.ts
+++ b/galaxyui/src/app/resources/preferences/user-preferences.ts
@@ -6,6 +6,12 @@ export class UserPreferences {
         notify_content_release: boolean;
         notify_author_release: boolean;
         notify_galaxy_announce: boolean;
+        ui_notify_survey: boolean;
+        ui_notify_import_fail: boolean;
+        ui_notify_import_success: boolean;
+        ui_notify_content_release: boolean;
+        ui_notify_author_release: boolean;
+        ui_notify_galaxy_announce: boolean;
     };
 
     namespaces_followed: number[];


### PR DESCRIPTION
Backport: #1291 

* Add form for updating in app notifications

* Add ui notification preferences to DB.

* configure notification manger to use new preferences.

(cherry picked from commit b57d6020e0db44fcc6a64de58111cd4d738de65a)