### PR TITLE
Fix dropdown menus in react production build

### DIFF
--- a/galaxyui/angular.json
+++ b/galaxyui/angular.json
@@ -37,7 +37,7 @@
               "aot": true,
               "extractLicenses": true,
               "vendorChunk": false,
-              "buildOptimizer": true,
+              "buildOptimizer": false,
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",

--- a/galaxyui/package.json
+++ b/galaxyui/package.json
@@ -27,6 +27,7 @@
     "patternfly": "^3.54.1",
     "patternfly-ng": "4.2.0",
     "patternfly-react": "^2.29.0",
+    "prop-types": "^15.6.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "rxjs": "^6.2.2",

--- a/galaxyui/yarn.lock
+++ b/galaxyui/yarn.lock
@@ -5524,7 +5524,6 @@ preserve@^0.2.0:
 prettier@^1.15.3:
   version "1.15.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.3.tgz#1feaac5bdd181237b54dbe65d874e02a1472786a"
-  integrity sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -5567,6 +5566,14 @@ prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.1,
   dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+prop-types@^15.6.0:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 protractor@~5.4.0:
   version "5.4.0"
@@ -5839,6 +5846,10 @@ react-fontawesome@^1.6.1:
 react-is@^16.3.2:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
+
+react-is@^16.8.1:
+  version "16.8.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.2.tgz#09891d324cad1cb0c1f2d91f70a71a4bee34df0f"
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
- Disable angular build optimization.
- Add missing dependencies for patternfly-react.

Fixes this problem:
<img width="175" alt="screen shot 2019-02-18 at 9 57 35 am" src="https://user-images.githubusercontent.com/6063371/53031440-da7ec780-343a-11e9-81a3-53c41dffe088.png">

Unfortunately disabling build optimization will increase the size of our javascript bundles by about 20%, but there don't seem to be any other ways to prevent it from messing with react.