### PR TITLE
Fix docs site header link. (#1374)

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/layout.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/layout.html
@@ -130,7 +130,7 @@
         </ul>
     </div>
 
-  <a class="DocSite-nav" href="/" style="padding-bottom: 30px;">
+  <a class="DocSite-nav" href="/docs" style="padding-bottom: 30px;">
 
     <img class="DocSiteNav-logo"
       src="{{ pathto('_static/', 1) }}images/galaxy-logo-03.svg"

--- a/docs/docsite/_themes/srtd/layout.html
+++ b/docs/docsite/_themes/srtd/layout.html
@@ -140,7 +140,7 @@
         </ul>
     </div>
 
-  <a class="DocSite-nav" href="/">
+  <a class="DocSite-nav" href="/docs">
     <img class="DocSiteNav-logo"
       src="{{ pathto('_static/', 1) }}images/logo_invert.png"
       alt="Ansible Logo">


### PR DESCRIPTION
Backport: #1374

(cherry picked from commit e2524373938ce24c7fe39d734c78be676cfa6028)