### PR TITLE
Add MEDIA_ROOT value to test settings

### DIFF
--- a/galaxy/settings/testing.py
+++ b/galaxy/settings/testing.py
@@ -86,3 +86,5 @@ WAIT_FOR = [
 ]
 
 STATIC_ROOT = ''
+
+MEDIA_ROOT = '/var/lib/galaxy/media/'


### PR DESCRIPTION
artifacts created turning `make/dev test` are being left in project root which is not ignored, causing non PR CI to fail:

```
Building base container...
error checking context: 'no permission to read from '/home/travis/build/ansible/galaxy/artifact/84/ff92691f909a05b224e1c56abb4864f01b4f8e3c854e4bb4c7baf1d3f6d652''.
make: *** [build/release] Error 1
```

This edit allows `testing` settings to see the MEDIA_ROOT variable since it was recently moved out of `default` into `development` in #1815