### PR TITLE
Fix content not found issue on content detail page.

### DIFF
--- a/galaxyui/src/app/content-detail/content-detail.component.html
+++ b/galaxyui/src/app/content-detail/content-detail.component.html
@@ -2,7 +2,7 @@
     <app-page-header [headerTitle]="pageTitle" [headerIcon]="pageIcon"></app-page-header>
 
     <div class="container-fluid content-detail-container">
-        <div *ngIf="repository.deprecated" class="alert alert-danger">
+        <div *ngIf="repository && repository.deprecated" class="alert alert-danger">
             <span class="pficon pficon-error-circle-o"></span>
             This item has been deprecated. We recommend that you take a look at one of <a [routerLink]="['/','search']" [queryParams]="{keywords: repository.name, deprecated: false}">
                 these instead</a>.


### PR DESCRIPTION
Fixes: #1596

If the repository wasn't set when the page loaded checking `repository.deprecated` caused the page to crash before the Content Not Found empty page could be displayed.