### PR TITLE
Update search ranking algorithm.

### DIFF
--- a/galaxy/api/views/search.py
+++ b/galaxy/api/views/search.py
@@ -51,6 +51,8 @@ RANK_NORMALIZATION = 32
 
 DOWNLOAD_RANK_MULTIPLIER = 0.4
 CONTENT_SCORE_MULTIPLIER = 0.2
+COMMUNITY_SCORE_MODIFIER = 0.002
+COMMUNITY_SCORE_MODIFIER_MIN = 0.005
 
 
 class ApiV1SearchView(base.APIView):
@@ -138,32 +140,41 @@ class ContentSearchView(base.ListAPIView):
 
     @staticmethod
     def add_relevance(queryset):
+        c = 'repository__community_score'
+        d = 'repository__download_count'
+
+        # ln((MOD*c + MIN) * d + 1)
+        # where c = community_score and d = download_count
+        # We're using the community_score as a modifier to the download count
+        # instead of just allocating a certain number of points based on the
+        # score. The reason for this is that the download score is
+        # a logaritmic scale so adding a fixed number of points ended up
+        # boosting scores way too much for content with low numbers of
+        # downloads. This system allows for the weight of the community score
+        # to scale with the number of downloads
         download_count_ln_expr = Func(
-            F('repository__download_count') + 1, function='ln')
+            (((Coalesce(F(c), 0) * COMMUNITY_SCORE_MODIFIER) +
+                COMMUNITY_SCORE_MODIFIER_MIN)
+                * F(d)) + 1,
+            function='ln'
+        )
         download_rank_expr = (
             F('download_count_ln')
             / (1 + F('download_count_ln'))
             * DOWNLOAD_RANK_MULTIPLIER
         )
 
-        # This is the worlds most complicated way of expressing:
-        # if both scores are available: use the average of the two
-        # if one score is available use it,
-        # if no scores are available use 0
-        # This works becauseCoalesce just picks the first value that isn't
-        # null, and any operation that contains a null, just returns as null.
-        # This format is neccesary because we are limited to using database
-        # functions for performance reasons.
-        score_rank_expr = (Coalesce(
-            (F('repository__quality_score')
-                + F('repository__community_score')) / 10,
-            F('repository__quality_score') / 5,
-            F('repository__community_score') / 5,
-            0) * CONTENT_SCORE_MULTIPLIER
-        )
+        q = 'repository__quality_score'
+        # q / (q+1)
+        # where q = quality_score
+        # This function is better than using a linear function because it
+        # makes it so that the effect of losing the first few points is
+        # relatively minor, which reduces the impact of errors in scoring.
+        quality_rank_expr = (Coalesce(F(q), 0) / (Coalesce(F(q), 0) + 1) *
+                             CONTENT_SCORE_MULTIPLIER)
 
         relevance_expr = ExpressionWrapper(
-            F('search_rank') + F('download_rank') + F('score_rank'),
+            F('search_rank') + F('download_rank') + F('quality_rank'),
             output_field=db_fields.FloatField())
 
         return queryset.annotate(
@@ -172,7 +183,7 @@ class ContentSearchView(base.ListAPIView):
                 download_rank_expr,
                 output_field=db_fields.FloatField()),
             relevance=relevance_expr,
-            score_rank=score_rank_expr
+            quality_rank=quality_rank_expr
         )
 
     @staticmethod

--- a/galaxy/api/views/search.py
+++ b/galaxy/api/views/search.py
@@ -165,13 +165,11 @@ class ContentSearchView(base.ListAPIView):
         )
 
         q = 'repository__quality_score'
-        # q / (q+1)
-        # where q = quality_score
         # This function is better than using a linear function because it
         # makes it so that the effect of losing the first few points is
         # relatively minor, which reduces the impact of errors in scoring.
-        quality_rank_expr = (Coalesce(F(q), 0) / (Coalesce(F(q), 0) + 1) *
-                             CONTENT_SCORE_MULTIPLIER)
+        quality_rank_expr = Func(Coalesce(F(q), 0) + 1, function='log') * \
+            CONTENT_SCORE_MULTIPLIER
 
         relevance_expr = ExpressionWrapper(
             F('search_rank') + F('download_rank') + F('quality_rank'),


### PR DESCRIPTION
This updates the best match formula to:

![screen shot 2018-11-12 at 4 01 55 pm](https://user-images.githubusercontent.com/6063371/48375326-93dc3d00-e695-11e8-9559-f0381d9b23c6.png)

Where: 
k = keyword rank (0 to 1)
c = community score (0.005 to 0.015)
d = number of downloads
q = quality score (0 to 5)

Explanation:
This formula is broken into three components:  keyword, community/download score and quality score.

**Keyword**
Value received from postgres

**Community/download**
The community score is used as a modifier on the download count. This essentially allows for the weight of the download count to be lowered by lowering the community score.  Since the download count is factored in logarithmically this makes it so that large download counts will be relatively unaffected by community scores while content with low download counts will be dramatically affected by community scores.

This graph shows the result of this function on content that has received a community score of 5 (which corresponds to a modifier of 0.015) and a score of 0 (which corresponds to 0.005). Keeping the maximum modifier bellow 1 makes it so that the scale increases a lot more gradually in the beginning, allowing for more granularity at lower numbers of downloads.

![screen shot 2018-11-12 at 3 39 17 pm](https://user-images.githubusercontent.com/6063371/48373991-79a06000-e691-11e8-85c5-aff65b2d9c53.png)

In comparison, this is what the current function looks like. As you can see, the boost from the quality score is far too pronounced and the graph ramps up far too quickly initially.

![screen shot 2018-11-12 at 3 47 04 pm](https://user-images.githubusercontent.com/6063371/48374294-735eb380-e692-11e8-8e9f-79e9aaf648a2.png)


**Quality**
This allocates between 0 and 0.2 points based on the quality score. We expect that the quality scores will mostly be 0 or 5 since people will either not bother re importing their content, or they’ll put in a little effort to make their content get a 5. This uses a logarithmic scale so that a small decrease from 5 to 4.5 or 4 points has a relatively low effect on the search ranking. The rationale behind this is that there are inevitably going to be cases where people have to violate linter rules to make things work (such as using shell or command modules to call git in cases where the git module can't be used). This should mean that users with a small number of inevitable violations perform better than users with larger numbers of violations.

This portion of the formula will have a fairly large impact on best match regardless of the number of downloads a collection has. This is fine because we want good incentives to get people to improve their quality scores.