### PR TITLE
Fix Django deprecation warning

### DIFF
--- a/galaxy/main/fields.py
+++ b/galaxy/main/fields.py
@@ -35,7 +35,7 @@ class VersionField(models.CharField):
         kwargs.setdefault('max_length', 64)
         super(VersionField, self).__init__(*args, **kwargs)
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, expression, connection):
         if value is None:
             return value
         return semantic_version.Version(value)


### PR DESCRIPTION
Since Django 2.0 a `context` parameter of
`models.Field.from_db_value()` has been deprecated and
will be removed in Django 3.0.
This patch fixes signature of overloaded `from_db_value()` method
in custom fields.

https://docs.djangoproject.com/en/2.0/releases/2.0/#context-argument-of-field-from-db-value-and-expression-convert-value