### PR TITLE
Add polling to user notifications so they update without a site reload.

### DIFF
--- a/galaxy/api/urls.py
+++ b/galaxy/api/urls.py
@@ -292,12 +292,6 @@ me_urls = [
     ),
 
     url(
-        r'notifications/unread/',
-        views.ActiveUserUnreadNotificationView.as_view(),
-        name='active_user_unread_notifications_view'
-    ),
-
-    url(
         r'notifications/(?P<pk>[0-9]+)/$',
         views.ActiveUserNotificationsDetailView.as_view(),
         name='active_user_notifications_view_detail'

--- a/galaxy/api/views/active_user.py
+++ b/galaxy/api/views/active_user.py
@@ -12,7 +12,6 @@ __all__ = [
     'ActiveUserPreferencesView',
     'ActiveUserNotificationsView',
     'ActiveUserNotificationsDetailView',
-    'ActiveUserUnreadNotificationView',
     'ActiveUserClearNotificationView'
 ]
 
@@ -93,6 +92,18 @@ class ActiveUserNotificationsView(base_views.ListAPIView):
         )
         return obj
 
+    def list(self, request, *args, **kwargs):
+        response = super(ActiveUserNotificationsView, self)\
+            .list(request, args, kwargs)
+
+        count = models.UserNotification.objects.filter(
+            user=request.user,
+            seen=False,
+        ).count()
+
+        response.data['unseen_notifications'] = count
+        return response
+
 
 class ActiveUserNotificationsDetailView(
         base_views.RetrieveUpdateDestroyAPIView):
@@ -106,15 +117,6 @@ class ActiveUserNotificationsDetailView(
             user=self.request.user,
         )
         return obj
-
-
-class ActiveUserUnreadNotificationView(base_views.APIView):
-    def get(self, request):
-        count = models.UserNotification.objects.filter(
-            user=request.user,
-            seen=False,
-        ).count()
-        return Response({'count': count})
 
 
 class ActiveUserClearNotificationView(base_views.APIView):

--- a/galaxyui/src/app/resources/notifications/user-notification.service.ts
+++ b/galaxyui/src/app/resources/notifications/user-notification.service.ts
@@ -6,7 +6,10 @@ import { catchError, tap } from 'rxjs/operators';
 
 import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
 
-import { UserNotification } from './user-notification';
+import {
+    UserNotification,
+    NotificationPagedResponse,
+} from './user-notification';
 
 import { GenericQuerySave } from '../base/generic-query-save';
 
@@ -25,12 +28,26 @@ export class UserNotificationService extends GenericQuerySave<
         );
     }
 
-    getUnread(): Observable<any> {
-        const url = this.url + '/unread/';
-        return this.http.get<any>(url).pipe(
-            tap(_ => this.log(`fetched unread ${this.serviceName}`)),
-            catchError(this.handleError('Get', {} as any)),
-        );
+    pagedQuery(params?: any): Observable<NotificationPagedResponse> {
+        let objectUrl = this.url;
+        let objectParams = null;
+        if (params) {
+            if (typeof params === 'string') {
+                objectUrl += `?${params}`;
+            } else {
+                objectParams = params;
+            }
+        }
+        return this.http
+            .get<NotificationPagedResponse>(objectUrl + '/', {
+                params: objectParams,
+            })
+            .pipe(
+                tap(_ => this.log(`fetched ${this.serviceName}`)),
+                catchError(
+                    this.handleError('Query', {} as NotificationPagedResponse),
+                ),
+            );
     }
 
     deleteAll(): Observable<any> {

--- a/galaxyui/src/app/resources/notifications/user-notification.ts
+++ b/galaxyui/src/app/resources/notifications/user-notification.ts
@@ -6,3 +6,15 @@ export class UserNotification {
     seen: boolean;
     created: string;
 }
+
+export class NotificationPagedResponse {
+    count: number;
+    cur_page: number;
+    num_pages: number;
+    next_link: string;
+    previous_link: string;
+    next: string;
+    previous: string;
+    results: UserNotification[];
+    unseen_notifications: number;
+}


### PR DESCRIPTION
User notifications will be reloaded every 60 seconds. This makes it so that the user will see the notification dot after they run an import.