### PR TITLE
Run celery beat standalone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ runserver:
 
 .PHONY: celery
 celery:
-	python manage.py celeryd -B -Q 'celery,import_tasks,login_tasks,admin_tasks,user_tasks,star_tasks'
+	python manage.py celery worker --beat -Q 'celery,import_tasks,login_tasks,admin_tasks,user_tasks,star_tasks'
 
 .PHONY: ng_server
 ng_server:

--- a/scripts/docker/release/entrypoint.sh
+++ b/scripts/docker/release/entrypoint.sh
@@ -25,14 +25,22 @@ function run_web() {
 }
 
 function run_worker() {
-    _exec_cmd "${VENV_BIN}/galaxy-manage" celeryd \
-        --beat \
+    _exec_cmd "${VENV_BIN}/galaxy-manage" celery worker \
+        --loglevel WARNING \
+        --queues 'celery,import_tasks,login_tasks,admin_tasks,user_tasks,star_tasks'
+}
+
+function run_scheduler() {
+    _exec_cmd "${VENV_BIN}/galaxy-manage" celery beat \
         --loglevel WARNING \
         --queues 'celery,import_tasks,login_tasks,admin_tasks,user_tasks,star_tasks'
 }
 
 function run_service() {
     case $1 in
+        scheduler)
+            run_scheduler
+        ;;
         web)
             run_web
         ;;
@@ -49,6 +57,7 @@ case "$1" in
     manage)
         _exec_cmd "${VENV_BIN}/galaxy-manage" "${@:2}"
     ;;
+    *)
+        _exec_cmd "$@"
+    ;;
 esac
-
-_exec_cmd "$@"


### PR DESCRIPTION
* Release image `run worker` command doesn't start celery beat
  as a part of worker process.
* Release image `run scheduler` command starts standalone celery
  beat process.
* Replace deprecated `celeryd` command with `celery worker`.