### PR TITLE
Select only builtin flake8 errors and warnings in galaxy linter

### DIFF
--- a/galaxy/importer/linters/__init__.py
+++ b/galaxy/importer/linters/__init__.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 LINTERS_DIR = os.path.abspath(os.path.dirname(__file__))
 FLAKE8_MAX_LINE_LENGTH = 120
 FLAKE8_IGNORE_ERRORS = 'E402'
+FLAKE8_SELECT_ERRORS = 'E,F,W'
 
 
 class BaseLinter(object):
@@ -52,6 +53,7 @@ class Flake8Linter(BaseLinter):
     def _check_files(self, paths):
         cmd = [self.cmd, '--exit-zero', '--isolated',
                '--ignore', FLAKE8_IGNORE_ERRORS,
+               '--select', FLAKE8_SELECT_ERRORS,
                '--max-line-length', str(FLAKE8_MAX_LINE_LENGTH),
                '--'] + paths
         logger.debug('CMD: ' + ' '.join(cmd))


### PR DESCRIPTION
Flake8 by default enables all plugins installed in the Python
environment. Since Galaxy worker uses the same flake8 that is
used to lint project code, any installed plugin will cause additional
checks to be executed.

Worker linter configuration should be independent from the
environment configuration. Because flake8 does not provide
any option to blacklist or whitelist installed plugins,
this change explicitly enables prefixes that flake8 uses for
builtin checks [1] [2].

NOTE: This patch is useless if any plugin adds checks with the
same prefixes that are used by flake8.

References:

[1] https://gitlab.com/pycqa/flake8/issues/133
[2] https://gitlab.com/pycqa/flake8-docstrings/issues/10

Related PR: #905 