### PR TITLE
Fix typo on mazer install.rst

### DIFF
--- a/docs/docsite/rst/mazer/reference/install.rst
+++ b/docs/docsite/rst/mazer/reference/install.rst
@@ -26,7 +26,7 @@ The namespace to use when installing content. Required when installing from a gi
 
 .. option:: -n, --no-deps
 
-Do NOT download and isntall any dependencies.
+Do NOT download and install any dependencies.
 
 .. option:: -r ROLE_FILE, --role-file=ROLE_FILE
 


### PR DESCRIPTION
Fix 'isntall' to 'install' on mazer/reference/install.rst

+label: docsite_pr