### PR TITLE
Backport of  auth token fix from #1505 to stable/3.1

### DIFF
--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -176,6 +176,10 @@ DATABASES = {}
 # ---------------------------------------------------------
 
 REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    ),
     'DEFAULT_PERMISSION_CLASSES': (
         'galaxy.api.permissions.ModelAccessPermission',
     ),


### PR DESCRIPTION

Fix auth token use on artifact publish api.

Add TokenAuthentication to the default auth
classes.

Based on:
https://www.django-rest-framework.org/api-guide/authentication/#setting-the-authentication-scheme

(cherry picked from commit ee8ac5a80c3cbb2aa5c0998ef54359bbef8c62f7)
