### PR TITLE
Explicitely set default S3 ACL to None

### DIFF
--- a/galaxy/settings/production.py
+++ b/galaxy/settings/production.py
@@ -177,7 +177,7 @@ INFLUX_DB_UI_EVENTS_DB_NAME = os.environ.get(
 AWS_ACCESS_KEY_ID = os.environ['GALAXY_AWS_ACCESS_KEY_ID']
 AWS_SECRET_ACCESS_KEY = os.environ['GALAXY_AWS_SECRET_ACCESS_KEY']
 AWS_STORAGE_BUCKET_NAME = os.environ['GALAXY_AWS_STORAGE_BUCKET_NAME']
-# AWS_DEFAULT_ACL = 'public-read'
+AWS_DEFAULT_ACL = None
 
 
 # =========================================================


### PR DESCRIPTION
Django-storage S3 backend uses `public-read` canned ACL by default, which does not match the S3 documentation. Since it's prohibited to set object permissions from the S3 API on Galaxy buckets, the default behavior of django-storage causes permission error.

This patch explicitly sets the S3 ACL to `None`, which means that no additional object permissions are set when uploading a file to S3, and the file inherits the bucket ACL.