### PR TITLE
Refactor linter cli execution and add parsing unittests

### DIFF
--- a/galaxy/importer/linters/__init__.py
+++ b/galaxy/importer/linters/__init__.py
@@ -67,7 +67,7 @@ class Flake8Linter(BaseLinter):
 
     def parse_id_and_desc(self, message):
         try:
-            error_id, rule_desc = message.split(' ', 1)
+            _, error_id, rule_desc = message.split(' ', 2)
         except ValueError:
             pass
         else:


### PR DESCRIPTION
- Refactor parse methods for linters
- Fix error_id parsing for flake8 
- Simplify test calls to ansible-lint .yaml files 
- Add unittests for each linter parse method 

Addresses issues noted in #1689