### PR TITLE
Swap migration order to allow for backport.

### DIFF
--- a/galaxy/main/migrations/0125_community_score_question_average.py
+++ b/galaxy/main/migrations/0125_community_score_question_average.py
@@ -23,7 +23,7 @@ set community_score =
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('main', '0125_collection_base'),
+        ('main', '0124_auto_20181210_1433'),
     ]
 
     operations = [

--- a/galaxy/main/migrations/0126_collection_base.py
+++ b/galaxy/main/migrations/0126_collection_base.py
@@ -19,7 +19,7 @@ def delete_galaxy_repository(apps, schema_editor):
 class Migration(migrations.Migration):
     dependencies = [
         ('pulp_app', '0001_initial'),
-        ('main', '0124_auto_20181210_1433'),
+        ('main', '0125_community_score_question_average'),
     ]
 
     operations = [


### PR DESCRIPTION
Change order of migrations 0125_collection_base and 0126_community_score_question_average so we can backport 0126