### PR TITLE
Validation of content name format

### DIFF
--- a/galaxy/importer/collection.py
+++ b/galaxy/importer/collection.py
@@ -152,23 +152,20 @@ class CollectionLoader(object):
 
     def _load_contents(self, content_list):
         for content_type, rel_path, extra in content_list:
+            self.log.info(f'===== LOADING {content_type.name} =====')
             loader_cls = loaders.get_loader(content_type)
             loader = loader_cls(content_type, rel_path, self.path,
                                 logger=self.log, **extra)
-
-            self.log.info('===== LOADING {} ====='.format(
-                          content_type.name))
             content = loader.load()
             self.log.info(' ')
 
             name = ': {}'.format(content.name) if content.name else ''
-            self.log.info('===== LINTING {}{} ====='.format(
-                          content_type.name, name))
+            self.log.info(f'===== LINTING {content_type.name}{name} =====')
             loader.lint()
             content.scores = loader.score()
             self.log.info(' ')
-            self.log.info('===== IMPORTING {}{} ====='.format(
-                          content_type.name, name))
+
+            self.log.info(f'===== IMPORTING {content_type.name}{name} =====')
             self.log.info(' ')
 
             yield content

--- a/galaxy/importer/exceptions.py
+++ b/galaxy/importer/exceptions.py
@@ -43,3 +43,7 @@ class ContentLoadError(ImporterError):
 
 class APBContentLoadError(ContentLoadError):
     pass
+
+
+class ContentNameError(ImporterError):
+    pass

--- a/galaxy/importer/finders.py
+++ b/galaxy/importer/finders.py
@@ -114,7 +114,7 @@ class FileSystemFinder(BaseFinder):
             for content in func(content_type, content_path):
                 yield content
 
-    def _find_modules(self, content_type, content_dir):
+    def _find_plugins(self, content_type, content_dir):
         for file_name in os.listdir(content_dir):
             file_path = os.path.join(content_dir, file_name)
             if os.path.isdir(file_path):
@@ -146,10 +146,10 @@ class FileSystemFinder(BaseFinder):
             if content_type == constants.ContentType.ROLE:
                 yield content_type, 'roles', self._find_roles
             elif content_type == constants.ContentType.MODULE:
-                yield content_type, 'plugins/modules', self._find_modules
+                yield content_type, 'plugins/modules', self._find_plugins
             else:
                 yield (content_type, 'plugins/' + content_type.value,
-                       self._find_modules)
+                       self._find_plugins)
 
 
 class MetadataFinder(BaseFinder):

--- a/galaxy/importer/loaders/role.py
+++ b/galaxy/importer/loaders/role.py
@@ -284,7 +284,7 @@ class RoleLoader(base.BaseLoader):
         meta_parser = self._get_meta_parser()
         galaxy_info = meta_parser.metadata
         original_name = self.name
-        self.name = self._get_name(galaxy_info)
+        self.name = self._get_metadata_role_name(galaxy_info)
 
         tox_data = self._load_tox()
         meta_parser.set_tox(tox_data)
@@ -369,10 +369,17 @@ class RoleLoader(base.BaseLoader):
         meta = self._load_metadata()
         return RoleMetaParser(meta, logger=self.log)
 
-    def _get_name(self, galaxy_info):
-        name = self.name
+    def _get_metadata_role_name(self, galaxy_info):
+        """Get role_name from repository role metadata, if it exists.
 
-        if name:
+        Collections do not support role_name.
+        Collections have self.name already set via directory path.
+        """
+
+        name = self.name
+        is_collection = bool(self.name)
+
+        if is_collection:
             if galaxy_info.get('role_name'):
                 self.log.warning("Role in collection gets name from directory,"
                                  " ignoring the 'role_name' attribute")

--- a/galaxy/importer/repository.py
+++ b/galaxy/importer/repository.py
@@ -101,18 +101,16 @@ class RepositoryLoader(object):
 
     def _load_contents(self, contents):
         for content_type, rel_path, extra in contents:
+            self.log.info(f'===== LOADING {content_type.name} =====')
             loader_cls = loaders.get_loader(content_type)
             loader = loader_cls(content_type, rel_path, self.path,
                                 logger=self.log, **extra)
 
-            self.log.info('===== LOADING {} ====='.format(
-                          content_type.name))
             content = loader.load()
             self.log.info(' ')
 
             name = ': {}'.format(content.name) if content.name else ''
-            self.log.info('===== LINTING {}{} ====='.format(
-                          content_type.name, name))
+            self.log.info(f'===== LINTING {content_type.name}{name} =====')
             lint_result = loader.lint()
             content.scores = loader.score()
             self.log.info(' ')

--- a/galaxy/worker/importers/base.py
+++ b/galaxy/worker/importers/base.py
@@ -18,7 +18,6 @@
 import logging
 import re
 
-from galaxy import constants
 from django.utils import timezone
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -64,12 +63,10 @@ class ContentImporter(object):
             original_name = self.data.original_name
 
         # Check name
-        if not re.match(constants.NAME_REGEXP, name):
+        if not re.match(r'^[a-zA-Z0-9_-]+$', name):
             raise exc.LegacyTaskError(
-                f"Role has invalid name: '{name}', "
-                "expecting name to contain only lowercase "
-                "alphanumeric characters or '_'"
-            )
+                'Invalid name, only aplhanumeric characters, '
+                '"-" and "_" symbols are allowed.')
 
         try:
             # Check for an existing Content object matching name

--- a/galaxy/worker/importers/base.py
+++ b/galaxy/worker/importers/base.py
@@ -18,6 +18,7 @@
 import logging
 import re
 
+from galaxy import constants
 from django.utils import timezone
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -63,10 +64,12 @@ class ContentImporter(object):
             original_name = self.data.original_name
 
         # Check name
-        if not re.match(r'^[a-zA-Z0-9_-]+$', name):
+        if not re.match(constants.NAME_REGEXP, name):
             raise exc.LegacyTaskError(
-                'Invalid name, only aplhanumeric characters, '
-                '"-" and "_" symbols are allowed.')
+                f"Role has invalid name: '{name}', "
+                "expecting name to contain only lowercase "
+                "alphanumeric characters or '_'"
+            )
 
         try:
             # Check for an existing Content object matching name


### PR DESCRIPTION
Fixes #1836

Add validation for role and plugin content names for collections.

~~Replace regex used for repository roles to be the same used for collection roles.~~ Repo role name validation will be kept as-is to allow legacy roles to continue to be imported.

Import fails with invalid content names.
