### PR TITLE
Fix repositories deletion failure when using ansible-galaxy client

### DIFF
--- a/galaxy/api/views/views.py
+++ b/galaxy/api/views/views.py
@@ -922,7 +922,7 @@ class RemoveRole(base_views.APIView):
 
         roles = models.Content.objects.filter(
             repository__provider_namespace__name=gh_user,
-            repository__name=gh_repo)
+            repository__original_name=gh_repo)
         cnt = len(roles)
         if cnt == 0:
             response['status'] = (
@@ -949,7 +949,7 @@ class RemoveRole(base_views.APIView):
 
         repo = models.Repository.objects.get(
             provider_namespace__name=gh_user,
-            name=gh_repo)
+            original_name=gh_repo)
 
         models.Notification.objects.filter(repository=repo).delete()
         models.Content.objects.filter(repository=repo).delete()


### PR DESCRIPTION
ansible-galaxy client uses deprecated API to delete user repositories.
This patch fixes reporisotry and roles lookup performed by `name`
attribute instead of `original_name`.

Issue: #1420 