### PR TITLE
Add travis build status to content details. (#1304)

### DIFF
--- a/galaxyui/src/app/content-detail/repository/repository.component.html
+++ b/galaxyui/src/app/content-detail/repository/repository.component.html
@@ -95,6 +95,15 @@
                         tooltip="Visit the repository. Opens in a new browser tab." class="btn btn-default">
                             <i [ngClass]="repositoryView.scmIconClass"></i> {{ repositoryView.scmName }} Repo</a>
                 </div>
+
+                <div class="header-button">
+                    <div class="travis" *ngIf="repository.travis_build_url">
+                        <a href="{{ repository.travis_build_url }}" container="body" target="_blank" tooltip="View Travis build output. Opens in new tab or window.">
+                            <img src="{{ repository.travis_status_url }}"
+                                class="travis-status-img" title="Travis Build Status" />
+                        </a>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/galaxyui/src/app/resources/repositories/repository.ts
+++ b/galaxyui/src/app/resources/repositories/repository.ts
@@ -31,4 +31,6 @@ export class Repository {
     community_score: number;
     quality_score: number;
     quality_score_date: string;
+    travis_build_url: string;
+    travis_status_url: string;
 }


### PR DESCRIPTION
Backport #1304

* Add travis build status to content details.

* add travis details to repository object.

(cherry picked from commit ece5a8aaaa8429d6b080abb02328d0bc83bd1916)