### PR TITLE
Fix search API in python 3

### DIFF
--- a/galaxy/api/views/search.py
+++ b/galaxy/api/views/search.py
@@ -198,8 +198,8 @@ class ContentSearchView(base.ListAPIView):
             download_rank=ExpressionWrapper(
                 download_rank_expr,
                 output_field=db_fields.FloatField()),
-            relevance=relevance_expr,
-            quality_rank=quality_rank_expr
+            quality_rank=quality_rank_expr,
+            relevance=relevance_expr
         )
 
     @staticmethod


### PR DESCRIPTION
Python 3 requires that the KWargs maintain the correct ordering.