### PR TITLE
Collapse navigation on smaller screens

### DIFF
--- a/galaxyui/src/app/app.component.html
+++ b/galaxyui/src/app/app.component.html
@@ -1,6 +1,11 @@
-<div id="verticalNavLayout" class="layout-pf layout-pf-fixed faux-layout" style="background-color: white;"
-    (window:resize)="onResize($event)">
+<div
+    id="verticalNavLayout"
+    class="layout-pf layout-pf-fixed faux-layout"
+    style="background-color: white;"
+    (window:resize)="onResize($event)"
+>
     <pfng-vertical-navigation
+        #verticalNav
         [brandAlt]="'Galaxy'"
         [brandSrc]="'/assets/galaxy-logo-02.svg'"
         [contentContainer]="contentContainer"

--- a/galaxyui/src/app/app.component.ts
+++ b/galaxyui/src/app/app.component.ts
@@ -258,9 +258,8 @@ export class AppComponent implements OnInit {
     }
 
     collapseNavOnSmallScreens(screenWidth: number) {
-        console.log('collapsydoodle!!!!!!!!!!!!!!!!!!!!!!!!!!');
         if (
-            screenWidth < 1200 &&
+            screenWidth < 1300 &&
             !this.verticalNavigation.navCollapsed &&
             !this.verticalNavigation.inMobileState
         ) {

--- a/galaxyui/src/app/app.component.ts
+++ b/galaxyui/src/app/app.component.ts
@@ -23,11 +23,14 @@ import { NavigationEnd, NavigationStart, Router } from '@angular/router';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
 
-import { AboutModalConfig, AboutModalEvent } from 'patternfly-ng/modal';
-
 import { VerticalNavigationItem } from 'patternfly-ng/navigation/vertical-navigation/vertical-navigation-item';
-import { Notification } from 'patternfly-ng/notification';
-import { NotificationService } from 'patternfly-ng/notification/notification-service/notification.service';
+import {
+    Notification,
+    NotificationService,
+    AboutModalConfig,
+    AboutModalEvent,
+    VerticalNavigationComponent,
+} from 'patternfly-ng';
 
 import { AuthService } from './auth/auth.service';
 import { ApiRootService } from './resources/api-root/api-root.service';
@@ -106,6 +109,9 @@ export class AppComponent implements OnInit {
 
     @ViewChild(NotificationDrawerComponent)
     notificationList: NotificationDrawerComponent;
+
+    @ViewChild(VerticalNavigationComponent)
+    verticalNavigation: VerticalNavigationComponent;
 
     ngOnInit(): void {
         // Patternfly embeds everything not related to navigation in a div with
@@ -190,6 +196,8 @@ export class AppComponent implements OnInit {
                 this.removeContentButtons();
             }
             this.optionallyAddMobileButtons();
+
+            this.collapseNavOnSmallScreens(window.innerWidth);
         });
         this.redirectUrl = this.authService.redirectUrl;
     }
@@ -246,6 +254,17 @@ export class AppComponent implements OnInit {
             this.addMobileButtons();
         } else {
             this.removeMobileButtons();
+        }
+    }
+
+    collapseNavOnSmallScreens(screenWidth: number) {
+        console.log('collapsydoodle!!!!!!!!!!!!!!!!!!!!!!!!!!');
+        if (
+            screenWidth < 1200 &&
+            !this.verticalNavigation.navCollapsed &&
+            !this.verticalNavigation.inMobileState
+        ) {
+            this.verticalNavigation.handleNavBarToggleClick();
         }
     }
 


### PR DESCRIPTION
Collapses the navigation down to just display the icons on screens that are less than 1300 pixels. Wide.

Unfortunately there doesn't seem to be a way to get tooltips to work on the nav bar, so we don't have a way to display the name of the page when the nav bar is collapsed other than re-expanding it.

<img width="1341" alt="Screen Shot 2019-05-02 at 4 44 09 PM" src="https://user-images.githubusercontent.com/6063371/57105751-94c36280-6cf9-11e9-9365-91b6a3c9ba15.png">
