### PR TITLE
Add extra information to my content page

### DIFF
--- a/galaxyui/src/app/enums/content-types.enum.ts
+++ b/galaxyui/src/app/enums/content-types.enum.ts
@@ -4,6 +4,7 @@ export enum ContentTypes {
     plugin = 'plugin',
     role = 'role',
     moduleUtils = 'module_utils',
+    module_utils = 'module_utils',
 }
 
 export enum ContentTypesPlural {
@@ -12,6 +13,7 @@ export enum ContentTypesPlural {
     role = 'roles',
     plugin = 'plugins',
     moduleUtils = 'module_utils',
+    module_utils = 'module_utils',
 }
 
 export enum ContentTypesChoices {
@@ -20,6 +22,7 @@ export enum ContentTypesChoices {
     plugin = 'Plugin',
     role = 'Role',
     moduleUtils = 'Module Utils',
+    module_utils = 'Module Utils',
 }
 
 export enum ContentTypesPluralChoices {
@@ -28,6 +31,7 @@ export enum ContentTypesPluralChoices {
     plugin = 'Plugins',
     role = 'Roles',
     moduleUtils = 'Module Utils',
+    module_utils = 'Module Utils',
 }
 
 export enum ContentTypesIconClasses {
@@ -36,4 +40,5 @@ export enum ContentTypesIconClasses {
     plugin = 'fa fa-plug',
     role = 'fa fa-gear',
     moduleUtils = 'fa fa-microchip',
+    module_utils = 'fa fa-microchip',
 }

--- a/galaxyui/src/app/my-content/my-content.module.ts
+++ b/galaxyui/src/app/my-content/my-content.module.ts
@@ -39,6 +39,7 @@ import { SharedModule } from '../shared/shared.module';
 import { NamespaceActionComponent } from './namespace-list/action/action.component';
 
 import { NamespaceRepositoryActionComponent } from './namespace-list/content/repositories-content/action/action.component';
+import { RepoDetailsComponent } from './namespace-list/content/repositories-content/repo-details/repo-details.component';
 
 @NgModule({
     entryComponents: [AddRepositoryModalComponent, AlternateNameModalComponent],
@@ -52,6 +53,7 @@ import { NamespaceRepositoryActionComponent } from './namespace-list/content/rep
         AlternateNameModalComponent,
         NamespaceActionComponent,
         NamespaceRepositoryActionComponent,
+        RepoDetailsComponent,
     ],
     imports: [
         ActionModule,

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.html
@@ -82,7 +82,7 @@
         </div>
     </div>
 
-    <div class="row">
+    <div *ngIf="warnings.length > 0" class="row">
         <div class="col-sm-12">
             <h2>
                 Warnings
@@ -92,7 +92,7 @@
                 <ul>
                     <li *ngFor="let warn of warnings">
                         <span class="{{warn.warn_class}}"
-                            tooltip="{{'Severity: ' + warn.rule_severity}}"></span> 
+                            tooltip="{{'Severity: ' + warn.rule_severity}}"></span> &nbsp;
                         <b>{{ warn.linter_rule_id }}</b>: {{ warn.message_text }}
                     </li>
                 </ul>

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.html
@@ -58,7 +58,8 @@
             <div class="repo-contents">
                 <ul>
                     <li *ngFor="let content of repo.summary_fields.content_objects">
-                        <b>{{ content.name }}</b>: {{ content.description }}
+                        <span class="{{ content.icon_class }}" tooltip="{{content.type_text}}"></span>&nbsp;
+                        <b>{{ content.name }}</b><span *ngIf="content.description">: {{ content.description }}</span>
                     </li>
                 </ul>
             </div>

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.html
@@ -91,6 +91,8 @@
             <div class="repo-warnings">
                 <ul>
                     <li *ngFor="let warn of warnings">
+                        <span class="{{warn.warn_class}}"
+                            tooltip="{{'Severity: ' + warn.rule_severity}}"></span> 
                         <b>{{ warn.linter_rule_id }}</b>: {{ warn.message_text }}
                     </li>
                 </ul>

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.html
@@ -1,0 +1,84 @@
+<div class="container-fluid extra-details">
+    <div class="row">
+        <div class="col-sm-12">
+            <h2>
+                Info
+            </h2>
+            <div class="info">
+                <div class="info-row">
+                    <div class="info-left">
+                        Latest Commit:
+                    </div>
+                    <div class="info-right">
+                        {{ repo.commit_message }}
+                    </div>
+                </div>
+
+                <div class="info-row">
+                    <div class="info-left">
+                        Downloads:
+                    </div>
+                    <div class="info-right">
+                        {{ repo.download_count }}
+                    </div>
+                </div>
+
+                <div class="info-row">
+                    <div class="info-left">
+                        Community Score:
+                    </div>
+                    <div class="info-right">
+                        <span *ngIf="!repo.community_score">NA</span>
+                        {{ repo.community_score }}
+                    </div>
+                </div>
+
+                <div class="info-row">
+                    <div class="info-left">
+                        Quality Score:
+                    </div>
+                    <div class="info-right">
+                        <span *ngIf="!repo.quality_score">NA</span>
+                        {{ repo.quality_score }}
+                    </div>
+                </div>
+
+                <div class="info-row" *ngIf="repo.travis_build_url">
+                    <div class="info-left">
+                        Travis Status:
+                    </div>
+                    <div class="info-right">
+                        <a href="{{ repo.travis_build_url }}" container="body" target="_blank" tooltip="View Travis build output. Opens in new tab or window.">
+                            <img src="{{ repo.travis_status_url }}"
+                                class="travis-status-img" title="Travis Build Status" />
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+
+        <!-- Bootstrap stops working when I create two width 6 columns for some reason -->
+        <!-- <div class="col-xs-5">
+            <h2>
+                Surveys
+            </h2>
+        </div> -->
+    </div>
+
+    <div class="row">
+        <div class="col-sm-12">
+            <h2>
+                Content
+            </h2>
+
+            <div class="repo-contents">
+                <ul>
+                    <li *ngFor="let content of repo.summary_fields.content_objects">
+                        <b>{{ content.name }}</b>: {{ content.description }}
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.html
@@ -82,13 +82,14 @@
         </div>
     </div>
 
-    <div *ngIf="warnings.length > 0" class="row">
+    <div  class="row">
         <div class="col-sm-12">
             <h2>
                 Warnings
+                <span *ngIf="warningsLoading" class="fa fa-spin fa-spinner"></span>
             </h2>
 
-            <div class="repo-warnings">
+            <div *ngIf="warnings.length > 0" class="repo-warnings">
                 <ul>
                     <li *ngFor="let warn of warnings">
                         <span class="{{warn.warn_class}}"
@@ -96,6 +97,9 @@
                         <b>{{ warn.linter_rule_id }}</b>: {{ warn.message_text }}
                     </li>
                 </ul>
+            </div>
+            <div *ngIf="warnings.length === 0 && !warningsLoading">
+                <span class="fa fa-check-circle green-check"></span> No Warnings
             </div>
         </div>
     </div>

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.html
@@ -7,15 +7,6 @@
             <div class="info">
                 <div class="info-row">
                     <div class="info-left">
-                        Latest Commit:
-                    </div>
-                    <div class="info-right">
-                        {{ repo.commit_message }}
-                    </div>
-                </div>
-
-                <div class="info-row">
-                    <div class="info-left">
                         Downloads:
                     </div>
                     <div class="info-right">
@@ -28,8 +19,7 @@
                         Community Score:
                     </div>
                     <div class="info-right">
-                        <span *ngIf="!repo.community_score">NA</span>
-                        {{ repo.community_score }}
+                        {{ community }}
                     </div>
                 </div>
 
@@ -38,8 +28,7 @@
                         Quality Score:
                     </div>
                     <div class="info-right">
-                        <span *ngIf="!repo.quality_score">NA</span>
-                        {{ repo.quality_score }}
+                        {{ quality }}
                     </div>
                 </div>
 
@@ -58,12 +47,6 @@
         </div>
 
 
-        <!-- Bootstrap stops working when I create two width 6 columns for some reason -->
-        <!-- <div class="col-xs-5">
-            <h2>
-                Surveys
-            </h2>
-        </div> -->
     </div>
 
     <div class="row">

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.html
@@ -81,4 +81,20 @@
             </div>
         </div>
     </div>
+
+    <div class="row">
+        <div class="col-sm-12">
+            <h2>
+                Warnings
+            </h2>
+
+            <div class="repo-warnings">
+                <ul>
+                    <li *ngFor="let warn of warnings">
+                        <b>{{ warn.linter_rule_id }}</b>: {{ warn.message_text }}
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
 </div>

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.less
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.less
@@ -18,3 +18,7 @@
         }
     }
 }
+
+.green-check {
+    color: #5bb75b;
+}

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.less
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.less
@@ -1,0 +1,20 @@
+.extra-details {
+    font-size: 14px;
+}
+
+.info {
+    .info-row {
+        display: flex;
+
+        .info-left {
+            width: 150px;
+            min-width: 150px;
+            font-weight: 700;
+            display: inline-block;
+        }
+
+        .info-right {
+            display: inline-block;
+        }
+    }
+}

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RepoDetailsComponent } from './repo-details.component';
+
+describe('RepoDetailsComponent', () => {
+  let component: RepoDetailsComponent;
+  let fixture: ComponentFixture<RepoDetailsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ RepoDetailsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RepoDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.spec.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RepoDetailsComponent } from './repo-details.component';
 
 describe('RepoDetailsComponent', () => {
-  let component: RepoDetailsComponent;
-  let fixture: ComponentFixture<RepoDetailsComponent>;
+    let component: RepoDetailsComponent;
+    let fixture: ComponentFixture<RepoDetailsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ RepoDetailsComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [RepoDetailsComponent],
+        }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(RepoDetailsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(RepoDetailsComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.ts
@@ -18,7 +18,12 @@ export class RepoDetailsComponent implements OnInit {
     warnings: any[] = [];
     warningsLoading = true;
 
+    community: any;
+    quality: any;
+
     ngOnInit() {
+        this.quality = this.getScore(this.repo.quality_score);
+        this.community = this.getScore(this.repo.community_score);
         this.contentService
             .query({ repository_id: this.repo.id, page_size: 1000 })
             .subscribe(response => {
@@ -46,6 +51,15 @@ export class RepoDetailsComponent implements OnInit {
             return 'pficon-info';
         } else {
             return 'pficon-warning-triangle-o';
+        }
+    }
+
+    getScore(score) {
+        console.log(score);
+        if (score !== null) {
+            return Math.round(score * 10) / 10;
+        } else {
+            return 'NA';
         }
     }
 }

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.ts
@@ -3,6 +3,13 @@ import { Component, OnInit, Input } from '@angular/core';
 import { ContentService } from '../../../../../resources/content/content.service';
 import { Content } from '../../../../../resources/content/content';
 
+import {
+    ContentTypesIconClasses,
+    ContentTypesChoices,
+} from '../../../../../enums/content-types.enum';
+
+import { PluginTypes } from '../../../../../enums/plugin-types.enum';
+
 @Component({
     selector: 'app-repo-details',
     templateUrl: './repo-details.component.html',
@@ -24,6 +31,16 @@ export class RepoDetailsComponent implements OnInit {
     ngOnInit() {
         this.quality = this.getScore(this.repo.quality_score);
         this.community = this.getScore(this.repo.community_score);
+        this.repo.summary_fields.content_objects.forEach(cont => {
+            if (PluginTypes[cont.content_type]) {
+                cont['icon_class'] = ContentTypesIconClasses.plugin;
+                cont['type_text'] = PluginTypes[cont.content_type];
+            } else {
+                cont['icon_class'] = ContentTypesIconClasses[cont.content_type];
+                cont['type_text'] = ContentTypesChoices[cont.content_type];
+            }
+        });
+
         this.contentService
             .query({ repository_id: this.repo.id, page_size: 1000 })
             .subscribe(response => {
@@ -55,7 +72,6 @@ export class RepoDetailsComponent implements OnInit {
     }
 
     getScore(score) {
-        console.log(score);
         if (score !== null) {
             return Math.round(score * 10) / 10;
         } else {

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.ts
@@ -14,7 +14,22 @@ export class RepoDetailsComponent implements OnInit {
     @Input()
     repo;
 
-    repoContent: Content;
+    repoContent: Content[];
+    warnings: any[] = [];
 
-    ngOnInit() {}
+    ngOnInit() {
+        this.contentService
+            .query({ repository_id: this.repo.id, page_size: 1000 })
+            .subscribe(response => {
+                this.repoContent = response as Content[];
+
+                for (const cont of this.repoContent) {
+                    for (const task of cont.summary_fields['task_messages']) {
+                        if (task.message_type === 'WARNING') {
+                            this.warnings.push(task);
+                        }
+                    }
+                }
+            });
+    }
 }

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.ts
@@ -26,10 +26,23 @@ export class RepoDetailsComponent implements OnInit {
                 for (const cont of this.repoContent) {
                     for (const task of cont.summary_fields['task_messages']) {
                         if (task.message_type === 'WARNING') {
+                            task.warn_class = this.getWarningClass(
+                                task.rule_severity,
+                            );
                             this.warnings.push(task);
                         }
                     }
                 }
             });
+    }
+
+    getWarningClass(severity: number): string {
+        if (severity >= 4) {
+            return 'pficon-error-circle-o';
+        } else if (severity <= 1) {
+            return 'pficon-info';
+        } else {
+            return 'pficon-warning-triangle-o';
+        }
     }
 }

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.ts
@@ -16,6 +16,7 @@ export class RepoDetailsComponent implements OnInit {
 
     repoContent: Content[];
     warnings: any[] = [];
+    warningsLoading = true;
 
     ngOnInit() {
         this.contentService
@@ -33,6 +34,8 @@ export class RepoDetailsComponent implements OnInit {
                         }
                     }
                 }
+
+                this.warningsLoading = false;
             });
     }
 

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repo-details/repo-details.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+import { ContentService } from '../../../../../resources/content/content.service';
+import { Content } from '../../../../../resources/content/content';
+
+@Component({
+    selector: 'app-repo-details',
+    templateUrl: './repo-details.component.html',
+    styleUrls: ['./repo-details.component.less'],
+})
+export class RepoDetailsComponent implements OnInit {
+    constructor(private contentService: ContentService) {}
+
+    @Input()
+    repo;
+
+    repoContent: Content;
+
+    ngOnInit() {}
+}

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.html
@@ -65,7 +65,7 @@
                 </namespace-repository-action>
             </ng-template>
             <ng-template #listExpandTemplate let-item="item" let-index="index">
-                <h1>beep boop</h1>
+                <app-repo-details [repo]="item"></app-repo-details>
             </ng-template>
             </pfng-list>
 

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.html
@@ -15,6 +15,7 @@
             [config]="listConfig"
             [items]="items"
             [itemTemplate]="itemTemplate"
+            [expandTemplate]="listExpandTemplate"
             (onActionSelect)="handleAction($event, null)">
             <ng-template #itemTemplate let-item="item" let-index="index">
                 <div class="list-pf-left">
@@ -62,6 +63,9 @@
                     [repository]="item"
                     (handleAction)="handleItemAction($event)">
                 </namespace-repository-action>
+            </ng-template>
+            <ng-template #listExpandTemplate let-item="item" let-index="index">
+                <h1>beep boop</h1>
             </ng-template>
             </pfng-list>
 

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.html
@@ -37,7 +37,7 @@
                             (click)="toggleItem(item)"
                         >
                             <span class="pficon-warning-triangle-o"></span>
-                            <span class="warning-link"> See Warnings</span>
+                            <span class="warning-link"> Show Warnings</span>
                         </div>
 
 

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.html
@@ -32,6 +32,14 @@
                         <div>
                             <app-score [quality]="item.quality_score" [community]="item.community_score"></app-score>
                         </div>
+                        <div
+                            *ngIf="item.quality_score && item.quality_score < 5"
+                            (click)="toggleItem(item)"
+                        >
+                            <span class="pficon-warning-triangle-o"></span>
+                            <span class="warning-link"> See Warnings</span>
+                        </div>
+
 
                         <div *ngIf="item['latest_import'] && (item['latest_import']['state'] === 'PENDING' || item['latest_import']['state'] === 'RUNNING')">
                             <a [routerLink]="['/my-imports']" [queryParams]="{namespace: namespace.name, repository_name: item.name}" class="running"

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.less
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.less
@@ -49,3 +49,8 @@
     height: 30px;
     width: 30px;
 }
+
+.warning-link:hover {
+    color: #0088ce;
+    cursor: pointer;
+}

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.ts
@@ -27,7 +27,7 @@ import { ToolbarConfig } from 'patternfly-ng/toolbar/toolbar-config';
 import { Namespace } from '../../../../resources/namespaces/namespace';
 import { PagedResponse } from '../../../../resources/paged-response';
 import { ProviderNamespace } from '../../../../resources/provider-namespaces/provider-namespace';
-import { Repository } from '../../../../resources/repositories/repository';
+import { Repository as VanillaRepo } from '../../../../resources/repositories/repository';
 import { RepositoryService } from '../../../../resources/repositories/repository.service';
 import { RepositoryImportService } from '../../../../resources/repository-imports/repository-import.service';
 
@@ -36,6 +36,10 @@ import { AlternateNameModalComponent } from './alternate-name-modal/alternate-na
 import { forkJoin, interval, Observable } from 'rxjs';
 
 import * as moment from 'moment';
+
+class Repository extends VanillaRepo {
+    expanded: boolean;
+}
 
 @Component({
     encapsulation: ViewEncapsulation.None,
@@ -182,7 +186,7 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
             selectItems: false,
             selectionMatchProp: 'name',
             showCheckbox: false,
-            useExpandItems: false,
+            useExpandItems: true,
         } as ListConfig;
 
         if (this.namespace.active && provider_namespaces.length) {
@@ -290,6 +294,7 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
     }
 
     private prepareRepository(item: Repository) {
+        item['expanded'] = false;
         item['latest_import'] = {};
         item['detail_url'] = this.getDetailUrl(item);
         item['iconClass'] = this.getIconClass(item.format);
@@ -352,10 +357,21 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
                 this.maxItems = this.paginationConfig.totalItems;
             }
 
+            const expanded = [];
+
+            this.items.forEach(item => {
+                if (item.expanded) {
+                    expanded.push(item.id);
+                }
+            });
+
             // Generate a new list of repos
             const updatedList: Repository[] = [];
             repositories.forEach(repo => {
                 this.prepareRepository(repo);
+                if (expanded.includes(repo.id)) {
+                    repo.expanded = true;
+                }
                 updatedList.push(repo);
             });
 

--- a/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.ts
+++ b/galaxyui/src/app/my-content/namespace-list/content/repositories-content/repositories-content.component.ts
@@ -247,6 +247,10 @@ export class RepositoriesContentComponent implements OnInit, OnDestroy {
         this.refreshRepositories();
     }
 
+    toggleItem(item) {
+        item.expanded = !item.expanded;
+    }
+
     // Private
 
     private deprecate(isDeprecated: boolean, repo: Repository): void {


### PR DESCRIPTION
Fixes: #1206

These changes allow for:
- users to get quicker information about their galaxy content
- us to add in links for future functionality (ex: links to future repository dashboards, pages where you can suggest new platforms- #882, documentation about warnings etc.)

Warnings
![screen shot 2018-12-06 at 1 26 09 pm](https://user-images.githubusercontent.com/6063371/49604096-04a40b80-f95b-11e8-9855-de56909e2248.png)

No Warnings
![screen shot 2018-12-06 at 1 26 28 pm](https://user-images.githubusercontent.com/6063371/49604097-04a40b80-f95b-11e8-9223-e1182b2ab4c5.png)
