### PR TITLE
Ignore untracked files for `make /dev/test/changed`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ dev/test/changed:
 	@$(DOCKER_COMPOSE) exec galaxy bash -c '\
 		source $(GALAXY_VENV)/bin/activate; \
 		export DJANGO_SETTINGS_MODULE="galaxy.settings.testing"; \
-		git status | grep test | cut -d: -f2 > /tmp/tests_changed ;\
+		git status --untracked-files=no | grep "galaxy\/.*test" | cut -d: -f2 > /tmp/tests_changed; \
 		if [[ -s /tmp/tests_changed ]]; then \
 				cat /tmp/tests_changed | xargs pytest -s -vvv --reuse-db \
 		;else \


### PR DESCRIPTION
If the git working tree has untracked files in it, they
would cause the grep/cut to include lines with '#' and fail.

Add --untracked-files=no to 'git status' ignore them

And add a slightly stricter grep so it does accidently
match if your branch name also inclues 'test'