### PR TITLE
Fix artrifact upload paths

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,4 @@ dist/
 docs/docsite/_build/
 galaxy.egg-info/
 galaxyui/node_modules
-
+var/

--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -177,6 +177,8 @@ STATIC_URL = '/static/'
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'build', 'static')
 
+MEDIA_ROOT = '/var/lib/galaxy/media/'
+
 # Database
 # ---------------------------------------------------------
 

--- a/scripts/docker/dev/Dockerfile
+++ b/scripts/docker/dev/Dockerfile
@@ -33,7 +33,7 @@ RUN yum -y install epel-release \
 # Create directories structure
 RUN mkdir -p /galaxy \
              /usr/share/galaxy \
-             /var/lib/galaxy \
+             /var/lib/galaxy/media \
              /var/tmp/galaxy/imports \
              /var/tmp/galaxy/uploads \
              /var/run/galaxy


### PR DESCRIPTION
* Move artifact upload directory out of source tree by setting
  MEDIA_ROOT to `/var/lib/galaxy/media/`
* Add `/var` directory to dockerignore.

Signed-off-by: Alexander Saprykin <osapryki@redhat.com>