### PR TITLE
Fix auth token use on artifact publish api.

### DIFF
--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -190,6 +190,10 @@ DATABASES = {}
 # ---------------------------------------------------------
 
 REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    ),
     'DEFAULT_PERMISSION_CLASSES': (
         'galaxy.api.permissions.ModelAccessPermission',
     ),


### PR DESCRIPTION
Add TokenAuthentication to the default auth
classes.

Based on:
https://www.django-rest-framework.org/api-guide/authentication/#setting-the-authentication-scheme

Without this a POST to api/v1/collections with token auth headers always gives a 403

For a request like
```
 POST /api/v1/collections/ HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Authorization: Token aaaabbbbdeadbeefcafedddda123412344cf9a5c
Connection: keep-alive
Content-Length: 8843
Content-Type: multipart/form-data; boundary=30a79a721dbc260b13098f42e3d971f9
Host: localhost:8000
User-Agent: HTTPie/0.9.9
```

with devel (without this pr) response
```
HTTP/1.1 403 Forbidden
Access-Control-Allow-Origin: *
X-Powered-By: Express
allow: POST, OPTIONS
connection: keep-alive
content-length: 58
content-type: application/json
date: Fri, 01 Feb 2019 16:56:41 GMT
server: WSGIServer/0.2 CPython/3.6.6
vary: Accept, Cookie
x-frame-options: SAMEORIGIN

{
    "detail": "Authentication credentials were not provided."
}
```

(With this pr) reposonse:
```
HTTP/1.1 202 Accepted
Access-Control-Allow-Origin: *
X-Powered-By: Express
allow: POST, OPTIONS
connection: keep-alive
content-length: 28
content-type: application/json
date: Fri, 01 Feb 2019 16:58:43 GMT
server: WSGIServer/0.2 CPython/3.6.6
vary: Accept
x-frame-options: SAMEORIGIN

{
    "task": "/api/v1/tasks/30/"
}
```