### PR TITLE
Add SMTP email backend to production config. (#1318)

### DIFF
--- a/galaxy/settings/production.py
+++ b/galaxy/settings/production.py
@@ -142,6 +142,8 @@ SECRET_KEY = _read_secret_key()
 # ---------------------------------------------------------
 
 # FIXME(cutwater): Review parameters usage
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+
 EMAIL_HOST = os.environ.get('GALAXY_EMAIL_HOST', '')
 
 EMAIL_PORT = int(os.environ.get('GALAXY_EMAIL_PORT', 587))


### PR DESCRIPTION
Backport: #1318

* Configure SMTP backend in production.

(cherry picked from commit c0261cca91a2300702824786fe2a7ebac1fee69d)