### PR TITLE
Fix pulp tasks api

### DIFF
--- a/galaxy/pulp/serializers.py
+++ b/galaxy/pulp/serializers.py
@@ -1,0 +1,69 @@
+from gettext import gettext as _
+
+from rest_framework import serializers
+
+from pulpcore.app import models as pulp_models
+from pulpcore.app import serializers as pulp_serializers
+
+
+class TaskSerializer(pulp_serializers.ModelSerializer):
+    _href = pulp_serializers.IdentityField(view_name='tasks-detail')
+    job_id = serializers.UUIDField(
+        help_text=_("ID of the job in rq."),
+        read_only=True
+    )
+    state = serializers.CharField(
+        help_text=_(
+            "The current state of the task. The possible values include:"
+            " 'waiting', 'skipped', 'running', 'completed',"
+            " 'failed' and 'canceled'."),
+        read_only=True
+    )
+    started_at = serializers.DateTimeField(
+        help_text=_("Timestamp of the when this task started execution."),
+        read_only=True
+    )
+    finished_at = serializers.DateTimeField(
+        help_text=_("Timestamp of the when this task stopped execution."),
+        read_only=True
+    )
+    non_fatal_errors = serializers.JSONField(
+        help_text=_(
+            "A JSON Object of non-fatal errors encountered during"
+            " the execution of this task."),
+        read_only=True
+    )
+    error = serializers.JSONField(
+        help_text=_(
+            "A JSON Object of a fatal error encountered during"
+            " the execution of this task."),
+        read_only=True
+    )
+    worker = pulp_serializers.RelatedField(
+        help_text=_("The worker associated with this task."
+                    " This field is empty if a worker is not yet assigned."),
+        read_only=True,
+        view_name='workers-detail'
+    )
+    parent = pulp_serializers.RelatedField(
+        help_text=_("The parent task that spawned this task."),
+        read_only=True,
+        view_name='tasks-detail'
+    )
+    spawned_tasks = pulp_serializers.RelatedField(
+        help_text=_("Any tasks spawned by this task."),
+        many=True,
+        read_only=True,
+        view_name='tasks-detail'
+    )
+    progress_reports = pulp_serializers.ProgressReportSerializer(
+        many=True,
+        read_only=True
+    )
+
+    class Meta:
+        model = pulp_models.Task
+        fields = pulp_serializers.ModelSerializer.Meta.fields + (
+            'job_id', 'state', 'started_at', 'finished_at',
+            'non_fatal_errors', 'error', 'worker', 'parent',
+            'spawned_tasks', 'progress_reports')

--- a/galaxy/pulp/urls.py
+++ b/galaxy/pulp/urls.py
@@ -1,8 +1,10 @@
 from django.conf.urls import include, url
+from pulpcore.app import viewsets as pulp_viewsets
 
 from . import views
 
-pulp_urls = [
+
+api_urls = [
     url(r'^tasks/$',
         views.TaskViewSet.as_view({'get': 'list'})),
     url(r'^tasks/(?P<pk>[^/.]+)/$',
@@ -10,6 +12,28 @@ pulp_urls = [
         name='tasks-detail'),
 ]
 
+# NOTE(cutwater): Pulp views have hard dependencies on other views by
+# serializing reversed URLs as references to other resources.
+# Therefore we expose views that are not intended to be accessed publicly
+# to standalone URL.
+private_urls = [
+    url(r'^workers/(?P<pk>[^/.]+)/$',
+        pulp_viewsets.WorkerViewSet.as_view({'get', 'retrieve'}),
+        name='workers-detail'),
+    url(r'^repository/(?P<pk>[^/.]+)/',
+        pulp_viewsets.RepositoryViewSet.as_view({'get', 'retrieve'}),
+        name='repositories-detail'),
+    url(r'^repository/(?P<repository_pk>[^/.]+)/versions/(?P<number>[^/.]+)/',
+        pulp_viewsets.RepositoryVersionViewSet.as_view({'get': 'retrieve'}),
+        name='versions-detail'),
+    url(
+        r'^repository/(?P<repository_pk>[^/.]+)/'
+        r'versions/(?P<number>[^/.]+)/content/',
+        pulp_viewsets.RepositoryVersionViewSet.as_view({'get': 'content'}),
+        name='versions-content'),
+]
+
 urlpatterns = [
-    url(r'^v1/pulp/', include(pulp_urls)),
+    url(r'^api/v1/', include(api_urls)),
+    url(r'^_pulp/', include(private_urls)),
 ]

--- a/galaxy/pulp/views.py
+++ b/galaxy/pulp/views.py
@@ -1,7 +1,9 @@
 from pulpcore.app.viewsets import TaskViewSet as _TaskViewSet
 from rest_framework.permissions import IsAuthenticated
 
+from . import serializers
+
 
 class TaskViewSet(_TaskViewSet):
-
     permission_classes = (IsAuthenticated, )
+    serializer_class = serializers.TaskSerializer

--- a/galaxy/urls.py
+++ b/galaxy/urls.py
@@ -27,12 +27,12 @@ admin.autodiscover()
 urlpatterns = [
     url(r'^accounts/', include('allauth.urls')),
     url(r'^api/', include('galaxy.api.urls')),
-    url(r'^api/', include('galaxy.pulp.urls')),
     url(r'^api-auth/', include('rest_framework.urls',
                                namespace='rest_framework')),
     url(settings.ADMIN_URL_PATTERN, admin.site.urls),
     url(r'^robots\.txt$', TemplateView.as_view(template_name="robots.txt",
                                                content_type='text/plain')),
+    url(r'', include('galaxy.pulp.urls')),
     url(r'', include('django_prometheus.urls')),
     url(r'', include('galaxy.main.urls')),
 ]


### PR DESCRIPTION
* Use custom serializer that does not include created resources.
* Expose routes required by tasks serializer to private URL
  namespace `/_pulp`.

Fixes: #1490