### PR TITLE
Reword used in production question.

### DIFF
--- a/galaxyui/src/app/content-detail/cards/survey/community-survey.component.html
+++ b/galaxyui/src/app/content-detail/cards/survey/community-survey.component.html
@@ -56,7 +56,7 @@
                     <div class="title">Tell us about this collection</div>
 
                     <div *ngFor="let key of surveyKeys" class="input">
-                        <div class="input-title">{{surveyConfig[key].question}}</div>
+                        <div class="input-title" [tooltip]="surveyConfig[key].tooltip" >{{surveyConfig[key].question}}</div>
                         <div class="input-form">
                             <div *ngFor="let button of surveyConfig[key].type"
                                  (click)="submitRating(key, button.value)"

--- a/galaxyui/src/app/content-detail/cards/survey/community-survey.component.ts
+++ b/galaxyui/src/app/content-detail/cards/survey/community-survey.component.ts
@@ -104,22 +104,29 @@ export class CardCommunitySurveyComponent implements OnInit {
             docs: {
                 question: 'Quality of docs?',
                 type: likehartType,
+                tooltip: '',
             },
             ease_of_use: {
                 question: 'Ease of use?',
                 type: likehartType,
+                tooltip: '',
             },
             does_what_it_says: {
                 question: 'Does what it promises?',
                 type: boolType,
+                tooltip: '',
             },
             works_as_is: {
                 question: 'Works without change?',
                 type: boolType,
+                tooltip: '',
             },
             used_in_production: {
-                question: 'Used in production?',
+                question: 'Ready for production?',
                 type: boolType,
+                tooltip:
+                    'Would you be comfortable using this in a production ' +
+                    'class or mission critical workflow?',
             },
         };
 


### PR DESCRIPTION
Change "Used in Production" to "Ready for Production" on community survey:

<img width="467" alt="screen shot 2019-01-28 at 10 16 07 am" src="https://user-images.githubusercontent.com/6063371/51845730-16b08380-22e6-11e9-8d90-bd5ba54fefd3.png">

Fixes: #1444 
