### PR TITLE
Add 'test/quick' and 'dev/test/quick' targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ GALAXY_RELEASE_TAG ?= latest
 GALAXY_VENV=/usr/share/galaxy/venv
 DOCKER_COMPOSE=docker-compose -p galaxy -f ./scripts/docker/dev/compose.yml
 
+PYTEST_TARGET ?= galaxy
+PYTEST_ARGS ?=
+
 .PHONY: help
 help:
 	@echo "Prints help"
@@ -92,12 +95,18 @@ build/release:
 
 .PHONY: test
 test:
-	@pytest galaxy \
+	pytest $(PYTEST_TARGET) \
 	--cov galaxy \
 	--cov-report xml \
 	--cov-report term \
 	--cov-report html \
 	--cov-config setup.cfg \
+	$(PYTEST_ARGS)
+
+.PHONY: test/quick
+test/quick:
+	pytest $(PYTEST_TARGET) \
+	$(PYTEST_ARGS) --reuse-db
 
 .PHONY: test/changed
 test/changed:
@@ -198,13 +207,22 @@ dev/test:
 	@$(DOCKER_COMPOSE) exec galaxy bash -c '\
 		source $(GALAXY_VENV)/bin/activate; \
 		export DJANGO_SETTINGS_MODULE=galaxy.settings.testing; \
-		pytest galaxy \
+		pytest $(PYTEST_TARGET) \
 		--cov galaxy \
 		--cov-report xml \
 		--cov-report term \
 		--cov-report html \
 		--cov-config setup.cfg \
-		'
+		$(PYTEST_ARGS)'
+
+.PHONY: dev/test/quick
+dev/test/quick:
+	@echo "Running quick tests"
+	@$(DOCKER_COMPOSE) exec galaxy bash -c '\
+		source $(GALAXY_VENV)/bin/activate; \
+		export DJANGO_SETTINGS_MODULE=galaxy.settings.testing; \
+		pytest $(PYTEST_TARGET) \
+		$(PYTEST_ARGS) --reuse-db'
 
 .PHONY: dev/test/changed
 dev/test/changed:


### PR DESCRIPTION
The 'quick' tests mostly just also add the
pytest option '--reused-db'. They also turn off
test coverage.

And use PYTEST_TARGET and PYTEST_ARGS with pytest.

PYTEST_TARGET is used in 'pytest $(PYTEST_TARGET) and
defaults 'galaxy', but could be
'galaxy/main/tests/test_whatever.py::test_stuff'

PYTEST_ARGS is empty, but can be used for any pytest
args ('-vvv' or '--log-level=DEBUG' etc)