### PR TITLE
Remove fail silently on sending email notifications

### DIFF
--- a/galaxy/main/celerytasks/user_notifications.py
+++ b/galaxy/main/celerytasks/user_notifications.py
@@ -77,7 +77,7 @@ class NotificationManger(object):
                     email_message,
                     settings.GALAXY_NOTIFICATION_EMAIL,
                     [email[0].email],
-                    fail_silently=True
+                    fail_silently=False
                 )
 
     def notify(self, context):


### PR DESCRIPTION
Emails are breaking in prod and I'm hoping this will help me figure out why.