### PR TITLE
Importer log updates

### DIFF
--- a/galaxy/importer/linters/__init__.py
+++ b/galaxy/importer/linters/__init__.py
@@ -98,8 +98,8 @@ class YamlLinter(BaseLinter):
             msg_parts = message.split(' ')
             rule_desc = ' '.join(msg_parts[2:])
 
-            error_id = msg_parts[1][1:-1]
-            if error_id not in ['error', 'warning']:
+            error_id = 'YAML_{}'.format(msg_parts[1][1:-1]).upper()
+            if error_id not in ['YAML_ERROR', 'YAML_WARNING']:
                 error_id = None
 
         except IndexError:

--- a/galaxy/importer/loaders/role.py
+++ b/galaxy/importer/loaders/role.py
@@ -88,7 +88,6 @@ class RoleMetaParser(object):
 
     def _validate_tag(self, tag):
         if not re.match(constants.TAG_REGEXP, tag):
-            self.log.warning("Skipping invalid tag '{}'".format(tag))
             return False
         return True
 

--- a/galaxy/worker/tasks.py
+++ b/galaxy/worker/tasks.py
@@ -250,8 +250,8 @@ def _update_quality_score(import_task):
         'ansible-lint_e504': 3,
         'ansible-lint_e601': 4,
         'ansible-lint_e602': 4,
-        'yamllint_error': 4,
-        'yamllint_warning': 1,
+        'yamllint_yaml_error': 4,
+        'yamllint_yaml_warning': 1,
     }
     METADATA_SEVERITY = {
         'ansible-lint_e701': 4,
@@ -332,6 +332,7 @@ def _update_quality_score(import_task):
         content.save()
         repo_points += content.quality_score
 
+        LOG.debug('scoring content.name: {}'.format(content.name))
         LOG.debug('content - ids, weights, score: {}, {}, {}'.format(
             str([m.linter_rule_id for m in content_m]),
             str(content_w), content.content_score))


### PR DESCRIPTION
Backport: #1323
Make yamllint rule id more descriptive
Remove duplicate warning for invalid tag
Added content name to logging
(cherry picked from commit 8f873b596d9d024ccdf7d15b95ee94c7eb25653b)