### PR TITLE
Improve handling of long namespace descriptions (#1889)

### DIFF
--- a/galaxyui/src/app/authors/detail/author-detail.component.html
+++ b/galaxyui/src/app/authors/detail/author-detail.component.html
@@ -13,10 +13,14 @@
                             </tr>
                         </table>
                     </div>
-                    <div class="namespace-bio text-overflow-pf">
+                    <div class="namespace-bio">
                         <p class="name">{{ namespace.name }}</p>
-                        <p>{{ namespace.description }}</p>
-                        <p *ngIf="namespace.company">{{ namespace.company }}</p>
+                        <div class="description">
+                            {{
+                                namespace.description.length > maxDescriptionLength ? (namespace.description | slice:0:maxDescriptionLength) + '...' : namespace.description}}
+                            <div class="fade-out"></div>
+                        </div>
+                        <p *ngIf="namespace.company"><i class="fa fa-building"></i> {{ namespace.company }}</p>
                         <p *ngIf="namespace.location"><i class="fa fa-map-marker"></i> {{ namespace.location }}</p>
                         <p *ngIf="namespace.email">
                             <a [appLogEvent]='namespace.email' [href]="'mailto:'+ namespace.email" tooltip="Send an email">

--- a/galaxyui/src/app/authors/detail/author-detail.component.less
+++ b/galaxyui/src/app/authors/detail/author-detail.component.less
@@ -83,6 +83,12 @@
         p {
             margin-bottom: 3px;
         }
+
+        .description {
+            font-size: 12px;
+            margin-bottom: 3px;
+        }
+
         .name {
             color: @black;
             font-weight: 700;

--- a/galaxyui/src/app/authors/detail/author-detail.component.ts
+++ b/galaxyui/src/app/authors/detail/author-detail.component.ts
@@ -86,6 +86,7 @@ export class AuthorDetailComponent implements OnInit {
     sortBy = 'name';
     isFollower = false;
     followerClass = 'fa fa-user-plus';
+    maxDescriptionLength = 150;
 
     preferences: UserPreferences = null;
 

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.html
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.html
@@ -35,13 +35,15 @@
                     [itemTemplate]="itemTemplate"
                     (onActionSelect)="handleListAction($event)">
                     <ng-template #itemTemplate let-item="item">
-                        <div class="list-pf-left">
-                            <span class="fa fa-folder-o list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
+                        <div class="list-pf-left center-icon">
+                            <div>
+                                <span class="fa fa-folder-o list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
+                            </div>
                         </div>
                         <div class="list-pf-content-wrapper">
                             <div class="list-pf-main-content">
                                 <div class="list-pf-title">{{item.name}}</div>
-                                <div class="list-pf-description text-overflow-pf">{{item.description }}</div>
+                                <div class="list-pf-description">{{item.description }}</div>
                             </div>
                             <div class="list-pf-additional-content">
                                 <pfng-list-expand-toggle [expandId]="'owners'" [item]="item" [template]="ownersTemplate">

--- a/galaxyui/src/app/my-content/namespace-list/namespace-list.component.less
+++ b/galaxyui/src/app/my-content/namespace-list/namespace-list.component.less
@@ -35,28 +35,9 @@
 #my-content-list {
     margin-bottom: 20px;
 
-    .list-pf,
-    .list-pf-item,
-    .list-pf-container,
-    .list-pf-content {
-        max-width: 100%;
-    }
-    .list-pf-main-content {
-        flex-basis: 50%;
-        flex-grow: 0;
-    }
-    .list-pf-additional-content {
-        flex-basis: 30%;
-        flex-grow: 0;
-    }
-
-    .list-pf-content-wrapper {
-        max-width: 100%;
-    }
-
-    .list-pf-title,
-    .list-pf-description {
-        flex-grow: 0;
-        flex-basis: 50%;
+    .center-icon {
+        display: flex;
+        justify-content: center;
+        align-items: center;
     }
 }


### PR DESCRIPTION
* Center icon on namespace list.
* Limit character count in namespace detail description.
* Remove broken text-overflow-pf class from namespace list description.

backport #1889 

(cherry picked from commit ae562b3eafbf36522d35d4d501fd4ad9ad552c63)