### PR TITLE
Fix search click event logger. (#1357)

### DIFF
--- a/galaxy/api/serializers/influx.py
+++ b/galaxy/api/serializers/influx.py
@@ -177,7 +177,7 @@ class SearchLinkMeasurementSerializer(BaseMeasurement):
 
     # This doen't use any tags becase the number of possible combinations of
     # search parameters exceeds influxdb's ability to index them
-    class Fields(BaseTags):
+    class Fields(BaseFields):
         cloud_platforms = drf_serializers.CharField(
             required=False, allow_blank=True
         )


### PR DESCRIPTION
Backport: #1357 

(cherry picked from commit 153b229ebb478c6caf9108d1528a026750faffd0)