### PR TITLE
Increase test coverage requirement to current level

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ omit = */migrations/*
 branch = True
 
 [coverage:report]
-fail_under = 40
+fail_under = 43.5
+precision = 2
 
 [flake8]


### PR DESCRIPTION
Raise the fail_under for test coverage to the current coverage level of 43.52% to keep from dropping again.