### PR TITLE
Fix namespace selector in Chrome

### DIFF
--- a/galaxyui/src/app/react/components/my-imports/import-list.tsx
+++ b/galaxyui/src/app/react/components/my-imports/import-list.tsx
@@ -20,7 +20,6 @@ import {
     FilterConfig,
     FilterOption,
     AppliedFilter,
-    SortConfig,
 } from '../../shared-types/pf-toolbar';
 
 import { FilterPF, ToolBarResultsPF } from '../patternfly-filter';
@@ -276,13 +275,15 @@ export class ImportListComponent extends React.Component<IProps, {}> {
             <div className='namespace-selector-wrapper'>
                 <div className='label'>Namespace</div>
                 <div className='selector'>
-                    <FormControl value={selectedNS.id} componentClass='select'>
+                    <FormControl
+                        onChange={event =>
+                            this.props.selectNamespace(event.target.value)
+                        }
+                        value={selectedNS.id}
+                        componentClass='select'
+                    >
                         {namespaces.map(ns => (
-                            <option
-                                key={ns.id}
-                                value={ns.id}
-                                onClick={() => this.props.selectNamespace(ns)}
-                            >
+                            <option key={ns.id} value={ns.id}>
                                 {ns.name}
                             </option>
                         ))}

--- a/galaxyui/src/app/react/containers/my-imports.tsx
+++ b/galaxyui/src/app/react/containers/my-imports.tsx
@@ -342,7 +342,12 @@ export class MyImportsPage extends React.Component<IProps, IState> {
         );
     }
 
-    private selectedNamespace(ns: Namespace) {
+    private selectedNamespace(nsID: number) {
+        // For some reason the value passed back by the react component isn't
+        // a number
+        // tslint:disable-next-line:triple-equals
+        const ns = this.props.namespaces.find(x => x.id == nsID);
+
         this.setState(
             {
                 selectedNS: ns,


### PR DESCRIPTION
Fixes: #1780