### PR TITLE
Upgrade pyyaml to 4.2b4 release

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -92,7 +92,7 @@ python-dateutil==2.7.5
 python-dotenv==0.10.1     # via dynaconf
 python3-openid==3.1.0     # via django-allauth
 pytz==2018.7
-pyyaml==3.13
+pyyaml==4.2b4
 redis==3.0.1              # via rq
 requests-oauthlib==1.0.0
 requests==2.20.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -10,7 +10,7 @@ PyGithub
 pyOpenSSL
 python-dateutil
 pytz
-PyYAML
+PyYAML>=4.2b0
 requests
 requests-oauthlib
 rst2html5-tools

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -79,7 +79,7 @@ python-dateutil==2.7.5
 python-dotenv==0.10.1     # via dynaconf
 python3-openid==3.1.0     # via django-allauth
 pytz==2018.7
-pyyaml==3.13
+pyyaml==4.2b4
 redis==3.0.1              # via rq
 requests-oauthlib==1.0.0
 requests==2.20.1


### PR DESCRIPTION
pyyaml < 4.2b1 has security vulnerabilities.

Vulnerable versions: < 4.2b1
Patched version: 4.2b1
In PyYAML before 4.1, the yaml.load() API could execute arbitrary code. In other words, yaml.safe_load is not used.

Details: https://nvd.nist.gov/vuln/detail/CVE-2017-18342