### PR TITLE
Fix item selection on My Imports page.

### DIFF
--- a/galaxyui/src/app/my-imports/import-list/import-list.component.ts
+++ b/galaxyui/src/app/my-imports/import-list/import-list.component.ts
@@ -183,27 +183,16 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
         }
     }
 
-    selectItem(select: number, deselect?: number): void {
-        this.items.forEach(item => {
-            if (
-                deselect !== null &&
-                select !== deselect &&
-                item.id === deselect
-            ) {
-                this.pfList.selectItem(item, false);
-            } else if (item.id === select) {
-                this.pfList.selectItem(item, true);
-            }
-        });
+    selectItem(select: number): void {
+        const item = this.items.find(x => x.id === select);
+        this.pfList.selectItem(item, true);
     }
 
     getImport(id: number, showPageLoader: boolean): void {
         if (showPageLoader) {
             this.pageLoading = true;
         }
-        let deselectId: number;
         if (this.selected) {
-            deselectId = this.selected.id;
             this.selected.id = 0;
         }
         if (this.polling) {
@@ -215,7 +204,7 @@ export class ImportListComponent implements OnInit, AfterViewInit, OnDestroy {
             this.selectedId = result.id;
             this.setQuery();
             if (this.pfList) {
-                this.selectItem(this.selected.id, deselectId);
+                this.selectItem(this.selected.id);
             }
             this.cancelPageLoading();
             if (


### PR DESCRIPTION
Currently when you select an item from the list of Imports on My Imports, the item that gets highlighted on this list doesn't always match the item that's showing in the details area. This patch should fix that problem.

![screen shot 2018-11-27 at 2 09 34 pm](https://user-images.githubusercontent.com/6063371/49105422-7b9c1e80-f24e-11e8-8b78-624f5d7a7fba.png)
