### PR TITLE
Use ansible-lint v4.0.0 and its default rules #1434

### DIFF
--- a/galaxy/importer/linters/__init__.py
+++ b/galaxy/importer/linters/__init__.py
@@ -118,8 +118,7 @@ class AnsibleLinter(BaseLinter):
     cmd = 'ansible-lint'
 
     def _check_files(self, paths):
-        rules_path = '/usr/local/galaxy-lint-rules/rules'
-        cmd = [self.cmd, '-p', '-r', rules_path, '.']
+        cmd = [self.cmd, '-p', '.']
         logger.debug('CMD: ' + ' '.join(cmd))
 
         # different logic needed for multi role repos since

--- a/galaxy/worker/tasks.py
+++ b/galaxy/worker/tasks.py
@@ -72,6 +72,7 @@ CONTENT_SEVERITY = {
     'ansible-lint_e402': 3,
     'ansible-lint_e403': 1,
     'ansible-lint_e404': 4,
+    'ansible-lint_e405': 2,
     'ansible-lint_e501': 5,
     'ansible-lint_e502': 3,
     'ansible-lint_e503': 3,


### PR DESCRIPTION
Backport: #1434

Signed-off-by: Andrew Crosby <acrosby@redhat.com>
(cherry picked from commit 79f767987ced809d74992c91b1d9f5e63d639066)