### PR TITLE
Update install.rst

### DIFF
--- a/docs/docsite/rst/mazer/install.rst
+++ b/docs/docsite/rst/mazer/install.rst
@@ -72,5 +72,5 @@ If 'DEFAULT_CONFIG_PATH' is found the correct branch of ansible is installed.
 
 .. code-block:: bash
 
-    $ ansible-config list | grep DEFAULT_CONTENT_PATH
-    DEFAULT_CONTENT_PATH:
+    $ ansible-config list | grep COLLECTIONS_PATHS
+    COLLECTIONS_PATHS:


### PR DESCRIPTION
Looks like the configuration name has changed.

```
ansible-config list | grep COLLECTIONS
COLLECTIONS_PATHS:
  - {name: ANSIBLE_COLLECTIONS_PATHS}
```

```
ansible --version
ansible 2.8.0rc2
  config file = None
  configured module search path = [u'/home/meyers/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/meyers/ansible/ansible/lib/ansible
  executable location = /home/meyers/ansible/ansible/bin/ansible
```