### PR TITLE
Implement artifact download and info views

### DIFF
--- a/galaxy/api/download/tests/test_download_views.py
+++ b/galaxy/api/download/tests/test_download_views.py
@@ -1,0 +1,128 @@
+# (c) 2012-2019, Ansible by Red Hat
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+import importlib
+from urllib import parse as urlparse
+from unittest import mock
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from pulpcore.app import models as pulp_models
+from rest_framework import status as http_codes
+from rest_framework.test import APITestCase
+
+from galaxy.main import models
+
+
+UserModel = get_user_model()
+
+
+class TestArtifactDownloadView(APITestCase):
+    download_url = '/download/{filename}'
+    mazer_user_agent = 'Mazer/0.4.0 (linux; python:3.6.8) ansible_galaxy/0.4.0'
+
+    @classmethod
+    def setUpClass(cls):
+        # Parameters of `storages.backends.s3boto3.S3Boto3Storage` class are
+        # initialized as class-attributes on module load.
+        # Because `storages.backends.s3boto3` module can be imported even
+        # before S3 specific test is executed overriding parameters locally
+        # is not effective.
+        # Thus we import `storages.backends.s3boto3` module before any
+        # request to download view is called.
+        super().setUpClass()
+        settings = dict(
+            AWS_ACCESS_KEY_ID='key',
+            AWS_SECRET_ACCESS_KEY='secret',
+            AWS_STORAGE_BUCKET_NAME='test',
+            AWS_DEFAULT_ACL=None,
+        )
+        with override_settings(**settings):
+            importlib.import_module('storages.backends.s3boto3')
+
+    def setUp(self):
+        super().setUp()
+        self.sha256 = \
+            '01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b'
+        self.storage_path = f'artifact/{self.sha256[:2]}/{self.sha256[2:]}'
+        self.filename = 'mynamespace-mycollection-1.2.3.tar.gz'
+
+        self.user = UserModel.objects.create_user(
+            username='testuser', password='secret')
+        self.namespace = models.Namespace.objects.create(name='mynamespace')
+        self.namespace.owners.set([self.user])
+
+        self.collection = models.Collection.objects.create(
+            namespace=self.namespace, name='mycollection')
+        self.version = models.CollectionVersion.objects.create(
+            collection=self.collection, version='1.2.3')
+
+    def _create_artifact(self):
+        self.artifact = pulp_models.Artifact.objects.create(
+            size=427611,
+            sha256=self.sha256,
+            file=SimpleUploadedFile(self.storage_path, ''),
+        )
+        self.ca = pulp_models.ContentArtifact.objects.create(
+            content=self.version, artifact=self.artifact,
+            relative_path=self.filename
+        )
+
+    @override_settings(
+        MEDIA_ROOT='',
+        DEFAULT_FILE_STORAGE='storages.backends.s3boto3.S3Boto3Storage',
+        AWS_DEFAULT_ACL=None,
+    )
+    @mock.patch('storages.backends.s3boto3.S3Boto3Storage.save')
+    def test_s3_redirect(self, save_mock):
+        save_mock.return_value = self.storage_path
+        self._create_artifact()
+
+        old_download_count = self.collection.download_count
+        url = self.download_url.format(filename=self.filename)
+        response = self.client.get(url, HTTP_USER_AGENT=self.mazer_user_agent)
+        assert response.status_code == http_codes.HTTP_302_FOUND
+
+        location = response['Location']
+        parsed_url = urlparse.urlparse(location)
+        assert parsed_url.scheme == 'https'
+        assert parsed_url.netloc == 'test.s3.amazonaws.com'
+        assert parsed_url.path == '/' + self.storage_path
+
+        query = urlparse.parse_qs(parsed_url.query)
+        assert query['response-content-disposition'] == [
+            f'attachment; filename={self.filename}'
+        ]
+
+        self.collection.refresh_from_db()
+        assert self.collection.download_count == old_download_count + 1
+
+    @override_settings(
+        MEDIA_ROOT='/var/lib/galaxy/media/',
+        DEFAULT_FILE_STORAGE='pulpcore.app.models.storage.FileSystem',
+    )
+    def test_direct_serve(self):
+        self._create_artifact()
+        url = self.download_url.format(filename=self.filename)
+
+        mock_open = mock.mock_open(read_data=b'CONTENT')
+        with mock.patch.object(self.artifact.file.storage, 'open', mock_open):
+            response = self.client.get(url)
+
+        assert response.status_code == http_codes.HTTP_200_OK
+        assert response.getvalue() == b'CONTENT'

--- a/galaxy/api/download/urls.py
+++ b/galaxy/api/download/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from . import views
+
+
+urlpatterns = [
+    path('download/<filename>', views.ArtifactDownloadView.as_view(),
+         name='artifact-download'),
+]

--- a/galaxy/api/download/views.py
+++ b/galaxy/api/download/views.py
@@ -1,0 +1,82 @@
+import logging
+from pathlib import PurePath
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.core.files.storage import FileSystemStorage
+from django.http import FileResponse
+from django.shortcuts import redirect, get_object_or_404
+from storages.backends import s3boto3
+from rest_framework.exceptions import NotFound
+from rest_framework.permissions import AllowAny
+
+from galaxy.api.base import APIView
+from galaxy.common.schema import CollectionFilename
+from galaxy.main import models
+
+
+__all__ = (
+    'ArtifactDownloadView',
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ArtifactDownloadView(APIView):
+    permission_classes = (AllowAny,)
+
+    def get(self, request, filename):
+        try:
+            filename = CollectionFilename.parse(filename)
+        except ValueError:
+            raise NotFound
+
+        version = get_object_or_404(
+            models.CollectionVersion,
+            collection__namespace__name__iexact=filename.namespace,
+            collection__name__iexact=filename.name,
+            version__exact=filename.version,
+        )
+
+        user_agent = request.META.get('HTTP_USER_AGENT', '')
+        if user_agent.startswith('Mazer/'):
+            version.collection.inc_download_count()
+
+        ca = version.get_content_artifact()
+        filename = PurePath(ca.relative_path).name
+
+        # If artifact url is a remote URL (e.g. S3 URL) return redirect to
+        # # this URL.
+        artifact_file = ca.artifact.file
+        storage = artifact_file.storage
+        if isinstance(storage, s3boto3.S3Boto3Storage):
+            return self._s3_redirect(artifact_file, filename)
+
+        # If running in debug mode serve file directly by Django.
+        if isinstance(storage, FileSystemStorage):
+            return self._serve_file(artifact_file, filename)
+
+        raise ImproperlyConfigured(
+            'Only S3 and local filesystem storage backends are supported.')
+
+    def _s3_redirect(self, artifact_file, filename):
+        content_disposition = f'attachment; filename={filename}'
+        parameters = {
+            'ResponseContentDisposition': content_disposition
+        }
+        url = artifact_file.storage.url(
+            artifact_file.name, parameters=parameters)
+        return redirect(url)
+
+    def _serve_file(self, artifact_file, filename):
+        if not settings.DEBUG:
+            logger.warning(
+                f'Serving artifact "{filename}" directly by Django '
+                f'application. This can affect service performance and '
+                f'should not be used in production.')
+        storage = artifact_file.storage
+        try:
+            return FileResponse(storage.open(artifact_file.path),
+                                as_attachment=True, filename=filename)
+        except FileNotFoundError:
+            raise NotFound(f'Artifact "{filename}" does not exist.')

--- a/galaxy/api/urls.py
+++ b/galaxy/api/urls.py
@@ -313,9 +313,7 @@ internal_urls = [
     url(r'^me/', include(me_urls)),
 ]
 
-
-app_name = 'api'
-urlpatterns = [
+api_urls = [
     # TODO(cutwater): Remove ApiRootView
     url(r'^$', views.ApiRootView.as_view(), name='api_root_view'),
     # TODO(cutwater): Move old urls from `api` to `api.v1` package.
@@ -327,4 +325,11 @@ urlpatterns = [
     # url(r'^v1/', include('galaxy.api.v1.urls')),
     path('v2/', include('galaxy.api.v2.urls', namespace='v2')),
     path('internal/', include('galaxy.api.internal.urls', namespace='int')),
+]
+
+
+app_name = 'api'
+urlpatterns = [
+    path('', include('galaxy.api.download.urls')),
+    path('api/', include(api_urls)),
 ]

--- a/galaxy/api/v2/serializers/__init__.py
+++ b/galaxy/api/v2/serializers/__init__.py
@@ -16,6 +16,7 @@
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
 from .collection import (  # noqa: F401
+    CollectionArtifactSerializer,
     CollectionImportSerializer,
     CollectionUploadSerializer,
     CollectionSerializer,
@@ -27,6 +28,7 @@ from .tasks import (  # noqa: F401
 )
 
 __all__ = (
+    'CollectionArtifactSerializer',
     'CollectionImportSerializer',
     'CollectionUploadSerializer',
     'CollectionSerializer',

--- a/galaxy/api/v2/serializers/collection.py
+++ b/galaxy/api/v2/serializers/collection.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
+from pathlib import PurePath
+
 from rest_framework import exceptions as drf_exc
 from rest_framework import serializers
 from rest_framework.reverse import reverse
@@ -26,6 +28,7 @@ from .tasks import BaseTaskSerializer
 
 
 __all__ = (
+    'CollectionArtifactSerializer',
     'CollectionImportSerializer',
     'CollectionUploadSerializer',
     'CollectionSerializer',
@@ -66,13 +69,10 @@ class VersionDetailSerializer(serializers.ModelSerializer):
         )
 
     def get_download_url(self, obj):
+        ca = obj.get_content_artifact()
         return reverse(
-            'api:v2:version-artifact',
-            kwargs={
-                'namespace': obj.collection.namespace.name,
-                'name': obj.collection.name,
-                'version': obj.version,
-            },
+            'api:artifact-download',
+            kwargs={'filename': ca.relative_path},
             request=self.context.get('request'),
         )
 
@@ -186,3 +186,20 @@ class CollectionUploadSerializer(serializers.Serializer):
             raise drf_exc.ValidationError(str(e))
 
         return data
+
+
+class CollectionArtifactSerializer(serializers.Serializer):
+    filename = serializers.SerializerMethodField()
+    size = serializers.IntegerField(source='artifact.size')
+    sha256 = serializers.CharField(source='artifact.sha256')
+    download_url = serializers.SerializerMethodField()
+
+    def get_filename(self, obj):
+        return PurePath(obj.relative_path).name
+
+    def get_download_url(self, obj):
+        return reverse(
+            'api:artifact-download',
+            kwargs={'filename': obj.relative_path},
+            request=self.context.get('request'),
+        )

--- a/galaxy/api/v2/views/collection_version.py
+++ b/galaxy/api/v2/views/collection_version.py
@@ -16,7 +16,7 @@
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
 
-from django.shortcuts import redirect, get_object_or_404
+from django.shortcuts import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny
 import semantic_version
@@ -107,26 +107,20 @@ class VersionDetailView(base.APIView):
         return get_object_or_404(models.Collection, namespace=ns, name=name)
 
 
-# TODO(cutwater): Use internal redirect for nginx
-class CollectionArtifactView(base.APIView):
+class CollectionArtifactView(base.RetrieveAPIView):
     permission_classes = (AllowAny, )
+    serializer_class = serializers.CollectionArtifactSerializer
 
-    def get(self, request, pk=None, namespace=None, name=None, version=None):
+    def get_object(self):
+        pk = self.kwargs.get('pk')
         if pk is not None:
             version = get_object_or_404(models.CollectionVersion, pk=pk)
         else:
             version = get_object_or_404(
                 models.CollectionVersion,
-                collection__namespace__name__iexact=namespace,
-                collection__name__iexact=name,
-                version__exact=version,
+                collection__namespace__name__iexact=self.kwargs['namespace'],
+                collection__name__iexact=self.kwargs['name'],
+                version__exact=self.kwargs['version'],
             )
 
-        user_agent = request.META.get('HTTP_USER_AGENT', '')
-
-        # count downloads by mazer
-        if user_agent.startswith('Mazer/'):
-            version.collection.download_count += 1
-            version.collection.save()
-
-        return redirect(version.get_download_url())
+        return version.get_content_artifact()

--- a/galaxy/main/models/collection.py
+++ b/galaxy/main/models/collection.py
@@ -77,6 +77,10 @@ class Collection(mixins.TimestampsMixin, models.Model):
             psql_indexes.GinIndex(fields=['search_vector'])
         ]
 
+    def inc_download_count(self):
+        Collection.objects.filter(pk=self.pk).update(
+            download_count=models.F('download_count') + 1)
+
 
 class CollectionVersion(mixins.TimestampsMixin, pulp_models.Content):
     """

--- a/galaxy/urls.py
+++ b/galaxy/urls.py
@@ -26,7 +26,7 @@ admin.autodiscover()
 
 urlpatterns = [
     url(r'^accounts/', include('allauth.urls')),
-    url(r'^api/', include('galaxy.api.urls')),
+    url(r'', include('galaxy.api.urls')),
     url(r'^api-auth/', include('rest_framework.urls',
                                namespace='rest_framework')),
     url(settings.ADMIN_URL_PATTERN, admin.site.urls),

--- a/galaxyui/proxy.conf.js
+++ b/galaxyui/proxy.conf.js
@@ -20,7 +20,7 @@ const PROXY_CONFIG = {
         'secure': false
     },
     "/download": {
-        'target': "http://localhost:8080",
+        'target': "http://localhost:8888",
         'secure': false
     }
 }


### PR DESCRIPTION
* Artifact download view performs redirect to external URL if
  external S3 storage is used and serves files directly in DEBUG mode.
  Other configurations are not supported and cause error.
  An appropriate `ResponseContentDisposition` parameter is addeto to S3 URL.
  Endpoint: `/download/<filename>`
* Artifact info view returns artifact metadata (i.e.`filename`, `size`,
  `sha256`, `download_url`.
  NOTE: `filename` represents public filename and does not reflect
  actual storage path.
  Endpoints:
    - `/api/v2/collections/<namespace>/<name>/versions/<version>/artifact/`
    - `/api/v2/collection-versions/<id>/artifact/`

Fixes: #1847 