### PR TITLE
Rev Collection download_count on /artifact/ get

### DIFF
--- a/galaxy/api/v2/tests/test_collection_version_views.py
+++ b/galaxy/api/v2/tests/test_collection_version_views.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
-import logging
 
 from django.contrib.auth import get_user_model
 from pulpcore.app import models as pulp_models
@@ -24,8 +23,6 @@ from rest_framework.test import APITestCase
 from galaxy.main import models
 
 UserModel = get_user_model()
-
-log = logging.getLogger(__name__)
 
 mazer_user_agent = \
     'Mazer/0.4.0 (linux; python:3.6.8) ansible_galaxy/0.4.0'
@@ -68,7 +65,6 @@ class TestCollectionArtifactView(APITestCase):
 
     def test_download_count(self):
         download_count_before = self.collection.download_count
-        log.debug('download_count_before: %s', download_count_before)
 
         url = '/api/v2/collections/mynamespace/mycollection' \
             + '/versions/1.2.3/artifact/'
@@ -84,7 +80,6 @@ class TestCollectionArtifactView(APITestCase):
 
     def test_download_count_non_mazer_user_agent(self):
         download_count_before = self.collection.download_count
-        log.debug('download_count_before: %s', download_count_before)
 
         url = '/api/v2/collections/mynamespace/mycollection' \
             + '/versions/1.2.3/artifact/'

--- a/galaxy/api/v2/views/collection_version.py
+++ b/galaxy/api/v2/views/collection_version.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
+
 from django.shortcuts import redirect, get_object_or_404
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny
@@ -120,4 +121,12 @@ class CollectionArtifactView(base.APIView):
                 collection__name__iexact=name,
                 version__exact=version,
             )
+
+        user_agent = request.META.get('HTTP_USER_AGENT', '')
+
+        # count downloads by mazer
+        if user_agent.startswith('Mazer/'):
+            version.collection.download_count += 1
+            version.collection.save()
+
         return redirect(version.get_download_url())


### PR DESCRIPTION
Rev Collection download_count on /artifact/ GET

CollectionArtifactView.get() increments the artifacts
related Collection's download_count.

Add a unit test to verify.

Work in progress at the moment

- [x] Add Collection download count for 'mazer' download_url hits
  - [x] inc count on download_url hits
  - [x] exclude any non-mazer hits, including from the wui
- [x] ~Determine if the count should be against a Collection entirely, or a CollectionVersion, or both~
- [x] cleanup debug logging
- [x] more tests (for mazer vs wui stuff when it exists)

Aside from the unit test and some manual testing with mazer, this hasn't been
tested much (ie, haven't tested with concurrent hits to the same /artifact/ url etc).

