### PR TITLE
Drop six library

### DIFF
--- a/galaxy/api/filters.py
+++ b/galaxy/api/filters.py
@@ -19,8 +19,6 @@
 #   to `galaxy.api.v1` package and eventually removed.
 import re
 
-import six
-
 # Django
 from django.core.exceptions import (
     FieldError, ValidationError, ObjectDoesNotExist)
@@ -95,7 +93,7 @@ class _FieldLookupBackend(BaseFilterBackend):
         return field
 
     def to_python_boolean(self, value, allow_none=False):
-        value = six.text_type(value)
+        value = str(value)
         if value.lower() in ('true', '1'):
             return True
         elif value.lower() in ('false', '0'):
@@ -107,7 +105,7 @@ class _FieldLookupBackend(BaseFilterBackend):
                 u'Unable to convert "{}" to boolean'.format(value))
 
     def to_python_related(self, value):
-        value = six.text_type(value)
+        value = str(value)
         if value.lower() in ('none', 'null'):
             return None
         else:

--- a/galaxy/api/views/base_views.py
+++ b/galaxy/api/views/base_views.py
@@ -17,7 +17,6 @@
 
 import inspect
 import logging
-import six
 
 from django.http import Http404
 from django.shortcuts import get_object_or_404
@@ -101,9 +100,9 @@ class GenericAPIView(generics.GenericAPIView, APIView):
         d = super(GenericAPIView, self).get_description_context()
         d.update({
             'model_verbose_name':
-                six.text_type(self.model._meta.verbose_name),
+                str(self.model._meta.verbose_name),
             'model_verbose_name_plural':
-                six.text_type(self.model._meta.verbose_name_plural),
+                str(self.model._meta.verbose_name_plural),
             'serializer_fields': self.get_serializer().metadata(),
         })
         return d
@@ -212,9 +211,9 @@ class SubListAPIView(ListAPIView):
         d = super(SubListAPIView, self).get_description_context()
         d.update({
             'parent_model_verbose_name':
-                six.text_type(self.parent_model._meta.verbose_name),
+                str(self.parent_model._meta.verbose_name),
             'parent_model_verbose_name_plural':
-                six.text_type(self.parent_model._meta.verbose_name_plural),
+                str(self.parent_model._meta.verbose_name_plural),
         })
         return d
 

--- a/galaxy/api/views/notification.py
+++ b/galaxy/api/views/notification.py
@@ -1,10 +1,10 @@
 import base64
 import json
 import logging
+import urllib.parse as urlparse
 
 from hashlib import sha256
 import requests
-from six.moves.urllib import parse as urlparse
 
 from OpenSSL import crypto
 from django.conf import settings

--- a/galaxy/api/views/repository.py
+++ b/galaxy/api/views/repository.py
@@ -18,8 +18,6 @@
 import logging
 import re
 
-from six import string_types
-
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count
 
@@ -125,7 +123,7 @@ class RepositoryList(views.ListCreateAPIView):
 
         for field in GITHUB_REPO_FIELDS:
             if repo.get(field) is not None:
-                if isinstance(repo[field], string_types):
+                if isinstance(repo[field], str):
                     data[field] = repo[field][:256]
                 else:
                     data[field] = repo[field]

--- a/galaxy/api/views/search.py
+++ b/galaxy/api/views/search.py
@@ -17,8 +17,7 @@
 
 import operator
 from collections import OrderedDict
-
-import six
+import functools
 
 from django.db.models import F, Func, Value, Count, ExpressionWrapper, Q
 from django.db.models.functions import Coalesce
@@ -230,7 +229,7 @@ class ContentSearchView(base.ListAPIView):
         if not namespaces:
             return queryset
         queries = [Q(namespace__name__icontains=name) for name in namespaces]
-        query = six.moves.reduce(operator.or_, queries)
+        query = functools.reduce(operator.or_, queries)
         return queryset.filter(query)
 
     @staticmethod
@@ -254,7 +253,7 @@ class ContentSearchView(base.ListAPIView):
             return queryset.annotate(
                 search_rank=Value(0.0, output_field=db_fields.FloatField()))
 
-        tsquery = six.moves.reduce(
+        tsquery = functools.reduce(
             operator.and_,
             (psql_search.SearchQuery(kw) for kw in keywords))
 

--- a/galaxy/importer/finders.py
+++ b/galaxy/importer/finders.py
@@ -21,8 +21,6 @@ import itertools
 import logging
 import os
 
-import six
-
 from galaxy import constants
 from galaxy.importer import exceptions as exc
 
@@ -38,14 +36,14 @@ Result = collections.namedtuple(
     'Result', ['content_type', 'path', 'extra'])
 
 
-@six.add_metaclass(abc.ABCMeta)
-class BaseFinder(object):
+class BaseFinder(metaclass=abc.ABCMeta):
 
     def __init__(self, path, logger=None):
         self.path = path
         self.log = logger or default_logger
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def repository_format(self):
         pass
 

--- a/galaxy/importer/linters/__init__.py
+++ b/galaxy/importer/linters/__init__.py
@@ -19,8 +19,6 @@ import os
 import subprocess
 import logging
 
-import six
-
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +34,7 @@ class BaseLinter(object):
         self.root = workdir
 
     def check_files(self, paths):
-        if isinstance(paths, six.string_types):
+        if isinstance(paths, str):
             paths = [paths]
         paths = [os.path.normpath(p) for p in paths]
         return self._check_files(paths)

--- a/galaxy/importer/loaders/apb.py
+++ b/galaxy/importer/loaders/apb.py
@@ -18,7 +18,6 @@
 import os
 import re
 
-import six
 import semantic_version as semver
 import yaml
 
@@ -67,7 +66,7 @@ class APBMetaParser(object):
 
     def _check_version(self):
         version = self._get_key('version')
-        if not isinstance(version, six.string_types):
+        if not isinstance(version, str):
             self.log.warning('Version value in metadata is not a string')
             return
         try:

--- a/galaxy/importer/loaders/base.py
+++ b/galaxy/importer/loaders/base.py
@@ -19,8 +19,6 @@ import abc
 import logging
 import os
 
-import six
-
 from galaxy.common import logutils
 from galaxy.importer.utils import readme as readmeutils
 from galaxy.main import models
@@ -82,8 +80,7 @@ COMPATIBILITY_SEVERITY = {
 }
 
 
-@six.add_metaclass(abc.ABCMeta)
-class BaseLoader(object):
+class BaseLoader(metaclass=abc.ABCMeta):
 
     content_types = None
     linters = None

--- a/galaxy/importer/loaders/role.py
+++ b/galaxy/importer/loaders/role.py
@@ -19,7 +19,6 @@ import collections
 import os
 import re
 
-import six
 import yaml
 import configparser
 
@@ -138,7 +137,7 @@ class RoleMetaParser(object):
 
     def parse_cloud_platforms(self):
         cloud_platforms = self.metadata.get('cloud_platforms', [])
-        if isinstance(cloud_platforms, six.string_types):
+        if isinstance(cloud_platforms, str):
             cloud_platforms = [cloud_platforms]
         return cloud_platforms
 
@@ -170,7 +169,7 @@ class RoleMetaParser(object):
                 continue
             if set(video) != {'url', 'title'}:
                 continue
-            for name, expr in six.iteritems(self.VIDEO_REGEXP):
+            for name, expr in self.VIDEO_REGEXP.items():
                 match = expr.match(video['url'])
                 if match:
                     file_id = match.group(1)
@@ -355,7 +354,7 @@ class RoleLoader(base.BaseLoader):
         attrs = {}
         for key, default in self.STRING_ATTRS:
             value = metadata.get(key) or default
-            if isinstance(value, six.string_types):
+            if isinstance(value, str):
                 value = value.strip()
             attrs[key] = value
         return attrs

--- a/galaxy/main/celerytasks/tasks.py
+++ b/galaxy/main/celerytasks/tasks.py
@@ -20,14 +20,12 @@ import logging
 
 import celery
 import github
-import six
 
 from django.db import transaction
 from django.utils import timezone
 from django.core.exceptions import ObjectDoesNotExist
 
-from galaxy.main.models import (Content,
-                                ImportTask)
+from galaxy.main.models import Content, ImportTask
 from galaxy.main import models
 from galaxy import constants
 
@@ -214,7 +212,7 @@ def refresh_user_stars(user, token):
     old_starred = {(s.repository.github_user, s.repository.github_repo): s.id
                    for s in user.starred.select_related('repository').all()}
 
-    to_remove = [v for k, v in six.iteritems(old_starred)
+    to_remove = [v for k, v in old_starred.items()
                  if k not in new_starred]
     to_add = new_starred - set(old_starred)
 

--- a/galaxy/main/mixins.py
+++ b/galaxy/main/mixins.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-import six
-
 
 __all__ = ['DirtyMixin']
 
@@ -32,7 +30,7 @@ class DirtyMixin(object):
     @property
     def is_dirty(self):
         missing = object()
-        for key, value in six.iteritems(self._original_state):
+        for key, value in self._original_state.items():
             if value != self.__dict__.get(key, missing):
                 return True
         return False

--- a/galaxy/worker/utils.py
+++ b/galaxy/worker/utils.py
@@ -16,15 +16,13 @@
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
 import semantic_version
-import six
-
 
 from galaxy.main import models
 
 
 class Context(object):
     def __init__(self, **kwargs):
-        for arg, value in six.iteritems(kwargs):
+        for arg, value in kwargs.items():
             setattr(self, arg, value)
 
 

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -106,7 +106,6 @@ rst2html5-tools==0.5.3
 ruamel.yaml==0.15.85      # via ansible-lint, drf-yasg
 s3transfer==0.2.0         # via boto3
 semantic-version==2.6.0
-six==1.12.0
 snowballstemmer==1.2.1    # via sphinx
 sphinx==1.7.9
 sphinxcontrib-websupport==1.1.0  # via sphinx

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -51,10 +51,6 @@ celery==3.1.24
 django-celery
 
 
-# Python 3 compatibility
-six
-
-
 # Web analytics/metrics
 prometheus_client
 django-prometheus

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -93,7 +93,6 @@ rst2html5-tools==0.5.3
 ruamel.yaml==0.15.85      # via ansible-lint, drf-yasg
 s3transfer==0.2.0         # via boto3
 semantic-version==2.6.0
-six==1.12.0
 snowballstemmer==1.2.1    # via sphinx
 sphinx==1.7.9
 sphinxcontrib-websupport==1.1.0  # via sphinx


### PR DESCRIPTION
After Galaxy fully migrated to Python 3, six library can be safely
replaced with Python 3 native code.