### PR TITLE
Fix import task list API

### DIFF
--- a/galaxy/api/views/repository.py
+++ b/galaxy/api/views/repository.py
@@ -161,7 +161,7 @@ class RepositoryList(views.ListCreateAPIView):
         serializer = self.get_serializer(repository)
         data = serializer.data
         data['summary_fields']['latest_import'] = \
-            serializers.ImportTaskSerializer(import_task).data
+            serializers.ImportTaskDetailSerializer(import_task).data
         headers = self.get_success_headers(data)
         return Response(serializer.data, status=status.HTTP_201_CREATED,
                         headers=headers)
@@ -249,7 +249,7 @@ class RepositoryDetail(views.RetrieveUpdateDestroyAPIView):
             )
 
             data['summary_fields']['latest_import'] = \
-                serializers.ImportTaskSerializer(import_task).data
+                serializers.ImportTaskDetailSerializer(import_task).data
         return Response(data)
 
     def destroy(self, request, *args, **kwargs):
@@ -267,7 +267,7 @@ class RepositoryDetail(views.RetrieveUpdateDestroyAPIView):
 class RepositoryImportTaskList(views.SubListAPIView):
     view_name = "Repository Imports"
     model = models.ImportTask
-    serializer_class = serializers.ImportTaskSerializer
+    serializer_class = serializers.ImportTaskDetailSerializer
     parent_model = models.Repository
     relationship = "import_tasks"
 


### PR DESCRIPTION
`ImportTaskList` and `RoleImportTaskList` views were using
the same serializer as `ImportTaskDetail`.
It was causing lots of extra queries executed for each import task item.

The following changes significantly reduce number of queries
for list mentioned above API views:

* Tune `ImportTaskSerializer` that is intended to be used with
  multiple items and does not include extra data that is not
  intended to be a part of list API.
* Add `ImportTaskDetailSerializer` that is intended to be used
  with a single object and produces extra queries.
* Use `ImportTaskListSerializer` for `ImportTaskList` and
  `RoleImportTaskList` API views.
* Return `summary_fields.task_messages` only for single ImportTask item.
* Return `summary_fields.notifications` only for single ImportTask item.
* Use joined load `select_related` for related tables.

(cherry picked from commit a042908ac5304d9730f546a4a5b58aa022e4c010)