### PR TITLE
Send email address verifications from galaxy notification manager.

### DIFF
--- a/galaxy/api/views/email.py
+++ b/galaxy/api/views/email.py
@@ -8,6 +8,7 @@ from django.shortcuts import get_object_or_404
 
 from galaxy.api.views import base_views
 from galaxy.api import serializers
+from galaxy.main.celerytasks import user_notifications
 
 from rest_framework.response import Response
 
@@ -87,7 +88,13 @@ class EmailVerification(base_views.ListCreateAPIView):
                 'verified': True
             })
 
-        verification = email.send_confirmation(request=request)
+        verification = self.model.create(email)
+        user_notifications.email_verification(
+            email=email.email,
+            code=verification.key,
+            username=request.user.username
+        )
+
         serializer = self.get_serializer(instance=verification)
         return Response(serializer.data)
 

--- a/galaxy/main/celerytasks/user_notifications.py
+++ b/galaxy/main/celerytasks/user_notifications.py
@@ -85,6 +85,27 @@ class NotificationManger(object):
         self.send(email)
 
 
+def email_verification(email, code, username):
+    url = settings.GALAXY_URL.format(
+        site=Site.objects.get_current().domain
+    )
+
+    url += '/me/preferences/?verify=' + code
+
+    message = email_verification_template.format(
+        username=username,
+        url=url
+    )
+
+    mail.send_mail(
+        'Ansible Galaxy Please Confirm Your E-mail Address',
+        message,
+        settings.GALAXY_NOTIFICATION_EMAIL,
+        [email],
+        fail_silently=True
+    )
+
+
 @celery.task
 def import_status(task_id, user_initiated, has_failed=False):
     task = models.ImportTask.objects.get(id=task_id)
@@ -266,3 +287,15 @@ Cheers,
 
 -- To stop seeing these messages, visit {preferences_link} to update your \
 settings.'''
+
+
+email_verification_template = '''Hello,
+
+You're receiving this e-mail because user {username} has give this address as \
+an e-mail address to connect their account.
+
+To confirm this is correct, go to {url}.
+
+Cheers,
+   Ansible Galaxy
+'''

--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -429,5 +429,5 @@ GALAXY_URL = 'http://{site}:8000'
 # =========================================================
 # Notification Settings
 # =========================================================
-GALAXY_NOTIFICATION_EMAIL = 'noreply@galaxy.ansible.com'
+GALAXY_NOTIFICATION_EMAIL = 'notifications@galaxy.ansible.com'
 DEFAULT_FROM_EMAIL = 'noreply@galaxy.ansible.com'

--- a/galaxy/templates/account/email/email_confirmation_message.txt
+++ b/galaxy/templates/account/email/email_confirmation_message.txt
@@ -1,8 +1,0 @@
-{% load account %}{% user_display user as user_display %}{% load i18n %}{% autoescape off %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Hello from {{ site_name }}!
-
-You're receiving this e-mail because user {{ user_display }} has given yours as an e-mail address to connect their account.
-
-To confirm this is correct, go to {{ current_site }}/me/preferences/?verify={{ key }}
-{% endblocktrans %}{% endautoescape %}
-{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Thank you from {{ site_name }}!
-{{ site_domain }}{% endblocktrans %}


### PR DESCRIPTION
Django allauth was failing to recognize our customized email template, so I'm just switching the whole email notification system over to the system that we use for user notifications.