### PR TITLE
Add artifact info field to collection version detail view

### DIFF
--- a/galaxy/api/v2/tests/test_collection_version_views.py
+++ b/galaxy/api/v2/tests/test_collection_version_views.py
@@ -150,6 +150,12 @@ class TestVersionDetailView(APITestCase):
                     '/mycollection/versions/1.0.0/',
             'download_url': 'http://testserver/download/'
                             'mynamespace-mycollection-1.0.0.tar.gz',
+            'artifact': {
+                'filename': 'mynamespace-mycollection-1.0.0.tar.gz',
+                'size': 427611,
+                'sha256': '01ba4719c80b6fe911b091a7c05124b6'
+                          '4eeece964e09c058ef8f9805daca546b',
+            },
             'namespace': {
                 'id': self.namespace.pk,
                 'name': 'mynamespace',

--- a/galaxy/api/v2/views/collection_version.py
+++ b/galaxy/api/v2/views/collection_version.py
@@ -107,6 +107,7 @@ class VersionDetailView(base.APIView):
         return get_object_or_404(models.Collection, namespace=ns, name=name)
 
 
+# TODO(cutwater): Whith #1858 this view is considered for removal.
 class CollectionArtifactView(base.RetrieveAPIView):
     permission_classes = (AllowAny, )
     serializer_class = serializers.CollectionArtifactSerializer


### PR DESCRIPTION
This patch adds `artifact` field to the collection version detail
response which provides the following artifact info:
`filename`, `size` and `sha256`.

Fixes: #1846 