### PR TITLE
Fix typo (#1881)

### DIFF
--- a/galaxyui/src/app/react/components/my-content/content-list.tsx
+++ b/galaxyui/src/app/react/components/my-content/content-list.tsx
@@ -98,7 +98,7 @@ export class ContentList extends React.Component<IProps, {}> {
                         <EmptyState.Title>No Content</EmptyState.Title>
 
                         <EmptyState.Info>
-                            Add conent by clicking the "Add Content" button
+                            Add content by clicking the "Add Content" button
                             above.
                         </EmptyState.Info>
                     </div>


### PR DESCRIPTION
conent -> content

(cherry picked from commit ab50f258745068b32660f7b2a75fb573970fe7d4)

backport #1881 