### PR TITLE
Implement combined Search API

### DIFF
--- a/galaxy/api/internal/search.py
+++ b/galaxy/api/internal/search.py
@@ -1,0 +1,381 @@
+# (c) 2012-2019, Ansible by Red Hat
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+import functools
+import operator
+
+from django.contrib.postgres import search as psql_search
+from django.db.models import fields as db_fields
+from django.db.models.expressions import Func, F, Case, When, Value, \
+    ExpressionWrapper as Expr, RawSQL
+from django.db.models.functions.comparison import Coalesce
+from django.db.models.query_utils import Q
+
+from galaxy import constants
+from galaxy.main import models
+
+
+__all__ = (
+    'CollectionSearch',
+    'ContentSearch',
+)
+
+
+RANK_FUNCTION = 'ts_rank'
+RANK_NORMALIZATION = 32
+
+VENDOR_RANK = 0.1
+DOWNLOAD_RANK_MULTIPLIER = 0.4
+CONTENT_SCORE_MULTIPLIER = 0.2
+COMMUNITY_SCORE_MODIFIER = 0.002
+COMMUNITY_SCORE_MODIFIER_MIN = 0.005
+
+CONTENT_MATCH_QUERY = """
+    SELECT json_agg(json_build_object('name', cvc ->> 'name',
+                                      'content_type', cvc ->> 'content_type'))
+    FROM jsonb_array_elements("main_collectionversion"."contents") AS cvc
+    WHERE plainto_tsquery(%s) @@ to_tsvector(cvc ->> 'name')
+"""
+
+
+class BaseSearch:
+    def __init__(self, filters, order_by='relevance', order='desc'):
+        self.filters = filters
+        self.order_by = order_by
+        self.order = order
+
+    def count(self):
+        raise NotImplementedError
+
+    def search(self):
+        raise NotImplementedError
+
+
+class CollectionSearch(BaseSearch):
+    """Builds queries to search for collections."""
+
+    def count(self):
+        """Returns number of matching collections."""
+        return self._base_queryset().count()
+
+    def search(self):
+        qs = self._base_queryset().select_related('latest_version')
+        qs = self._add_relevance(qs)
+        qs = self._add_order_by(qs)
+        return qs
+
+    def _base_queryset(self):
+        """Returns generic queryset used both for count and search."""
+        qs = models.Collection.objects.order_by()
+
+        keywords = self.filters.get('keywords')
+        if keywords:
+            qs = qs.filter(
+                search_vector=psql_search.SearchQuery(keywords))
+
+        ns_type = self.filters.get('contributor_type')
+        if ns_type:
+            qs = qs.filter(namespace__is_vendor=(
+                ns_type == constants.NS_TYPE_PARTNER))
+
+        namespaces = self.filters.get('namespaces')
+        if namespaces:
+            filters = [Q(namespace__name__icontains=name)
+                       for name in self.filters['namespaces']]
+            qs = qs.filter(functools.reduce(operator.or_, filters))
+
+        names = self.filters.get('names')
+        if names:
+            filters = [Q(name__icontains=name) for name in names]
+            qs = qs.filter(functools.reduce(operator.or_, filters))
+
+        tags = self.filters.get('tags')
+        if tags:
+            tags_qs = models.Tag.objects.filter(name__in=tags)
+            qs = qs.distinct().filter(tags__in=tags_qs)
+
+        deprecated = self.filters.get('deprecated')
+        if deprecated:
+            qs = qs.filter(deprecated=deprecated)
+
+        return qs
+
+    def _add_relevance(self, qs):
+        if self.filters.get('keywords'):
+            return self._add_keyword_relevance(qs)
+        else:
+            return self._add_quality_relevance(qs)
+
+    def _add_keyword_relevance(self, qs):
+        """Annotates query with search rank value.
+
+        Search rank is calculated as result of `ts_rank` PostgreSQL
+        function, which ranks vectors based on the frequency of their matching
+        lexemes. Search rank is normalized by dividing it by itself + 1:
+        """
+        ts_rank_fn = Func(
+            F('search_vector'),
+            psql_search.SearchQuery(self.filters['keywords']),
+            RANK_NORMALIZATION,
+            function=RANK_FUNCTION,
+            output_field=db_fields.FloatField()
+        )
+        return qs.annotate(relevance=ts_rank_fn)
+
+    def _add_quality_relevance(self, qs):
+        """Annotates query with relevance based on quality score.
+
+        It is calculated by a formula:
+            R = log(Q + 1) + 0.1 * v
+        Where:
+            R - Relevance;
+            Q - Quality score (0 to 5);
+            v - 1 if collection belongs to a partner namespace, otherwise 0.
+        """
+        quality_rank_expr = (
+            Func(Coalesce(F('latest_version__quality_score'), 0) + 1,
+                 function='log')
+            * CONTENT_SCORE_MULTIPLIER
+        )
+        vendor_rank_expr = Case(
+            When(namespace__is_vendor=True, then=Value(VENDOR_RANK)),
+            When(namespace__is_vendor=False, then=Value(0)),
+        )
+        relevance_expr = F('quality_rank') + F('vendor_rank')
+        return qs.annotate(
+            quality_rank=Expr(
+                quality_rank_expr, output_field=db_fields.FloatField()),
+            vendor_rank=Expr(
+                vendor_rank_expr, output_field=db_fields.FloatField()),
+            relevance=Expr(
+                relevance_expr, output_field=db_fields.FloatField()),
+        )
+
+    def _add_order_by(self, qs):
+        order_by = self.order_by
+        prefix = '-' if self.order == 'desc' else ''
+        if order_by == 'qualname':
+            order_by = [prefix + 'namespace__name', prefix + 'name']
+        else:
+            order_by = [prefix + order_by]
+        return qs.order_by(*order_by)
+
+    def _add_content_match(self, collections):
+        keywords = self.filters.get('keywords')
+        if not keywords:
+            return
+
+        ids = [c.latest_version_id for c in collections]
+        content_match_query = RawSQL(CONTENT_MATCH_QUERY, params=(keywords,))
+        versions = (
+            models.CollectionVersion.objects.all()
+            .annotate(content_match=content_match_query)
+            .values('pk', 'content_match')
+            .filter(pk__in=ids)
+        )
+        content_match = {v['pk']: v['content_match'] for v in versions}
+        for collection in collections:
+            collection.content_match = content_match.get(
+                collection.latest_version_id)
+
+
+class ContentSearch(BaseSearch):
+    """Builds queries to search for content."""
+
+    def count(self):
+        """Returns number of matching content items."""
+        return self._base_queryset().count()
+
+    def search(self):
+        qs = self._base_queryset().select_related(
+            'content_type',
+            'namespace',
+            'repository',
+            'repository__provider_namespace',
+            'repository__provider_namespace__namespace',
+        ).prefetch_related(
+            'videos',
+            'tags',
+            'dependencies',
+            'platforms',
+            'repository__versions',
+        )
+        qs = self._add_search_rank(qs)
+        qs = self._add_relevance(qs)
+        qs = self._add_order_by(qs)
+        return qs
+
+    def _base_queryset(self):
+        """Returns generic queryset used both for count and search."""
+        qs = models.Content.objects.order_by().filter(
+            repository__provider_namespace__namespace__isnull=False,
+            repository__provider_namespace__namespace__active=True
+        )
+
+        keywords = self.filters.get('keywords')
+        if keywords:
+            qs = qs.filter(search_vector=psql_search.SearchQuery(keywords))
+
+        ns_type = self.filters.get('contributor_type')
+        if ns_type:
+            qs = qs.filter(namespace__is_vendor=(
+                ns_type == constants.NS_TYPE_PARTNER))
+
+        namespaces = self.filters.get('namespaces')
+        if namespaces:
+            filters = [Q(namespace__name__icontains=name)
+                       for name in self.filters['namespaces']]
+            qs = qs.filter(functools.reduce(operator.or_, filters))
+
+        names = self.filters.get('names')
+        if names:
+            filters = [Q(name__icontains=name) for name in names]
+            qs = qs.filter(functools.reduce(operator.or_, filters))
+
+        tags = self.filters.get('tags')
+        if tags:
+            tags_qs = models.Tag.objects.filter(name__in=tags)
+            qs = qs.distinct().filter(tags__in=tags_qs)
+
+        deprecated = self.filters.get('deprecated')
+        if deprecated:
+            qs = qs.filter(repository__deprecated=deprecated)
+
+        platforms = self.filters.get('platforms')
+        if platforms:
+            platforms_qs = models.Platform.objects.filter(
+                name__in=platforms)
+            qs = qs.distinct().filter(platforms__in=platforms_qs)
+
+        clouds = self.filters.get('cloud_platforms')
+        if clouds:
+            clouds_qs = models.CloudPlatform.objects.filter(
+                name__in=clouds)
+            qs = qs.distinct().filter(cloud_platforms__in=clouds_qs)
+
+        return qs
+
+    def _add_search_rank(self, qs):
+        """Annotates query with search rank value.
+
+        Search rank is calculated as result of `ts_rank` PostgreSQL
+        function, which ranks vectors based on the frequency of their matching
+        lexemes. Search rank is normalized by dividing it by itself + 1:
+        """
+        keywords = self.filters.get('keywords')
+        if not keywords:
+            return qs.annotate(
+                search_rank=Value(0.0, output_field=db_fields.FloatField()))
+        search_rank_fn = Func(
+            F('search_vector'),
+            psql_search.SearchQuery(keywords),
+            RANK_NORMALIZATION,
+            function=RANK_FUNCTION,
+            output_field=db_fields.FloatField())
+        return qs.annotate(search_rank=search_rank_fn)
+
+    def _add_relevance(self, qs):
+        """Annotates query with relevance rank and its constituent values.
+
+        Relevance is calculated by a formula:
+
+            R = Sr + Dr + Qr,
+
+        where
+            R - relevance;
+            Sr - search rank (from 0 to 1);
+            Dr - download rank;
+            Qr - quality rank;
+
+                   ts_rank()
+            Sr = -------------
+                 ts_rank() + 1
+
+        For more details on search rank see `_add_search_rank` function.
+
+        Download rank is calculated by a formula:
+
+                         ln(cd + 1)
+            Dr = 0.4 * --------------
+                       ln(cd + 1) + 1
+
+        Quality rank is calculated by a formula:
+
+            Qr = 0.2 * log(Q + 1)
+
+        """
+        c = 'repository__community_score'
+        d = 'repository__download_count'
+
+        # ln((MOD*c + MIN) * d + 1)
+        # where c = community_score and d = download_count
+        # We're using the community_score as a modifier to the download count
+        # instead of just allocating a certain number of points based on the
+        # score. The reason for this is that the download score is
+        # a logaritmic scale so adding a fixed number of points ended up
+        # boosting scores way too much for content with low numbers of
+        # downloads. This system allows for the weight of the community score
+        # to scale with the number of downloads
+        download_count_ln_expr = Func(
+            (((Coalesce(F(c), 0) * COMMUNITY_SCORE_MODIFIER) +
+              COMMUNITY_SCORE_MODIFIER_MIN)
+             * F(d)) + 1,
+            function='ln'
+        )
+        download_rank_expr = (
+                F('download_count_ln')
+                / (1 + F('download_count_ln'))
+                * DOWNLOAD_RANK_MULTIPLIER
+        )
+
+        q = 'repository__quality_score'
+        # This function is better than using a linear function because it
+        # makes it so that the effect of losing the first few points is
+        # relatively minor, which reduces the impact of errors in scoring.
+        quality_rank_expr = (
+                Func(Coalesce(F(q), 0) + 1, function='log')
+                * CONTENT_SCORE_MULTIPLIER
+        )
+
+        relevance_expr = (
+                F('search_rank') + F('download_rank') + F('quality_rank')
+        )
+
+        return qs.annotate(
+            download_count_ln=Expr(
+                download_count_ln_expr,
+                output_field=db_fields.FloatField()),
+            download_rank=Expr(
+                download_rank_expr,
+                output_field=db_fields.FloatField()),
+            quality_rank=Expr(
+                quality_rank_expr,
+                output_field=db_fields.FloatField()),
+            relevance=Expr(
+                relevance_expr,
+                output_field=db_fields.FloatField()),
+        )
+
+    def _add_order_by(self, qs):
+        order_by = self.order_by
+        prefix = '-' if self.order == 'desc' else ''
+        if order_by == 'qualname':
+            order_by = [prefix + 'namespace__name', prefix + 'name']
+        elif order_by == 'download_count':
+            order_by = [prefix + 'repository__download_count']
+        else:
+            order_by = [prefix + order_by]
+        return qs.order_by(*order_by)

--- a/galaxy/api/internal/serializers/__init__.py
+++ b/galaxy/api/internal/serializers/__init__.py
@@ -24,6 +24,10 @@ from .imports import (  # noqa: F401
     CollectionImportTaskItem,
     RepositoryImportTaskItem,
 )
+from .search import (  # noqa: F401
+    CollectionSearchSerializer,
+    SearchRequestSerializer,
+)
 
 __all__ = (
     'CollectionListSerializer',
@@ -31,4 +35,6 @@ __all__ = (
     'RepositoryImportTaskItem',
     'CollectionImportTaskItem',
     'CollectionUpdateSerializer',
+    'CollectionSearchSerializer',
+    'SearchRequestSerializer',
 )

--- a/galaxy/api/internal/serializers/search.py
+++ b/galaxy/api/internal/serializers/search.py
@@ -1,0 +1,95 @@
+# (c) 2012-2019, Ansible by Red Hat
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+from rest_framework import serializers
+from rest_framework import fields
+
+from galaxy import constants
+from .collections import CollectionListSerializer
+
+
+__all__ = (
+    'SearchRequestSerializer',
+    'CollectionSearchSerializer',
+)
+
+
+# TODO(cutwater): Move to fields
+class SeparatedStringField(fields.Field):
+
+    child = fields.CharField()
+
+    def __init__(self, **kwargs):
+        self.separator = kwargs.pop('separator', ' ')
+        self.child = kwargs.pop('child', self.child)
+        super().__init__(**kwargs)
+
+    def to_internal_value(self, data):
+        return [self.child.run_validation(item)
+                for item in data.split(self.separator)]
+
+
+class SearchRequestSerializer(serializers.Serializer):
+    keywords = fields.CharField(default=None)
+    namespaces = SeparatedStringField(
+        child=fields.RegexField(regex=constants.NAME_REGEXP),
+        default=None,
+    )
+    names = SeparatedStringField(
+        child=fields.RegexField(regex=constants.NAME_REGEXP),
+        default=None,
+    )
+    tags = SeparatedStringField(
+        child=fields.RegexField(regex=constants.TAG_REGEXP),
+        default=None,
+    )
+    contributor_type = fields.ChoiceField(
+        choices=constants.NS_TYPES,
+        default=None,
+    )
+    platforms = SeparatedStringField(default=None)
+    cloud_platforms = SeparatedStringField(default=None)
+    deprecated = fields.NullBooleanField(default=False)
+
+
+class CollectionSearchSerializer(CollectionListSerializer):
+    content_match = serializers.SerializerMethodField()
+
+    class Meta(CollectionListSerializer.Meta):
+        fields = CollectionListSerializer.Meta.fields + (
+            'content_match',
+        )
+
+    def get_content_match(self, obj):
+        content_match = getattr(obj, 'content_match', None)
+        if not content_match:
+            return None
+
+        contents = {
+            'module': [],
+            'role': [],
+            'playbook': [],
+            'plugin': []
+        }
+
+        for content in content_match:
+            if content['content_type'] in contents:
+                contents[content['content_type']].append(content['name'])
+            else:
+                contents['plugin'].append(content['name'])
+
+        return {'total_count': len(content_match), 'contents': contents}

--- a/galaxy/api/internal/tests/test_search.py
+++ b/galaxy/api/internal/tests/test_search.py
@@ -1,0 +1,513 @@
+# (c) 2012-2019, Ansible by Red Hat
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+import typing as t
+
+from django.test import TestCase
+
+from galaxy import constants
+from galaxy.main import models
+from galaxy.api.internal.search import (
+    BaseSearch, CollectionSearch, ContentSearch
+)
+
+
+class CommonSearchTestMixin:
+    def _create_content(self, namespace: str, name: str, **kwargs):
+        raise NotImplementedError
+
+    def _create_namespace(
+            self, name: str, is_vendor: bool = False) -> models.Namespace:
+        obj = models.Namespace.objects.create(name=name, is_vendor=is_vendor)
+        self.namespaces[name] = obj
+        return obj
+
+    def _assert_search_results(
+            self, query: BaseSearch, expected: t.List[str],
+            check_order: bool = False) -> t.NoReturn:
+        assert query.count() == len(expected)
+        result_names = [item.name for item in query.search()]
+        match_names = [self.content[name].name for name in expected]
+
+        if check_order:
+            assert result_names == match_names
+        else:
+            assert sorted(result_names) == sorted(match_names)
+
+    def _init_data(self) -> t.NoReturn:
+        self.namespaces = {}
+        self.content = {}
+
+        self._create_namespace('webtools')
+        self._create_namespace('cloudtools', is_vendor=True)
+
+        self._create_content(
+            namespace='webtools', name='nginx', version='1.0.0',
+            description='Nginx is a web server which can also be used '
+                        'as a reverse proxy, load balancer, mail proxy '
+                        'and HTTP cache.',
+            download_count=830000,
+            quality_score=4.9,
+            tags=['web', 'nginx', 'reverse', 'proxy'],
+            cloud_platforms=['gcloud'],
+            contents=[
+                {'content_type': 'role', 'name': 'nginx'},
+            ],
+        )
+        self._create_content(
+            namespace='webtools', name='apache2', version='1.0.0',
+            description='The Apache HTTP Server, colloquially called Apache, '
+                        'is free and open-source cross-platform web '
+                        'server software.',
+            download_count=6000,
+            quality_score=3.0,
+            deprecated=True,
+            tags=['apache', 'web', 'webserver', 'httpd'],
+            contents=[
+                {'content_type': 'role', 'name': 'httpd'},
+            ],
+        )
+        self._create_content(
+            namespace='webtools', name='uwsgi', version='1.0.0',
+            description='uWSGI is a software application that "aims at '
+                        'developing a full stack for building hosting '
+                        'services".',
+            download_count=490000,
+            quality_score=4.5,
+            tags=['development', 'web', 'wsgi'],
+            contents=[
+                {'content_type': 'role', 'name': 'uwsgi'},
+                {'content_type': 'role', 'name': 'uwsgi-docker'},
+            ],
+        )
+
+        self._create_content(
+            namespace='cloudtools', name='openstack', version='1.0.0',
+            description='OpenStack is a free and open-source software '
+                        'platform for cloud computing',
+            download_count=850000,
+            quality_score=4.5,
+            tags=['cloud', 'openstack'],
+            platforms=['debian:stretch', 'ubuntu:xenial'],
+            cloud_platforms=['aws'],
+            contents=[
+                {'content_type': 'role', 'name': 'nova'},
+                {'content_type': 'role', 'name': 'neutron'},
+                {'content_type': 'role', 'name': 'cinder'},
+            ],
+        )
+        self._create_content(
+            namespace='cloudtools', name='docker', version='1.0.0',
+            description='Docker is a collection of interoperating '
+                        'software-as-a-service and platform-as-a-service '
+                        'offerings.',
+            download_count=150000,
+            quality_score=4.2,
+            tags=['cloud', 'docker', 'containers'],
+            platforms=['debian:stretch', 'ubuntu:xenial'],
+            contents=[
+                {'content_type': 'role', 'name': 'docker'},
+            ],
+        )
+        self._create_content(
+            namespace='cloudtools', name='kubernetes', version='1.0.0',
+            description='Kubernetes is an open-source container-orchestration '
+                        'system for automating application deployment, '
+                        'scaling, and management.',
+            download_count=770000,
+            quality_score=4.7,
+            tags=['cloud', 'kubernetes', 'k8s', 'containers'],
+            platforms=['centos:6', 'centos:7', 'ubuntu:xenial'],
+            cloud_platforms=['aws', 'gcloud'],
+            contents=[
+                {'content_type': 'module', 'name': 'k8s_service'},
+                {'content_type': 'module', 'name': 'k8s_deploymentconfig'},
+                {'content_type': 'module', 'name': 'k8s_route'},
+            ],
+        )
+
+
+class TestCollectionSearch(CommonSearchTestMixin, TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._init_data()
+
+    def _create_content(
+            self,
+            namespace: str,
+            name: str,
+            **kwargs,
+    ) -> models.Collection:
+        namespace_obj = self.namespaces[namespace]
+        collection_obj = models.Collection.objects.create(
+            namespace=namespace_obj,
+            name=name,
+            deprecated=kwargs.get('deprecated', False),
+            download_count=kwargs.get('download_count', 0)
+        )
+        for tag in kwargs.get('tags', []):
+            tag_obj, _ = models.Tag.objects.get_or_create(name=tag)
+            collection_obj.tags.add(tag_obj)
+        self.content[name] = collection_obj
+
+        version_obj = models.CollectionVersion.objects.create(
+            collection=collection_obj,
+            version=kwargs.get('version', '1.0.0'),
+            metadata={
+                'namespace': namespace,
+                'name': name,
+                'description': kwargs.get('description', ''),
+                'tags': kwargs.get('tags', [])
+            },
+            contents=kwargs.get('contents', []),
+            quality_score=kwargs.get('quality_score', 0.)
+        )
+        collection_obj.latest_version = version_obj
+        collection_obj.save()
+        return collection_obj
+
+    def test_filter_by_keyword_in_name(self):
+        query = CollectionSearch({'keywords': 'openstack'})
+        self._assert_search_results(query, ['openstack'])
+
+    def test_filter_by_keyword_in_namespace(self):
+        query = CollectionSearch({'keywords': 'cloudtools'})
+        self._assert_search_results(
+            query, ['docker', 'openstack', 'kubernetes'])
+
+    def test_filter_by_keyword_in_description(self):
+        query = CollectionSearch({'keywords': 'balancer'})
+        self._assert_search_results(query, ['nginx'])
+
+    def test_filter_by_keyword_in_tags(self):
+        query = CollectionSearch({'keywords': 'httpd'})
+        self._assert_search_results(query, ['apache2'])
+
+    def test_filter_by_keyword_in_modules(self):
+        query = CollectionSearch({'keywords': 'cinder'})
+        self._assert_search_results(query, ['openstack'])
+
+    def test_filter_by_one_namespace(self):
+        # Search by full namespace
+        query = CollectionSearch({'namespaces': ['webtools']})
+        self._assert_search_results(
+            query, ['nginx', 'apache2', 'uwsgi'])
+
+        # Search by partial namespace
+        query = CollectionSearch({'namespaces': ['web']})
+        self._assert_search_results(
+            query, ['nginx', 'apache2', 'uwsgi'])
+
+    def test_filter_by_many_namespaces(self):
+        # Search by full namespace
+        query = CollectionSearch({'namespaces': ['cloudtools', 'webtools']})
+        expected = ['openstack', 'docker', 'kubernetes',
+                    'nginx', 'apache2', 'uwsgi']
+        self._assert_search_results(query, expected)
+
+        # Search by partial namespaces
+        query = CollectionSearch({'namespaces': ['cloud', 'web']})
+        expected = ['openstack', 'docker', 'kubernetes',
+                    'nginx', 'apache2', 'uwsgi']
+        self._assert_search_results(query, expected)
+
+        # Search by parts of the same namespace
+        query = CollectionSearch({'namespaces': ['webto', 'btools']})
+        self._assert_search_results(
+            query, ['nginx', 'apache2', 'uwsgi'])
+
+    def test_filter_by_one_name(self):
+        # Search by full name
+        query = CollectionSearch({'names': ['apache2']})
+        self._assert_search_results(query, ['apache2'])
+
+        # Search by partial name
+        query = CollectionSearch({'names': ['apac']})
+        self._assert_search_results(query, ['apache2'])
+
+    def test_filter_by_many_names(self):
+        # Search by full names
+        query = CollectionSearch({'names': ['apache2', 'nginx']})
+        self._assert_search_results(query, ['apache2', 'nginx'])
+
+        # Search by partial names
+        query = CollectionSearch({'names': ['apac', 'ngi']})
+        self._assert_search_results(query, ['apache2', 'nginx'])
+
+    def test_filter_by_ns_type(self):
+        query = CollectionSearch({'contributor_type': 'partner'})
+        self._assert_search_results(
+            query, ['docker', 'openstack', 'kubernetes'])
+
+        query = CollectionSearch({'contributor_type': 'community'})
+        self._assert_search_results(
+            query, ['nginx', 'apache2', 'uwsgi'])
+
+    def test_filter_by_tags(self):
+        query = CollectionSearch({'tags': ['proxy']})
+        self._assert_search_results(query, ['nginx'])
+
+        query = CollectionSearch({'tags': ['web']})
+        self._assert_search_results(query, ['apache2', 'nginx', 'uwsgi'])
+
+        query = CollectionSearch({'tags': ['web', 'nginx']})
+        self._assert_search_results(query, ['apache2', 'nginx', 'uwsgi'])
+
+    def test_filter_by_deprecated(self):
+        query = CollectionSearch({'deprecated': True})
+        self._assert_search_results(query, ['apache2'])
+
+    def test_filter_by_many_params(self):
+        query = CollectionSearch({'keywords': 'free', 'tags': ['cloud']})
+        self._assert_search_results(query, ['openstack'])
+
+    def test_order_by_keyword_relevance(self):
+        query = CollectionSearch({'keywords': 'docker'})
+        self._assert_search_results(
+            query, ['docker', 'uwsgi'], check_order=True)
+
+        query = CollectionSearch({'keywords': 'docker'}, order='asc')
+        self._assert_search_results(
+            query, ['uwsgi', 'docker'], check_order=True)
+
+    def test_order_by_quality_relevance(self):
+        # TODO(cutwater): Requires discussion of quality relevance function.
+        pass
+
+    def test_order_by_download_count(self):
+        expected = ['openstack', 'nginx', 'kubernetes',
+                    'uwsgi', 'docker', 'apache2']
+        query = CollectionSearch({}, order_by='download_count', order='desc')
+        self._assert_search_results(query, expected, check_order=True)
+
+        query = CollectionSearch({}, order_by='download_count', order='asc')
+        self._assert_search_results(
+            query, list(reversed(expected)), check_order=True)
+
+    def test_order_by_name(self):
+        expected = ['apache2', 'docker', 'kubernetes',
+                    'nginx', 'openstack', 'uwsgi']
+        query = CollectionSearch({}, order_by='name', order='asc')
+        self._assert_search_results(query, expected, check_order=True)
+
+        query = CollectionSearch({}, order_by='name', order='desc')
+        self._assert_search_results(
+            query, list(reversed(expected)), check_order=True)
+
+    def test_order_by_qualname(self):
+        expected = ['docker', 'kubernetes', 'openstack',
+                    'apache2',  'nginx', 'uwsgi']
+        query = CollectionSearch({}, order_by='qualname', order='asc')
+        self._assert_search_results(query, expected, check_order=True)
+
+        expected = ['uwsgi', 'nginx', 'apache2',
+                    'openstack', 'kubernetes', 'docker']
+        query = CollectionSearch({}, order_by='qualname', order='desc')
+        self._assert_search_results(query, expected, check_order=True)
+
+
+class TestContentSearch(CommonSearchTestMixin, TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._init_data()
+
+    def _create_content(
+            self,
+            namespace: str,
+            name: str,
+            **kwargs,
+    ) -> models.Content:
+        ns = self.namespaces[namespace]
+        provider = models.Provider.objects.get(name='GitHub')
+        content_type = models.ContentType.get(constants.ContentType.ROLE)
+        provider_ns = models.ProviderNamespace.objects.create(
+            provider=provider, namespace=ns, name=name)
+        repository = models.Repository.objects.create(
+            name=name, provider_namespace=provider_ns,
+            deprecated=kwargs.get('deprecated', False),
+            download_count=kwargs.get('download_count', 0),
+        )
+        content = models.Content.objects.create(
+            namespace=ns,
+            name=name,
+            repository=repository,
+            content_type=content_type,
+            description=kwargs.get('description', ''),
+            quality_score=kwargs.get('quality_score', 0.)
+
+        )
+        self.content[name] = content
+
+        for tag_name in kwargs.get('tags', []):
+            tag, _ = models.Tag.objects.get_or_create(name=tag_name)
+            content.tags.add(tag)
+
+        for platform_name in kwargs.get('platforms', []):
+            name, release = platform_name.split(':')
+            platform, _ = models.Platform.objects.get_or_create(
+                name=name, release=release)
+            content.platforms.add(platform)
+
+        for cloud_name in kwargs.get('cloud_platforms', []):
+            cloud, _ = models.CloudPlatform.objects.get_or_create(
+                name=cloud_name)
+            content.cloud_platforms.add(cloud)
+
+        return content
+
+    def test_filter_by_keyword_in_name(self):
+        query = ContentSearch({'keywords': 'openstack'})
+        self._assert_search_results(query, ['openstack'])
+
+    def test_filter_by_keyword_in_namespace(self):
+        query = ContentSearch({'keywords': 'cloudtools'})
+        self._assert_search_results(
+            query, ['docker', 'openstack', 'kubernetes'])
+
+    def test_filter_by_keyword_in_description(self):
+        query = ContentSearch({'keywords': 'balancer'})
+        self._assert_search_results(query, ['nginx'])
+
+    def test_filter_by_one_namespace(self):
+        # Search by full namespace
+        query = ContentSearch({'namespaces': ['webtools']})
+        self._assert_search_results(
+            query, ['nginx', 'apache2', 'uwsgi'])
+
+        # Search by partial namespace
+        query = ContentSearch({'namespaces': ['web']})
+        self._assert_search_results(
+            query, ['nginx', 'apache2', 'uwsgi'])
+
+    def test_filter_by_many_namespaces(self):
+        # Search by full namespace
+        query = ContentSearch({'namespaces': ['cloudtools', 'webtools']})
+        expected = ['openstack', 'docker', 'kubernetes',
+                    'nginx', 'apache2', 'uwsgi']
+        self._assert_search_results(query, expected)
+
+        # Search by partial namespaces
+        query = ContentSearch({'namespaces': ['cloud', 'web']})
+        expected = ['openstack', 'docker', 'kubernetes',
+                    'nginx', 'apache2', 'uwsgi']
+        self._assert_search_results(query, expected)
+
+        # Search by parts of the same namespace
+        query = ContentSearch({'namespaces': ['webto', 'btools']})
+        self._assert_search_results(
+            query, ['nginx', 'apache2', 'uwsgi'])
+
+    def test_filter_by_one_name(self):
+        # Search by full name
+        query = ContentSearch({'names': ['apache2']})
+        self._assert_search_results(query, ['apache2'])
+
+        # Search by partial name
+        query = ContentSearch({'names': ['apac']})
+        self._assert_search_results(query, ['apache2'])
+
+    def test_filter_by_many_names(self):
+        # Search by full names
+        query = ContentSearch({'names': ['apache2', 'nginx']})
+        self._assert_search_results(query, ['apache2', 'nginx'])
+
+        # Search by partial names
+        query = ContentSearch({'names': ['apac', 'ngi']})
+        self._assert_search_results(query, ['apache2', 'nginx'])
+
+    def test_filter_by_ns_type(self):
+        query = ContentSearch({'contributor_type': 'partner'})
+        self._assert_search_results(
+            query, ['docker', 'openstack', 'kubernetes'])
+
+        query = ContentSearch({'contributor_type': 'community'})
+        self._assert_search_results(
+            query, ['nginx', 'apache2', 'uwsgi'])
+
+    def test_filter_by_tags(self):
+        query = ContentSearch({'tags': ['proxy']})
+        self._assert_search_results(query, ['nginx'])
+
+    def test_filter_by_deprecated(self):
+        query = ContentSearch({'deprecated': True})
+        self._assert_search_results(query, ['apache2'])
+
+    def test_filter_by_many_params(self):
+        query = ContentSearch({'keywords': 'free', 'tags': ['cloud']})
+        self._assert_search_results(query, ['openstack'])
+
+    def test_filter_by_platform(self):
+        query = ContentSearch({'platforms': ['debian']})
+        self._assert_search_results(query, ['docker', 'openstack'])
+
+        query = ContentSearch({'platforms': ['debian', 'ubuntu', 'centos']})
+        self._assert_search_results(
+            query, ['docker', 'openstack', 'kubernetes'])
+
+    def test_filter_by_cloud_platform(self):
+        query = ContentSearch({'cloud_platforms': ['aws']})
+        self._assert_search_results(query, ['kubernetes', 'openstack'])
+
+        query = ContentSearch({'cloud_platforms': ['gcloud']})
+        self._assert_search_results(query, ['kubernetes', 'nginx'])
+
+        query = ContentSearch({'cloud_platforms': ['aws', 'gcloud']})
+        print(query.search())
+        self._assert_search_results(
+            query, ['kubernetes', 'openstack', 'nginx'])
+
+    def test_order_by_relevance(self):
+        query = ContentSearch(
+            {'keywords': 'server'}, order_by='relevance', order='desc')
+        self._assert_search_results(
+            query, ['nginx', 'apache2'], check_order=True)
+
+        query = ContentSearch(
+            {'keywords': 'server'}, order_by='relevance', order='asc')
+        self._assert_search_results(
+            query, ['apache2', 'nginx'], check_order=True)
+
+    def test_order_by_download_count(self):
+        expected = ['openstack', 'nginx', 'kubernetes',
+                    'uwsgi', 'docker', 'apache2']
+        query = ContentSearch({}, order_by='download_count', order='desc')
+        self._assert_search_results(query, expected, check_order=True)
+
+        query = ContentSearch({}, order_by='download_count', order='asc')
+        self._assert_search_results(
+            query, list(reversed(expected)), check_order=True)
+
+    def test_order_by_name(self):
+        expected = ['apache2', 'docker', 'kubernetes',
+                    'nginx', 'openstack', 'uwsgi']
+        query = ContentSearch({}, order_by='name', order='asc')
+        self._assert_search_results(query, expected, check_order=True)
+
+        query = ContentSearch({}, order_by='name', order='desc')
+        self._assert_search_results(
+            query, list(reversed(expected)), check_order=True)
+
+    def test_order_by_qualname(self):
+        expected = ['docker', 'kubernetes', 'openstack',
+                    'apache2',  'nginx', 'uwsgi']
+        query = ContentSearch({}, order_by='qualname', order='asc')
+        self._assert_search_results(query, expected, check_order=True)
+
+        expected = ['uwsgi', 'nginx', 'apache2',
+                    'openstack', 'kubernetes', 'docker']
+        query = ContentSearch({}, order_by='qualname', order='desc')
+        self._assert_search_results(query, expected, check_order=True)

--- a/galaxy/api/internal/tests/test_search_views.py
+++ b/galaxy/api/internal/tests/test_search_views.py
@@ -15,29 +15,9 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-from .collections import (  # noqa: F401
-    CollectionList,
-    CollectionDetail,
-    CollectionUpdate,
-)
-from .imports import (  # noqa: F401
-    NamespaceImportsList,
-)
-
-from .combined import (  # noqa: F401
-    RepoAndCollectionList,
-    CombinedDetail,
-)
-from .search import (  # noqa: F401
-    SearchView,
-)
+from rest_framework.test import APITestCase
 
 
-__all__ = (
-    'CollectionList',
-    'CollectionDetail',
-    'NamespaceImportsList',
-    'RepoAndCollectionList',
-    'CombinedDetail',
-    'CollectionUpdate',
-)
+class TestSearchView(APITestCase):
+    def setUp(self):
+        pass

--- a/galaxy/api/internal/urls.py
+++ b/galaxy/api/internal/urls.py
@@ -29,7 +29,8 @@ ui_urls = [
         'namespaces/<int:namespace_id>/imports/',
         views.NamespaceImportsList.as_view()),
     path('repos-and-collections/', views.RepoAndCollectionList.as_view()),
-    path('repo-or-collection-detail/', views.CombinedDetail.as_view())
+    path('repo-or-collection-detail/', views.CombinedDetail.as_view()),
+    path('search/', views.SearchView.as_view()),
 ]
 
 

--- a/galaxy/api/internal/views/search.py
+++ b/galaxy/api/internal/views/search.py
@@ -1,0 +1,141 @@
+# (c) 2012-2019, Ansible by Red Hat
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+
+from rest_framework.response import Response
+
+from galaxy.api import base
+from galaxy.api import exceptions
+from galaxy.api import serializers as serializers_v1
+from galaxy.api.internal import serializers as serializers_int
+from galaxy.api.internal.search import CollectionSearch, ContentSearch
+from galaxy.main import models
+
+
+__all__ = (
+    'SearchView',
+)
+
+CONTENT_ONLY_FILTERS = [
+    'platforms',
+    'cloud_platforms',
+]
+
+
+def _ensure_positive_int(string, field, cutoff=None):
+    msg = f'{field} must be a positive integer'
+    try:
+        value = int(string)
+    except ValueError:
+        raise exceptions.ValidationError(detail=msg)
+    if value < 0:
+        raise exceptions.ValidationError(detail=msg)
+    if cutoff is not None:
+        return min(value, cutoff)
+    return value
+
+
+# TODO(cutwater): Lazy pagination
+# TODO(cutwater): Implement autocomplete views
+class SearchView(base.APIView):
+
+    ordering_param = 'order_by'
+    allowed_ordering = (
+        'relevance',
+        'download_count',
+        'qualname',
+        'name',
+    )
+    default_ordering = '-relevance'
+
+    page_size = 10
+    max_page_size = 100
+
+    def get(self, request):
+        page = self.get_page(request)
+        page_size = self.get_page_size(request)
+        order_by, order = self.get_order_by(request)
+        filters = self._parse_query_params(request.query_params)
+
+        start = page_size * (page - 1)
+        end = page_size * page
+
+        # Collections
+        if any(filters[k] for k in CONTENT_ONLY_FILTERS):
+            collections_count = 0
+            collections = []
+        else:
+            collection_search = CollectionSearch(filters, order_by, order)
+            collections_count = collection_search.count()
+            collections = collection_search.search()[start:end]
+            # TODO(cutwater): This function should be refactored in order
+            #  to annotate collection objects retrieved withing search class.
+            #  However due to initial design search() function returns
+            #  a queryset, while pagination is performed outside.
+            #  This makes injecting content_match currently impossible.
+            collection_search._add_content_match(collections)
+
+        # Contents
+        content_search = ContentSearch(filters, order_by, order)
+        content_count = content_search.count()
+        if len(collections) >= page_size:
+            contents = models.Content.objects.none()
+        else:
+            c_start = max(0, start - collections_count)
+            c_end = end - collections_count
+            contents = content_search.search()[c_start:c_end]
+
+        result = {
+            'collection': {
+                'count': collections_count,
+                'results': serializers_int.CollectionSearchSerializer(
+                    collections, many=True).data
+            },
+            'content': {
+                'count': content_count,
+                'results': serializers_v1.RoleSearchSerializer(
+                    contents, many=True).data,
+            },
+        }
+
+        return Response(result)
+
+    def get_page(self, request):
+        return _ensure_positive_int(
+            request.query_params.get('page', 1), 'page')
+
+    def get_page_size(self, request):
+        return _ensure_positive_int(
+            request.query_params.get('page_size', self.page_size), 'page_size',
+            self.max_page_size)
+
+    def get_order_by(self, request):
+        param = request.query_params.get(
+            self.ordering_param, self.default_ordering)
+        order = 'asc'
+        if param.startswith('-'):
+            order = 'desc'
+            param = param[1:]
+        if param not in self.allowed_ordering:
+            raise exceptions.ValidationError(
+                f'{repr(param)} is not a valid ordering parameter value.')
+        return param, order
+
+    @staticmethod
+    def _parse_query_params(params):
+        params_serializer = serializers_int.SearchRequestSerializer(
+            data=params)
+        params_serializer.is_valid(raise_exception=True)
+        return params_serializer.validated_data

--- a/galaxy/api/v2/views/__init__.py
+++ b/galaxy/api/v2/views/__init__.py
@@ -19,11 +19,20 @@ from .collection import (  # noqa: F401
     CollectionListView,
     CollectionDetailView,
 )
-from galaxy.api.v2.views.collection_import import (  # noqa: F401
+from .collection_import import (  # noqa: F401
     CollectionImportView
 )
 from .collection_version import (  # noqa: F401
     CollectionArtifactView,
     VersionListView,
     VersionDetailView,
+)
+
+__all__ = (
+    'CollectionListView',
+    'CollectionDetailView',
+    'CollectionImportView',
+    'CollectionArtifactView',
+    'VersionListView',
+    'VersionDetailView',
 )

--- a/galaxy/constants.py
+++ b/galaxy/constants.py
@@ -29,6 +29,14 @@ NAME_REGEXP = re.compile(r'^(?!.*__)[a-z]+[0-9a-z_]*$')
 MATCH_LEADING_NUMBER_REGEXP = re.compile(r'^[0-9]')
 
 
+NS_TYPE_COMMUNITY = 'community'
+NS_TYPE_PARTNER = 'partner'
+NS_TYPES = [
+    NS_TYPE_COMMUNITY,
+    NS_TYPE_PARTNER,
+]
+
+
 class Enum(enum.Enum):
     """
     Values stored as `value`, `description` tuples to be used as `choices`

--- a/galaxy/main/models/collection.py
+++ b/galaxy/main/models/collection.py
@@ -37,11 +37,13 @@ class Collection(mixins.TimestampsMixin, models.Model):
     """
     A model representing an Ansible Content Collection.
 
-    :var name: Collection name.
     :var namespace: Reference to a collection nanespace.
+    :var name: Collection name.
     :var deprecated: Indicates if a collection is deprecated.
+    :var download_count: Number of collection downloads.
+    :var comminity_score: Total community score.
+    :var community_survey_count: Number of community surveys.
     :var tags: List of a last collection version tags.
-    :var dependencies: List a last collection version direct??? dependencies.
     """
 
     namespace = models.ForeignKey(Namespace, on_delete=models.PROTECT)
@@ -49,8 +51,6 @@ class Collection(mixins.TimestampsMixin, models.Model):
 
     deprecated = models.BooleanField(default=False)
 
-    # Search vector
-    search_vector = psql_search.SearchVectorField(default='')
     # Community and quality score
     download_count = models.IntegerField(default=0)
     community_score = models.FloatField(null=True)
@@ -64,6 +64,9 @@ class Collection(mixins.TimestampsMixin, models.Model):
         null=True,
     )
     tags = models.ManyToManyField('Tag')
+
+    # Search indexes
+    search_vector = psql_search.SearchVectorField(default='')
 
     class Meta:
         unique_together = (


### PR DESCRIPTION
Implement a `GET /api/v2/internal/ui/search/` endpoint that
performs a search against collections and roles (contents)
and returns a result in combined format.

Acceptable parameters:
  * `keywords` - A space separated list of search keywords.
  * `namespaces` - A space separated list of user namespaces.
  * `names` - A space separated list of collections or content names.
  * `ns_type` - A namespace type filter (one of "community", "partner").
  * `platforms` - A space separated list of platforms (content only).
  * `clouds` - A space separated list of cloud platforms (content only).
  * `deprecated` - Can be either `null`, `true` or `false` (default).
        If `true` - only deprecated records are returned.
        If `false` - only not deprecated records are returned.
        If `null` - all records are returned (both deprecated and not).
  * `page` - A page number, positive integer.
  * `page_size` - A page size (10 by default, allowed maximum is 100
        items per page).
  * `ordering` - A results ordering. Allowed values are: `relevance`,
        `download_count`, `qualname`, `name`. If prefixed with `-`,
        results are returned in reverse order.

Closes: #1526 