### PR TITLE
Save new namespaces as lowercase, in api post

### DIFF
--- a/galaxy/api/views/namespace.py
+++ b/galaxy/api/views/namespace.py
@@ -254,8 +254,10 @@ class NamespaceList(base_views.ListCreateAPIView):
                 data['id'], request.user.id):
             owners.append(request.user.id)
 
+        sanitized_name = data['name'].lower().replace('-', '_')
+
         namespace_attributes = {
-            'name': data['name'],
+            'name': sanitized_name,
             'description':
                 data['description']
                 if data.get('description') is not None else ''


### PR DESCRIPTION
Resolves #1805

We want to make sure new namespaces are created lower case in the database so they are compatible with collections.

I confirmed after logging in with a new github username that is mixed case, galaxy created a `Namespace` object with lowercase `name` as desired via handler: https://github.com/ansible/galaxy/blob/devel/galaxy/main/signals/handlers.py#L44.

The `NamespaceList` post view should also follow similar logic, this PR adds that.
