### PR TITLE
Remove public_repo github OAuth2 scope request

### DIFF
--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -259,7 +259,7 @@ SOCIALACCOUNT_PROVIDERS = {
         'SCOPE': ['r_emailaddress']
     },
     'github': {
-        'SCOPE': ['user:email', 'public_repo', 'read:org']
+        'SCOPE': ['user:email', 'read:org']
     },
 }
 


### PR DESCRIPTION
Galaxy now requires only read-only information to user's email,
public repositories and organizations.
Therefore `public_repo` scope can be not requested anymore.

Issue: #1424 