### PR TITLE
[WIP] Adjust configuration for local test runs, and add first tests for internal UI API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,21 @@ build/release:
 # Test targets
 # ---------------------------------------------------------
 
+.PHONY: test
+test:
+	@export DJANGO_SETTINGS_MODULE=galaxy.settings.testing
+	@pytest galaxy \
+	--cov galaxy \
+	--cov-report xml \
+	--cov-report term \
+	--cov-report html \
+	--cov-config setup.cfg \
+
+.PHONY: test/changed
+test/changed:
+	@export DJANGO_SETTINGS_MODULE=galaxy.settings.testing
+	@git status | grep 'test' | xargs pytest -s -vvv --reuse-db
+
 .PHONY: test/flake8
 test/flake8:
 	flake8 galaxy
@@ -183,7 +198,23 @@ dev/test:
 # - install side packages globally or
 # - call tools using python api instead of shell commands.
 	@$(DOCKER_COMPOSE) exec galaxy bash -c '\
-		source $(GALAXY_VENV)/bin/activate; pytest galaxy'
+		source $(GALAXY_VENV)/bin/activate \
+		export DJANGO_SETTINGS_MODULE=galaxy.settings.testing \
+		pytest galaxy \
+		--cov galaxy \
+		--cov-report xml \
+		--cov-report term \
+		--cov-report html \
+		--cov-config setup.cfg \
+		'
+
+.PHONY: dev/test/changed
+dev/test/changed:
+	@echo "Running changed tests"
+	@$(DOCKER_COMPOSE) exec galaxy bash -c '\
+		export DJANGO_SETTINGS_MODULE=galaxy.settings.testing \
+		git status | grep 'test' | xargs pytest -s -vvv --reuse-db \
+		'
 
 .PHONY: dev/waitenv
 dev/waitenv:

--- a/galaxy/api/v2/tests/test_collection_view.py
+++ b/galaxy/api/v2/tests/test_collection_view.py
@@ -1,0 +1,35 @@
+import pytest
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from galaxy.importer.models import BaseCollectionInfo, GalaxyCollectionInfo
+from galaxy.main import models
+
+
+
+class CollectionViewTests(TestCase):
+
+    def setUp(self):
+        self.namespace = models.Namespace.objects.create(
+            name='mynamespace',
+        )
+        self.collection = models.Collection.objects.create(
+            namespace=self.namespace,
+            name='mycollection',
+        )
+        self.version = models.CollectionVersion.objects.create(
+            collection=self.collection,
+            version='1.0.0',
+            contents='{}',
+        )
+
+    def test_get_collections(self):
+        client = APIClient()
+        resp = client.get("/api/internal/ui/collections/")
+        results = resp.json()['results']
+
+        collection = results[0]
+
+        assert collection['namespace'] == self.namespace.id
+        assert collection['name'] == self.collection.name
+        assert collection['latest_version']['version'] == self.version.version

--- a/galaxy/settings/local.py
+++ b/galaxy/settings/local.py
@@ -1,0 +1,10 @@
+from .testing import *
+
+
+DATABASES = {
+    'default': {
+        'NAME': 'galaxy',
+        'CONN_MAX_AGE': None,
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+    }
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,25 +36,12 @@ galaxy =
     templates/*.html
     templates/**/*.html
 
-[tool:pytest]
-# NOTE: This way won't work because env vars are already defined by compose
-# DJANGO_SETTINGS_MODULE=..
-# So instead of pytest-django we use pytest-env to override envvars forcefully
-env =
-    DJANGO_SETTINGS_MODULE=galaxy.settings.testing
-addopts =
-    --cov galaxy
-    --cov-report xml
-    --cov-report term
-    --cov-report html
-    --cov-config setup.cfg
-
 [coverage:run]
 omit = */migrations/*
        */test_*.py
 branch = True
 
 [coverage:report]
-fail_under = 39
+fail_under = 40
 
 [flake8]


### PR DESCRIPTION
Here's a starting point for unit tests against the internal UI API being added for collections.

It also includes some changes to make running tests easier, because the lower the friction on running tests the higher value the tests are going to have for the team. Here's a summary of the changes:

- Adding a make target `make test` to run tests locally, and moved some test configuration to allow running tests locally.
- Added make targets `make test/changed` and `make dev/test/changed` which only runs test modules that have uncommitted changes and skips coverage reporting (since they aren't valid when run on a subset of tests). This supports faster test runs and more efficient test/change/retest loops for the developer.
- Reduces most test run-times from minutes to 2 seconds.
- Coverage parameters are moved from `setup.cfg` to `Makefile` so they can be adjusted for the full versus partial targets