### PR TITLE
Move dependencies database check from importer to worker

### DIFF
--- a/galaxy/importer/models.py
+++ b/galaxy/importer/models.py
@@ -120,11 +120,11 @@ class BaseCollectionInfo(object):
 
     @property
     def label(self):
-        return '%s.%s' % (self.namespace, self.name)
+        return f"{self.namespace}.{self.name}"
 
     @staticmethod
     def value_error(msg):
-        raise ValueError("Invalid collection metadata. %s" % msg) from None
+        raise ValueError(f"Invalid collection metadata. {msg}") from None
 
     @namespace.validator
     @name.validator
@@ -132,34 +132,34 @@ class BaseCollectionInfo(object):
     def _check_required(self, attribute, value):
         '''Check that value is present'''
         if not value:
-            self.value_error("'%s' is required" % attribute.name)
+            self.value_error(f"'{attribute.name}' is required")
 
     @namespace.validator
     @name.validator
     def _check_name(self, attribute, value):
         '''Check value against name regular expression'''
         if not re.match(constants.NAME_REGEXP, value):
-            self.value_error("'%s' has invalid format: %s" %
-                             (attribute.name, value))
+            self.value_error(f"'{attribute.name}' has invalid format: {value}")
 
     @version.validator
     def _check_version_format(self, attribute, value):
         '''Check that version is in semantic version format'''
         if not semantic_version.validate(value):
-            self.value_error("Expecting 'version' to be in semantic version "
-                             "format, instead found '%s'." % value)
+            self.value_error(
+                "Expecting 'version' to be in semantic version "
+                f"format, instead found '{value}'.")
 
     @authors.validator
     @tags.validator
     @license.validator
     def _check_list_of_str(self, attribute, value):
         '''Check that value is a list of strings'''
-        err_msg = "Expecting '%s' to be a list of strings"
+        err_msg = "Expecting '{attr}' to be a list of strings"
         if not isinstance(value, list):
-            self.value_error(err_msg % attribute.name)
+            self.value_error(err_msg.format(attr=attribute.name))
         for list_item in value:
             if not isinstance(list_item, str):
-                self.value_error(err_msg % attribute.name)
+                self.value_error(err_msg.format(attr=attribute.name))
 
     @license.validator
     def _check_licenses(self, attribute, value):
@@ -173,10 +173,10 @@ class BaseCollectionInfo(object):
         if invalid_licenses:
             self.value_error(
                 "Expecting 'license' to be a list of valid SPDX license "
-                "identifiers, instead found invalid license identifiers: '%s' "
-                "in 'license' value %s. "
-                "For more info, visit https://spdx.org" %
-                (','.join(invalid_licenses), value))
+                "identifiers, instead found invalid license identifiers: '{}' "
+                "in 'license' value {}. "
+                "For more info, visit https://spdx.org"
+                .format(', '.join(invalid_licenses), value))
 
     @staticmethod
     def _is_valid_license_id(license_id, valid_license_ids):
@@ -206,14 +206,13 @@ class BaseCollectionInfo(object):
             try:
                 namespace, name = collection.split('.')
             except ValueError:
-                self.value_error(
-                    "Invalid dependency format: '%s'" % collection)
+                self.value_error(f"Invalid dependency format: '{collection}'")
 
             for value in [namespace, name]:
                 if not re.match(constants.NAME_REGEXP, value):
                     self.value_error(
-                        "Invalid dependency format: '%s' in '%s.%s'"
-                        % (value, namespace, name))
+                        f"Invalid dependency format: '{value}' "
+                        f"in '{namespace}.{name}'")
 
             if namespace == self.namespace and name == self.name:
                 self.value_error("Cannot have self dependency")
@@ -222,8 +221,8 @@ class BaseCollectionInfo(object):
                 semantic_version.Spec(version_spec)
             except ValueError:
                 self.value_error(
-                    "Dependency version spec range invalid: %s %s"
-                    % (collection, version_spec))
+                    "Dependency version spec range invalid: "
+                    f"{collection} {version_spec}")
 
     @tags.validator
     def _check_tags(self, attribute, value):
@@ -232,7 +231,7 @@ class BaseCollectionInfo(object):
             # TODO update tag format once resolved
             # https://github.com/ansible/galaxy/issues/1563
             if not re.match(constants.TAG_REGEXP, tag):
-                self.value_error("'tag' has invalid format: %s" % tag)
+                self.value_error(f"'tag' has invalid format: {tag}")
 
     def __attrs_post_init__(self):
         '''Checks called post init validation'''
@@ -244,8 +243,8 @@ class BaseCollectionInfo(object):
             return
         self.value_error(
             "Valid values for 'license' or 'license_file' are required. "
-            "But 'license' (%s) and 'license_file' (%s) were invalid." %
-            (license_ids, license_file))
+            f"But 'license' ({license_ids}) and "
+            f"'license_file' ({license_file}) were invalid.")
 
 
 @attr.s(frozen=True)
@@ -261,21 +260,21 @@ class GalaxyCollectionInfo(BaseCollectionInfo):
     def _check_required(self, name):
         '''Check that value is present'''
         if not getattr(self, name):
-            self.value_error("'%s' is required by galaxy" % name)
+            self.value_error(f"'{name}' is required by galaxy")
 
     def _check_non_null_str(self, name):
         '''Check that if value is present, it must be a string'''
         value = getattr(self, name)
         if value is not None and not isinstance(value, str):
-            self.value_error("'%s' must be a string" % name)
+            self.value_error(f"'{name}' must be a string")
 
     def _check_tags_count(self):
         '''Checks tag count in metadata against max tags count constant'''
         tags = getattr(self, 'tags')
         if tags is not None and len(tags) > constants.MAX_TAGS_COUNT:
             self.value_error(
-                'Expecting no more than %s tags in metadata' %
-                constants.MAX_TAGS_COUNT)
+                f"Expecting no more than {constants.MAX_TAGS_COUNT} tags "
+                "in metadata")
 
     def __attrs_post_init__(self):
         '''Additional galaxy checks called post init'''

--- a/galaxy/importer/models.py
+++ b/galaxy/importer/models.py
@@ -217,6 +217,9 @@ class BaseCollectionInfo(object):
                         "Invalid dependency format: '%s' in '%s.%s'"
                         % (value, namespace, name))
 
+            if namespace == self.namespace and name == self.name:
+                self.value_error("Cannot have self dependency")
+
     @tags.validator
     def _check_tags(self, attribute, value):
         '''Check value against tag regular expression'''
@@ -265,9 +268,6 @@ class GalaxyCollectionInfo(BaseCollectionInfo):
         '''Check dependencies and matching version present in database'''
         for dep_col, ver_spec in self.dependencies.items():
             ns_name, name = dep_col.split('.')
-
-            if ns_name == self.namespace and name == self.name:
-                self.value_error('Cannot have self dependency')
 
             try:
                 ns = models.Namespace.objects.get(name=ns_name)

--- a/galaxy/importer/models.py
+++ b/galaxy/importer/models.py
@@ -113,8 +113,10 @@ class BaseCollectionInfo(object):
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str)))
 
-    dependencies = attr.ib(factory=dict,
-                           converter=convert_none_to_empty_dict)
+    dependencies = attr.ib(
+        factory=dict,
+        converter=convert_none_to_empty_dict,
+        validator=attr.validators.instance_of(dict))
 
     @property
     def label(self):
@@ -195,9 +197,6 @@ class BaseCollectionInfo(object):
     @dependencies.validator
     def _check_dependencies_format(self, attribute, dependencies):
         '''Check type and format of dependencies collection and version'''
-        if not isinstance(dependencies, dict) or dependencies is None:
-            self.value_error("Expecting 'dependencies' to be a dictionary")
-
         for collection, version_spec in dependencies.items():
             if not isinstance(collection, str):
                 self.value_error("Expecting depencency to be string")

--- a/galaxy/importer/models.py
+++ b/galaxy/importer/models.py
@@ -124,7 +124,7 @@ class BaseCollectionInfo(object):
 
     @staticmethod
     def value_error(msg):
-        raise ValueError("Invalid collection metadata. %s" % msg)
+        raise ValueError("Invalid collection metadata. %s" % msg) from None
 
     @namespace.validator
     @name.validator

--- a/galaxy/importer/models.py
+++ b/galaxy/importer/models.py
@@ -133,6 +133,14 @@ class BaseCollectionInfo(object):
         if not value:
             self.value_error("'%s' is required" % attribute.name)
 
+    @namespace.validator
+    @name.validator
+    def _check_name(self, attribute, value):
+        '''Check value against name regular expression'''
+        if not re.match(constants.NAME_REGEXP, value):
+            self.value_error("'%s' has invalid format: %s" %
+                             (attribute.name, value))
+
     @version.validator
     def _check_version_format(self, attribute, value):
         '''Check that version is in semantic version format'''
@@ -202,14 +210,6 @@ class BaseCollectionInfo(object):
             # https://github.com/ansible/galaxy/issues/1563
             if not re.match(constants.TAG_REGEXP, tag):
                 self.value_error("'tag' has invalid format: %s" % tag)
-
-    @namespace.validator
-    @name.validator
-    def _check_name(self, attribute, value):
-        '''Check value against name regular expression'''
-        if not re.match(constants.NAME_REGEXP, value):
-            self.value_error("'%s' has invalid format: %s" %
-                             (attribute.name, value))
 
     def __attrs_post_init__(self):
         '''Checks called post init validation'''

--- a/galaxy/importer/models.py
+++ b/galaxy/importer/models.py
@@ -194,13 +194,28 @@ class BaseCollectionInfo(object):
         return True
 
     @dependencies.validator
-    def _check_dependencies_type(self, attribute, value):
-        '''Check type of dependencies dictionary and its contents'''
-        if not isinstance(value, dict) or value is None:
-            self.value_error("Expecting '%s' to be a dict" % attribute.name)
-        for k, v in value.items():
-            if not isinstance(k, str) or not isinstance(v, str):
-                self.value_error("Expecting dict key and value to be strings")
+    def _check_dependencies_format(self, attribute, dependencies):
+        '''Check type and format of dependencies collection and version'''
+        if not isinstance(dependencies, dict) or dependencies is None:
+            self.value_error("Expecting 'dependencies' to be a dictionary")
+
+        for collection, version_spec in dependencies.items():
+            if not isinstance(collection, str):
+                self.value_error("Expecting depencency to be string")
+            if not isinstance(version_spec, str):
+                self.value_error("Expecting depencency version to be string")
+
+            try:
+                namespace, name = collection.split('.')
+            except ValueError:
+                self.value_error(
+                    "Invalid dependency format: '%s'" % collection)
+
+            for value in [namespace, name]:
+                if not re.match(constants.NAME_REGEXP, value):
+                    self.value_error(
+                        "Invalid dependency format: '%s' in '%s.%s'"
+                        % (value, namespace, name))
 
     @tags.validator
     def _check_tags(self, attribute, value):

--- a/galaxy/importer/models.py
+++ b/galaxy/importer/models.py
@@ -30,7 +30,6 @@ from galaxy.common import schema
 from galaxy.importer.utils import git
 from galaxy.importer.utils import readme as readmeutils
 from galaxy.importer.utils import spdx_licenses
-from galaxy.main import models
 
 SHA1_LEN = 40
 
@@ -271,38 +270,6 @@ class GalaxyCollectionInfo(BaseCollectionInfo):
         if value is not None and not isinstance(value, str):
             self.value_error("'%s' must be a string" % name)
 
-    def _check_dependencies(self):
-        '''Check dependencies and matching version present in database'''
-        for dep_col, ver_spec in self.dependencies.items():
-            ns_name, name = dep_col.split('.')
-
-            try:
-                ns = models.Namespace.objects.get(name=ns_name)
-            except models.Namespace.DoesNotExist:
-                self.value_error('Dependency namespace not in '
-                                 'galaxy: %s' % dep_col)
-            try:
-                col = models.Collection.objects.get(
-                    namespace=ns.pk,
-                    name=name,
-                )
-            except models.Collection.DoesNotExist:
-                self.value_error('Dependency collection not in '
-                                 'galaxy: %s' % dep_col)
-
-            spec = semantic_version.Spec(ver_spec)
-            col_vers = models.CollectionVersion.objects.filter(collection=col)
-            for v in [item.version for item in col_vers]:
-                try:
-                    if spec.match(semantic_version.Version(v)):
-                        return
-                except TypeError:
-                    # semantic_version Spec('~1') is ok, but match throws error
-                    pass
-
-            self.value_error('Dependency found in galaxy but no matching '
-                             'version found: %s %s' % (dep_col, ver_spec))
-
     def _check_tags_count(self):
         '''Checks tag count in metadata against max tags count constant'''
         tags = getattr(self, 'tags')
@@ -316,7 +283,6 @@ class GalaxyCollectionInfo(BaseCollectionInfo):
         super().__attrs_post_init__()
         self._check_required('readme')
         self._check_required('authors')
-        self._check_dependencies()
         self._check_tags_count()
         for field in [
                         'description',

--- a/galaxy/importer/models.py
+++ b/galaxy/importer/models.py
@@ -220,6 +220,13 @@ class BaseCollectionInfo(object):
             if namespace == self.namespace and name == self.name:
                 self.value_error("Cannot have self dependency")
 
+            try:
+                semantic_version.Spec(version_spec)
+            except ValueError:
+                self.value_error(
+                    "Dependency version spec range invalid: %s %s"
+                    % (collection, version_spec))
+
     @tags.validator
     def _check_tags(self, attribute, value):
         '''Check value against tag regular expression'''
@@ -283,12 +290,7 @@ class GalaxyCollectionInfo(BaseCollectionInfo):
                 self.value_error('Dependency collection not in '
                                  'galaxy: %s' % dep_col)
 
-            try:
-                spec = semantic_version.Spec(ver_spec)
-            except ValueError:
-                self.value_error('Dependency version spec range '
-                                 'invalid: %s %s' % (dep_col, ver_spec))
-
+            spec = semantic_version.Spec(ver_spec)
             col_vers = models.CollectionVersion.objects.filter(collection=col)
             for v in [item.version for item in col_vers]:
                 try:

--- a/galaxy/importer/tests/test_collection_info.py
+++ b/galaxy/importer/tests/test_collection_info.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 from django.test import TestCase
 
@@ -226,6 +228,34 @@ def test_non_null_str_fields(galaxy_col_info):
     with pytest.raises(ValueError) as exc:
         GalaxyCollectionInfo(**galaxy_col_info)
     assert 'description' in str(exc)
+
+
+def test_dependency_bad_dot_format(galaxy_col_info):
+    dependent_collections = [
+        'no_dot_in_collection',
+        'too.many.dots',
+        '.too.many.dots',
+        'too.many.dots.',
+    ]
+    for collection in dependent_collections:
+        galaxy_col_info['dependencies'] = {collection: '1.0.0'}
+        with pytest.raises(ValueError) as exc:
+            GalaxyCollectionInfo(**galaxy_col_info)
+        assert 'Invalid dependency format' in str(exc)
+
+
+def test_dependency_not_match_regex(galaxy_col_info):
+    dependent_collections = [
+        'empty_name.',
+        '.empty_namespace',
+        'a_user.{}'.format(random.choice(invalid_names)),
+        '{}.gunicorn'.format(random.choice(invalid_names)),
+    ]
+    for collection in dependent_collections:
+        galaxy_col_info['dependencies'] = {collection: '1.0.0'}
+        with pytest.raises(ValueError) as exc:
+            GalaxyCollectionInfo(**galaxy_col_info)
+        assert 'Invalid dependency format' in str(exc)
 
 
 class DependenciesTestCase(TestCase):

--- a/galaxy/importer/tests/test_collection_info.py
+++ b/galaxy/importer/tests/test_collection_info.py
@@ -208,11 +208,25 @@ def test_invalid_license(base_col_info):
         assert "Expecting 'license' to be a list of valid" in str(exc)
 
 
-def test_invalid_dep_dict(base_col_info):
+def test_invalid_dep_type(base_col_info):
+    base_col_info['dependencies'] = 'joe.role1: 3'
+    with pytest.raises(TypeError) as exc:
+        BaseCollectionInfo(**base_col_info)
+    assert "'dependencies' must be <class 'dict'>" in str(exc)
+
+
+def test_invalid_dep_name(base_col_info):
+    base_col_info['dependencies'] = {3.3: '1.0.0'}
+    with pytest.raises(ValueError) as exc:
+        BaseCollectionInfo(**base_col_info)
+    assert 'Expecting depencency to be string' in str(exc)
+
+
+def test_invalid_dep_version(base_col_info):
     base_col_info['dependencies'] = {'joe.role1': 3}
     with pytest.raises(ValueError) as exc:
         BaseCollectionInfo(**base_col_info)
-    assert 'string' in str(exc)
+    assert 'Expecting depencency version to be string' in str(exc)
 
 
 def test_non_null_str_fields(galaxy_col_info):

--- a/galaxy/importer/tests/test_collection_info.py
+++ b/galaxy/importer/tests/test_collection_info.py
@@ -269,6 +269,22 @@ def test_self_dependency(galaxy_col_info):
     assert 'Cannot have self dependency' in str(exc)
 
 
+def test_dep_bad_version_spec(galaxy_col_info):
+    bad_version_specs = [
+        {'alice.apache': 'bad_version'},
+        {'alice.apache': '1.2.*'},
+        {'alice.apache': ''},
+        {'alice.apache': '*.*.*'},
+        {'alice.apache': '>=1.0.0, <=2.0.0'},
+        {'alice.apache': '>1 <2'},
+    ]
+    for dep in bad_version_specs:
+        galaxy_col_info['dependencies'] = dep
+        with pytest.raises(ValueError) as exc:
+            GalaxyCollectionInfo(**galaxy_col_info)
+        assert 'version spec range invalid' in str(exc)
+
+
 class DependenciesTestCase(TestCase):
     @classmethod
     def setUpClass(self):
@@ -309,18 +325,6 @@ class DependenciesTestCase(TestCase):
         with pytest.raises(ValueError) as exc:
             GalaxyCollectionInfo(**self.metadata)
         assert 'collection not in galaxy' in str(exc)
-
-    def test_dep_bad_version_spec(self):
-        bad_version_specs = [
-            {'alice.apache': 'bad_version'},
-            {'alice.apache': '1.2.*'},
-            {'alice.apache': '>=1.0.0, <=2.0.0'},
-        ]
-        for dep in bad_version_specs:
-            self.metadata['dependencies'] = dep
-            with pytest.raises(ValueError) as exc:
-                GalaxyCollectionInfo(**self.metadata)
-            assert 'version spec range invalid' in str(exc)
 
     def test_dep_cannot_find_ver(self):
         missing_versions = [

--- a/galaxy/importer/tests/test_collection_info.py
+++ b/galaxy/importer/tests/test_collection_info.py
@@ -258,6 +258,17 @@ def test_dependency_not_match_regex(galaxy_col_info):
         assert 'Invalid dependency format' in str(exc)
 
 
+def test_self_dependency(galaxy_col_info):
+    namespace = galaxy_col_info['namespace']
+    name = galaxy_col_info['name']
+    galaxy_col_info['dependencies'] = {
+        '{}.{}'.format(namespace, name): '1.0.0'
+    }
+    with pytest.raises(ValueError) as exc:
+        GalaxyCollectionInfo(**galaxy_col_info)
+    assert 'Cannot have self dependency' in str(exc)
+
+
 class DependenciesTestCase(TestCase):
     @classmethod
     def setUpClass(self):

--- a/galaxy/importer/tests/test_collection_info.py
+++ b/galaxy/importer/tests/test_collection_info.py
@@ -1,10 +1,8 @@
 import random
 
 import pytest
-from django.test import TestCase
 
 from galaxy.importer.models import BaseCollectionInfo, GalaxyCollectionInfo
-from galaxy.main import models
 
 
 @pytest.fixture
@@ -283,80 +281,3 @@ def test_dep_bad_version_spec(galaxy_col_info):
         with pytest.raises(ValueError) as exc:
             GalaxyCollectionInfo(**galaxy_col_info)
         assert 'version spec range invalid' in str(exc)
-
-
-class DependenciesTestCase(TestCase):
-    @classmethod
-    def setUpClass(self):
-        super(DependenciesTestCase, self).setUpClass()
-        # create namespace and coll objs into the database
-        ns1 = models.Namespace.objects.create(name='alice')
-        col1 = models.Collection.objects.create(namespace=ns1, name='apache')
-        models.CollectionVersion.objects.create(collection=col1,
-                                                version='1.0.0-beta')
-        ns2 = models.Namespace.objects.create(name='gunjan')
-        col2 = models.Collection.objects.create(namespace=ns2, name='gunicorn')
-        models.CollectionVersion.objects.create(collection=col2,
-                                                version='1.2.3')
-        models.CollectionVersion.objects.create(collection=col2,
-                                                version='1.2.4')
-
-    def setUp(self):
-        self.metadata = {
-            'namespace': 'acme',
-            'name': 'jenkins',
-            'version': '3.5.0',
-            'license': ['MIT'],
-            # 'min_ansible_version': '2.4',
-            'authors': ['Bob Smith <b.smith@acme.com>'],
-            'tags': ['testcases'],
-            'readme': 'README.rst',
-            'dependencies': {}
-        }
-
-    def test_dep_cannot_find_ns(self):
-        self.metadata['dependencies'].update({'ned.nginx': '1.2.3'})
-        with pytest.raises(ValueError) as exc:
-            GalaxyCollectionInfo(**self.metadata)
-        assert 'namespace not in galaxy' in str(exc)
-
-    def test_dep_cannot_find_col(self):
-        self.metadata['dependencies'].update({'alice.php': '1.2.3'})
-        with pytest.raises(ValueError) as exc:
-            GalaxyCollectionInfo(**self.metadata)
-        assert 'collection not in galaxy' in str(exc)
-
-    def test_dep_cannot_find_ver(self):
-        missing_versions = [
-            {'alice.apache': '2'},
-            {'alice.apache': '1.0.1'},
-            {'alice.apache': '>1.0.0'},
-            {'alice.apache': '!=1.0.0'},
-            {'alice.apache': '~1'},  # semantic_version error
-            {'gunjan.gunicorn': '<1.2.3'},
-            {'gunjan.gunicorn': '1.5'},
-            {'gunjan.gunicorn': '^1.5'},
-        ]
-        for dep in missing_versions:
-            self.metadata['dependencies'] = dep
-            with pytest.raises(ValueError) as exc:
-                GalaxyCollectionInfo(**self.metadata)
-            assert 'no matching version found' in str(exc)
-
-    def test_dep_success(self):
-        good_deps_ver_ranges = [
-            {'alice.apache': '1.0.0'},
-            {'alice.apache': '*'},
-            {'alice.apache': '^1.0'},
-            {'alice.apache': '>0.9.1'},
-            {'gunjan.gunicorn': '1.2.3'},
-            {'gunjan.gunicorn': '1.2.4'},
-            {'gunjan.gunicorn': '^1.1'},
-            {'gunjan.gunicorn': '!=1.2.3'},
-            {'gunjan.gunicorn': '>=1.0.0,<=2.0.0'},
-            {'gunjan.gunicorn': '>=1.0.0,!=1.0.5'},
-        ]
-        for dep in good_deps_ver_ranges:
-            self.metadata['dependencies'] = dep
-            res = GalaxyCollectionInfo(**self.metadata)
-            assert isinstance(res, GalaxyCollectionInfo)

--- a/galaxy/worker/importers/collection.py
+++ b/galaxy/worker/importers/collection.py
@@ -1,0 +1,58 @@
+# (c) 2012-2019, Ansible by Red Hat
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+import semantic_version
+
+from galaxy.main import models
+from galaxy.worker import exceptions as exc
+
+
+def _import_fail(msg):
+    raise exc.ImportFailed("Invalid collection metadata. %s" % msg)
+
+
+def check_dependencies(collection_info):
+    '''Check collection dependencies and matching version are in database'''
+    dependencies = collection_info.dependencies
+    for dep, version_spec in dependencies.items():
+        ns_name, name = dep.split('.')
+
+        try:
+            ns = models.Namespace.objects.get(name=ns_name)
+        except models.Namespace.DoesNotExist:
+            _import_fail('Dependency namespace not in galaxy: %s' % dep)
+        try:
+            collection = models.Collection.objects.get(
+                namespace=ns.pk,
+                name=name,
+            )
+        except models.Collection.DoesNotExist:
+            _import_fail('Dependency collection not in galaxy: %s' % dep)
+
+        spec = semantic_version.Spec(version_spec)
+        versions = models.CollectionVersion.objects.filter(
+            collection=collection)
+        for v in [item.version for item in versions]:
+            try:
+                if spec.match(semantic_version.Version(v)):
+                    return
+            except TypeError:
+                # semantic_version Spec('~1') is ok, but match throws error
+                pass
+
+        _import_fail('Dependency found in galaxy but no matching '
+                     'version found: %s %s' % (dep, version_spec))

--- a/galaxy/worker/importers/collection.py
+++ b/galaxy/worker/importers/collection.py
@@ -22,7 +22,7 @@ from galaxy.worker import exceptions as exc
 
 
 def _import_fail(msg):
-    raise exc.ImportFailed("Invalid collection metadata. %s" % msg)
+    raise exc.ImportFailed("Invalid collection metadata. %s" % msg) from None
 
 
 def check_dependencies(collection_info):

--- a/galaxy/worker/tasks/collection.py
+++ b/galaxy/worker/tasks/collection.py
@@ -29,6 +29,7 @@ from galaxy.importer import exceptions as i_exc
 from galaxy.main import models
 from galaxy.worker import exceptions as exc
 from galaxy.worker import logutils
+from galaxy.worker.importers.collection import check_dependencies
 
 
 log = logging.getLogger(__name__)
@@ -80,6 +81,8 @@ def _process_collection(artifact, filename, task_logger):
                 extract_dir, filename, task_logger)
         except i_exc.ImporterError as e:
             raise exc.ImportFailed(str(e))
+
+        check_dependencies(collection_info.collection_info)
 
     _log_collection_info(collection_info)
     return collection_info

--- a/galaxy/worker/tasks/collection.py
+++ b/galaxy/worker/tasks/collection.py
@@ -52,9 +52,8 @@ def import_collection(artifact_id, repository_id):
         f'Starting import: task_id={task.id}, artifact_id={artifact_id}')
 
     try:
-        collection_info = _process_collection(
-            artifact, filename, task_logger)
-        _publish_collection(task, artifact, repository, collection_info)
+        importer_obj = _process_collection(artifact, filename, task_logger)
+        _publish_collection(task, artifact, repository, importer_obj)
     except Exception as e:
         artifact.delete()
         task_logger.error(f'Import Task "{task.id}" failed: {e}')
@@ -77,20 +76,20 @@ def _process_collection(artifact, filename, task_logger):
             pkg_tar.extractall(extract_dir)
 
         try:
-            collection_info = importer.import_collection(
+            importer_obj = importer.import_collection(
                 extract_dir, filename, task_logger)
         except i_exc.ImporterError as e:
             raise exc.ImportFailed(str(e))
 
-        check_dependencies(collection_info.collection_info)
+        check_dependencies(importer_obj.collection_info)
 
-    _log_collection_info(collection_info)
-    return collection_info
+    _log_importer_results(importer_obj)
+    return importer_obj
 
 
 @transaction.atomic
-def _publish_collection(task, artifact, repository, collection_info):
-    metadata = collection_info.collection_info
+def _publish_collection(task, artifact, repository, importer_obj):
+    metadata = importer_obj.collection_info
     collection, _ = models.Collection.objects.get_or_create(
         namespace=task.namespace, name=metadata.name)
 
@@ -98,11 +97,11 @@ def _publish_collection(task, artifact, repository, collection_info):
         version = collection.versions.create(
             version=metadata.version,
             metadata=metadata.get_json(),
-            quality_score=collection_info.quality_score,
-            contents=collection_info.contents,
-            readme_mimetype=collection_info.readme['mimetype'],
-            readme_text=collection_info.readme['text'],
-            readme_html=collection_info.readme['html'],
+            quality_score=importer_obj.quality_score,
+            contents=importer_obj.contents,
+            readme_mimetype=importer_obj.readme['mimetype'],
+            readme_text=importer_obj.readme['text'],
+            readme_html=importer_obj.readme['html'],
         )
     except IntegrityError:
         raise exc.VersionConflict(
@@ -162,12 +161,12 @@ def _update_collection_tags(collection, version, metadata):
     collection.tags.remove(*tags_not_in_metadata)
 
 
-def _log_collection_info(collection_info):
+def _log_importer_results(importer_obj):
     log.debug('Collection loaded - metadata={}, quality_score={}'.format(
-        collection_info.collection_info.__dict__,
-        collection_info.quality_score
+        importer_obj.collection_info.__dict__,
+        importer_obj.quality_score
     ))
-    for content in collection_info.contents:
+    for content in importer_obj.contents:
         log.debug('Content: type={} name={} scores={}'.format(
             content['content_type'],
             content['name'],

--- a/galaxy/worker/tests/test_collection.py
+++ b/galaxy/worker/tests/test_collection.py
@@ -1,0 +1,86 @@
+import pytest
+from django.test import TestCase
+
+from galaxy.worker.exceptions import ImportFailed
+from galaxy.importer.models import GalaxyCollectionInfo
+from galaxy.worker.importers.collection import check_dependencies
+from galaxy.main import models
+
+
+class DependenciesTestCase(TestCase):
+    @classmethod
+    def setUpClass(self):
+        super(DependenciesTestCase, self).setUpClass()
+        ns1 = models.Namespace.objects.create(name='alice')
+        col1 = models.Collection.objects.create(namespace=ns1, name='apache')
+        models.CollectionVersion.objects.create(collection=col1,
+                                                version='1.0.0-beta')
+        ns2 = models.Namespace.objects.create(name='gunjan')
+        col2 = models.Collection.objects.create(namespace=ns2, name='gunicorn')
+        models.CollectionVersion.objects.create(collection=col2,
+                                                version='1.2.3')
+        models.CollectionVersion.objects.create(collection=col2,
+                                                version='1.2.4')
+
+    def setUp(self):
+        self.metadata = {
+            'namespace': 'acme',
+            'name': 'jenkins',
+            'version': '3.5.0',
+            'license': ['MIT'],
+            # 'min_ansible_version': '2.4',
+            'authors': ['Bob Smith <b.smith@acme.com>'],
+            'tags': ['testcases'],
+            'readme': 'README.rst',
+            'dependencies': {}
+        }
+
+    def test_dep_cannot_find_ns(self):
+        self.metadata['dependencies'].update({'ned.nginx': '1.2.3'})
+        collection_info = GalaxyCollectionInfo(**self.metadata)
+        with pytest.raises(ImportFailed) as exc:
+            check_dependencies(collection_info)
+        assert 'namespace not in galaxy' in str(exc)
+
+    def test_dep_cannot_find_col(self):
+        self.metadata['dependencies'].update({'alice.php': '1.2.3'})
+        collection_info = GalaxyCollectionInfo(**self.metadata)
+        with pytest.raises(ImportFailed) as exc:
+            check_dependencies(collection_info)
+        assert 'collection not in galaxy' in str(exc)
+
+    def test_dep_cannot_find_ver(self):
+        missing_versions = [
+            {'alice.apache': '2'},
+            {'alice.apache': '1.0.1'},
+            {'alice.apache': '>1.0.0'},
+            {'alice.apache': '!=1.0.0'},
+            {'alice.apache': '~1'},  # semantic_version error
+            {'gunjan.gunicorn': '<1.2.3'},
+            {'gunjan.gunicorn': '1.5'},
+            {'gunjan.gunicorn': '^1.5'},
+        ]
+        for dep in missing_versions:
+            self.metadata['dependencies'] = dep
+            collection_info = GalaxyCollectionInfo(**self.metadata)
+            with pytest.raises(ImportFailed) as exc:
+                check_dependencies(collection_info)
+            assert 'no matching version found' in str(exc)
+
+    def test_dep_success(self):
+        good_deps_ver_ranges = [
+            {'alice.apache': '1.0.0'},
+            {'alice.apache': '*'},
+            {'alice.apache': '^1.0'},
+            {'alice.apache': '>0.9.1'},
+            {'gunjan.gunicorn': '1.2.3'},
+            {'gunjan.gunicorn': '1.2.4'},
+            {'gunjan.gunicorn': '^1.1'},
+            {'gunjan.gunicorn': '!=1.2.3'},
+            {'gunjan.gunicorn': '>=1.0.0,<=2.0.0'},
+            {'gunjan.gunicorn': '>=1.0.0,!=1.0.5'},
+        ]
+        for dep in good_deps_ver_ranges:
+            self.metadata['dependencies'] = dep
+            res = GalaxyCollectionInfo(**self.metadata)
+            assert isinstance(res, GalaxyCollectionInfo)


### PR DESCRIPTION
This PR moves a database check for valid dependencies from the importer to worker, to help make importer standalone from database transactions.

A downside of this is we wait until all content is parsed and linted before erroring on an invalid dependency. To help with this, more checks were added in the importer to ensure dependency format is correct before proceeding with content loading and linting.

Resolves #1702 