### PR TITLE
Add ParamPaginator and ParamFilter react component

### DIFF
--- a/galaxyui/src/app/react/components/my-imports/import-list.tsx
+++ b/galaxyui/src/app/react/components/my-imports/import-list.tsx
@@ -9,16 +9,14 @@ import {
     ListView,
     ListViewItem,
     EmptyState,
-    Paginator,
 } from 'patternfly-react';
 
 import { FilterOption } from '../../shared-types/pf-toolbar';
-
 import { ParamFilter } from '../param-filter';
-
 import { PulpStatus } from '../../../enums/import-state.enum';
-
 import { cloneDeep } from 'lodash';
+
+import { ParamPaginator } from '../param-paginator';
 
 interface IProps {
     namespaces: Namespace[];
@@ -100,16 +98,10 @@ export class ImportListComponent extends React.Component<IProps, IState> {
                     )}
                 </div>
 
-                <Paginator
-                    viewType={'list'}
-                    pagination={{
-                        page: pageNumber,
-                        perPage: pageSize,
-                        perPageOptions: [10, 20, 40, 80, 100],
-                    }}
-                    itemCount={numberOfResults}
-                    onPageSet={i => this.setPageNumber(i)}
-                    onPerPageSelect={i => this.setPageSize(i)}
+                <ParamPaginator
+                    params={queryParams}
+                    count={numberOfResults}
+                    updateParams={x => this.props.setQueryParams(x)}
                 />
             </div>
         );

--- a/galaxyui/src/app/react/components/my-imports/import-list.tsx
+++ b/galaxyui/src/app/react/components/my-imports/import-list.tsx
@@ -87,6 +87,7 @@ export class ImportListComponent extends React.Component<IProps, IState> {
                     filterFields={this.filterFields}
                     params={queryParams}
                     count={numberOfResults}
+                    usePFToolbar={false}
                     updateParams={x => this.props.setQueryParams(x)}
                 />
 

--- a/galaxyui/src/app/react/components/param-filter.tsx
+++ b/galaxyui/src/app/react/components/param-filter.tsx
@@ -21,6 +21,9 @@ interface IProps {
     params: Object;
     count: number;
     orderParam?: string;
+    // This gives you the choice of whether or not to use the patternfly toolbar
+    // wrapper, which adds a lot of annoying styling
+    usePFToolbar?: boolean;
     updateParams: (params) => void;
 }
 
@@ -32,6 +35,7 @@ interface IState {
 export class ParamFilter extends React.Component<IProps, IState> {
     static defaultProps = {
         orderParam: 'order_by',
+        usePFToolbar: true,
     };
     constructor(props) {
         super(props);
@@ -144,7 +148,13 @@ export class ParamFilter extends React.Component<IProps, IState> {
     }
 
     render() {
-        const { count, filterFields, sortFields, params } = this.props;
+        const {
+            count,
+            filterFields,
+            sortFields,
+            params,
+            usePFToolbar,
+        } = this.props;
 
         // Derive the child configurations from the params object
         const appliedFilters = this.paramsToAppliedFilters(params);
@@ -166,32 +176,48 @@ export class ParamFilter extends React.Component<IProps, IState> {
             } as SortConfig;
         }
 
-        return (
-            <Toolbar>
-                {filterConfig ? (
-                    <FilterPF
-                        filterConfig={filterConfig}
-                        addFilter={(v, f) => this.addFilter(v, f)}
-                        updateParent={state => this.updateFromFilter(state)}
-                        value={this.state.filterValue}
-                        field={this.state.selectedFilter}
-                    />
-                ) : null}
+        const filterCom = filterConfig ? (
+            <FilterPF
+                filterConfig={filterConfig}
+                addFilter={(v, f) => this.addFilter(v, f)}
+                updateParent={state => this.updateFromFilter(state)}
+                value={this.state.filterValue}
+                field={this.state.selectedFilter}
+            />
+        ) : null;
 
-                {sortConfig ? (
-                    <SortPF
-                        config={sortConfig}
-                        onSortChange={x => this.onSortChange(x)}
-                    />
-                ) : null}
+        const sortCom = sortConfig ? (
+            <SortPF
+                config={sortConfig}
+                onSortChange={x => this.onSortChange(x)}
+            />
+        ) : null;
 
-                <ToolBarResultsPF
-                    numberOfResults={count}
-                    appliedFilters={appliedFilters}
-                    removeFilter={i => this.removeFilter(i)}
-                    removeAllFilters={() => this.removeAllFilters()}
-                />
-            </Toolbar>
+        const resultCom = (
+            <ToolBarResultsPF
+                numberOfResults={count}
+                appliedFilters={appliedFilters}
+                removeFilter={i => this.removeFilter(i)}
+                removeAllFilters={() => this.removeAllFilters()}
+            />
         );
+
+        if (usePFToolbar) {
+            return (
+                <Toolbar>
+                    {filterCom}
+                    {sortCom}
+                    {resultCom}
+                </Toolbar>
+            );
+        } else {
+            return (
+                <div>
+                    {filterCom}
+                    {sortCom}
+                    {resultCom}
+                </div>
+            );
+        }
     }
 }

--- a/galaxyui/src/app/react/components/param-filter.tsx
+++ b/galaxyui/src/app/react/components/param-filter.tsx
@@ -1,0 +1,186 @@
+import * as React from 'react';
+import { Toolbar } from 'patternfly-react';
+import { FilterPF, ToolBarResultsPF } from './patternfly-filter';
+import { SortPF } from './patternfly-sort';
+import { ParamHelper } from '../lib/param-helper';
+
+import { SortConfig } from '../shared-types/pf-toolbar';
+
+import {
+    FilterConfig,
+    AppliedFilter,
+    FilterOption,
+    SortFieldOption,
+} from '../shared-types/pf-toolbar';
+
+import { cloneDeep } from 'lodash';
+
+interface IProps {
+    filterFields?: FilterOption[];
+    sortFields?: SortFieldOption[];
+    params: Object;
+    count: number;
+    orderParam: string;
+    updateParams: (params) => void;
+}
+
+interface IState {
+    selectedFilter: FilterOption;
+    filterValue: string;
+}
+
+export class ToolBarPF extends React.Component<IProps, IState> {
+    static defaultProps;
+    constructor(props) {
+        super(props);
+        this.state = {
+            // filterConfig: this.props.toolbarConfig.filterConfig,
+            selectedFilter: this.props.filterFields[0],
+            filterValue: '',
+        };
+    }
+
+    private addFilter(value: string, field: FilterOption) {
+        // Check to see if an instance of the filter has already been added
+        if (ParamHelper.paramExists(this.props.params, field.id, value)) {
+            return;
+        }
+
+        if (field.type === 'typeahead') {
+            this.props.updateParams(
+                ParamHelper.appendParam(this.props.params, field.id, value),
+            );
+        } else {
+            this.props.updateParams(
+                ParamHelper.setParam(this.props.params, field.id, value),
+            );
+        }
+    }
+
+    private removeFilter(filter: AppliedFilter) {
+        this.props.updateParams(
+            ParamHelper.deleteParam(
+                this.props.params,
+                filter.field.id,
+                filter.value,
+            ),
+        );
+    }
+
+    private removeAllFilters() {
+        const params = cloneDeep(this.props.params);
+        for (const field of this.props.filterFields) {
+            delete params[field.id];
+        }
+
+        this.props.updateParams(params);
+    }
+
+    private updateFromFilter(state) {
+        this.setState(state);
+    }
+
+    private paramsToAppliedFilters(params) {
+        const appliedFilters = [] as AppliedFilter[];
+
+        for (const field of this.props.filterFields) {
+            const val = params[field.id];
+            if (val) {
+                if (Array.isArray(val)) {
+                    for (const v of val) {
+                        appliedFilters.push({
+                            field: field,
+                            value: v,
+                        });
+                    }
+                } else {
+                    appliedFilters.push({
+                        field: field,
+                        value: val,
+                    });
+                }
+            }
+        }
+
+        return appliedFilters;
+    }
+
+    private getIsAscending(params) {
+        // if sort starts with '-', isAscending = false
+        const sort = params[this.props.orderParam];
+        if (sort) {
+            return !sort.startsWith('-');
+        } else {
+            return true;
+        }
+    }
+
+    private onSortChange($event) {
+        let sortVal = '';
+        if ($event.isAscending) {
+            sortVal = $event.field.id;
+        } else {
+            sortVal = '-' + $event.field.id;
+        }
+
+        this.props.updateParams(
+            ParamHelper.setParam(
+                this.props.params,
+                this.props.orderParam,
+                sortVal,
+            ),
+        );
+    }
+
+    render() {
+        const { count, filterFields, sortFields, params } = this.props;
+
+        // Derive the child configurations from the params object
+        const appliedFilters = this.paramsToAppliedFilters(params);
+
+        let filterConfig = null;
+        if (filterFields) {
+            filterConfig = {
+                resultsCount: count,
+                fields: filterFields,
+                appliedFilters: appliedFilters,
+            } as FilterConfig;
+        }
+
+        let sortConfig = null;
+        if (sortFields) {
+            sortConfig = {
+                fields: sortFields,
+                isAscending: this.getIsAscending(params),
+            } as SortConfig;
+        }
+
+        return (
+            <Toolbar>
+                {filterConfig ? (
+                    <FilterPF
+                        filterConfig={filterConfig}
+                        addFilter={(v, f) => this.addFilter(v, f)}
+                        updateParent={state => this.updateFromFilter(state)}
+                        value={this.state.filterValue}
+                        field={this.state.selectedFilter}
+                    />
+                ) : null}
+
+                {sortConfig ? (
+                    <SortPF
+                        config={sortConfig}
+                        onSortChange={x => this.onSortChange(x)}
+                    />
+                ) : null}
+
+                <ToolBarResultsPF
+                    numberOfResults={count}
+                    appliedFilters={appliedFilters}
+                    removeFilter={i => this.removeFilter(i)}
+                    removeAllFilters={() => this.removeAllFilters()}
+                />
+            </Toolbar>
+        );
+    }
+}

--- a/galaxyui/src/app/react/components/param-filter.tsx
+++ b/galaxyui/src/app/react/components/param-filter.tsx
@@ -20,7 +20,7 @@ interface IProps {
     sortFields?: SortFieldOption[];
     params: Object;
     count: number;
-    orderParam: string;
+    orderParam?: string;
     updateParams: (params) => void;
 }
 
@@ -29,8 +29,10 @@ interface IState {
     filterValue: string;
 }
 
-export class ToolBarPF extends React.Component<IProps, IState> {
-    static defaultProps;
+export class ParamFilter extends React.Component<IProps, IState> {
+    static defaultProps = {
+        orderParam: 'order_by',
+    };
     constructor(props) {
         super(props);
         this.state = {
@@ -58,13 +60,20 @@ export class ToolBarPF extends React.Component<IProps, IState> {
     }
 
     private removeFilter(filter: AppliedFilter) {
-        this.props.updateParams(
-            ParamHelper.deleteParam(
-                this.props.params,
-                filter.field.id,
-                filter.value,
-            ),
-        );
+        let newValue = this.state.filterValue;
+        if (filter.field.id === this.state.selectedFilter.id) {
+            newValue = '';
+        }
+
+        this.setState({ filterValue: newValue }, () => {
+            this.props.updateParams(
+                ParamHelper.deleteParam(
+                    this.props.params,
+                    filter.field.id,
+                    filter.value,
+                ),
+            );
+        });
     }
 
     private removeAllFilters() {
@@ -73,7 +82,9 @@ export class ToolBarPF extends React.Component<IProps, IState> {
             delete params[field.id];
         }
 
-        this.props.updateParams(params);
+        this.setState({ filterValue: '' }, () => {
+            this.props.updateParams(params);
+        });
     }
 
     private updateFromFilter(state) {

--- a/galaxyui/src/app/react/components/param-paginator.tsx
+++ b/galaxyui/src/app/react/components/param-paginator.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { ParamHelper } from '../lib/param-helper';
+import { Paginator } from 'patternfly-react';
+
+interface IProps {
+    params: Object;
+    count: number;
+    pageNumberParam?: string;
+    pageSizeParam?: string;
+
+    updateParams: (params) => void;
+}
+
+export class ParamPaginator extends React.Component<IProps, {}> {
+    static defaultProps = {
+        pageNumberParam: 'page',
+        pageSizeParam: 'page_size',
+    };
+
+    render() {
+        const { params, count, pageNumberParam, pageSizeParam } = this.props;
+        const page = params[pageNumberParam] || 1;
+        const perPage = params[pageSizeParam] || 10;
+        return (
+            <Paginator
+                viewType={'list'}
+                pagination={{
+                    page: page,
+                    perPage: perPage,
+                    perPageOptions: [10, 20, 40, 80, 100],
+                }}
+                itemCount={count}
+                onPageSet={i => this.setPageNumber(i)}
+                onPerPageSelect={i => this.setPageSize(i)}
+            />
+        );
+    }
+
+    private setPageSize(size) {
+        let params = ParamHelper.setParam(
+            this.props.params,
+            this.props.pageSizeParam,
+            size,
+        );
+
+        params = ParamHelper.setParam(params, this.props.pageNumberParam, 1);
+
+        this.props.updateParams(params);
+    }
+
+    private setPageNumber(pageNum) {
+        this.props.updateParams(
+            ParamHelper.setParam(
+                this.props.params,
+                this.props.pageNumberParam,
+                pageNum,
+            ),
+        );
+    }
+}

--- a/galaxyui/src/app/react/components/patternfly-filter.tsx
+++ b/galaxyui/src/app/react/components/patternfly-filter.tsx
@@ -110,7 +110,11 @@ export const ToolBarResultsPF: React.FunctionComponent<
                         <Filter.Item
                             key={index}
                             filterData={{ index: index }}
-                            onRemove={i => props.removeFilter(i)}
+                            onRemove={i =>
+                                props.removeFilter(
+                                    props.appliedFilters[i.index],
+                                )
+                            }
                         >
                             {item.field.title}: {item.value}
                         </Filter.Item>

--- a/galaxyui/src/app/react/components/patternfly-toolbar.tsx
+++ b/galaxyui/src/app/react/components/patternfly-toolbar.tsx
@@ -87,16 +87,19 @@ export class ToolBarPF extends React.Component<IProps, IState> {
         );
     }
 
-    removeFilter(index) {
+    removeFilter(removed) {
         const newConfig = cloneDeep(this.state.filterConfig);
-        const removed = newConfig.appliedFilters[index.index];
 
         let newValue = this.state.filterValue;
         if (removed.field.id === this.state.selectedFilter.id) {
             newValue = '';
         }
 
-        newConfig.appliedFilters.splice(index.index, 1);
+        const index = this.state.filterConfig.appliedFilters.findIndex(
+            x => x.field.id === removed.field.id && x.value === removed.value,
+        );
+
+        newConfig.appliedFilters.splice(index, 1);
 
         this.setState({ filterConfig: newConfig, filterValue: newValue }, () =>
             this.props.onFilterChange({

--- a/galaxyui/src/app/react/containers/my-imports.tsx
+++ b/galaxyui/src/app/react/containers/my-imports.tsx
@@ -21,6 +21,8 @@ import { ImportListComponent } from '../components/my-imports/import-list';
 import { PageHeader } from '../components/page-header';
 import { ImportConsoleComponent } from '../components/my-imports/import-console';
 
+import { ParamHelper } from '../lib/param-helper';
+
 interface IProps {
     injector: Injector;
     namespaces: Namespace[];
@@ -139,15 +141,10 @@ export class MyImportsPage extends React.Component<IProps, IState> {
             const params = newState.queryParams || this.state.queryParams;
             const ns = newState.selectedNS || this.state.selectedNS;
 
-            let paramString = '';
-            for (const key of Object.keys(params)) {
-                paramString += key + '=' + params[key] + '&';
-            }
-
-            // Remove trailing '&'
-            paramString = paramString.substring(0, paramString.length - 1);
-
-            this.location.replaceState(`my-imports/${ns.id}`, paramString);
+            this.location.replaceState(
+                `my-imports/${ns.id}`,
+                ParamHelper.getQueryString(params),
+            );
         }
     }
 

--- a/galaxyui/src/app/react/lib/param-helper.ts
+++ b/galaxyui/src/app/react/lib/param-helper.ts
@@ -1,0 +1,49 @@
+import { cloneDeep } from 'lodash';
+
+export class ParamHelper {
+    // Helper class for managing param object.
+    // Param object is just a dictionary of lists where the keys map to
+    // parameter names that contain a list of values for the given parameter
+    static setParam(p, key, value) {
+        const params = cloneDeep(p);
+        params[key] = [value];
+
+        return params;
+    }
+
+    static appendParam(p, key, value) {
+        const params = cloneDeep(p);
+        if (params[key]) {
+            params[key].push(value);
+        } else {
+            params[key] = [value];
+        }
+
+        return params;
+    }
+
+    static deleteParam(p, key, value?) {
+        const params = cloneDeep(p);
+        if (value && params[key].length > 1) {
+            const i = params[key].indexOf(value);
+            if (i !== -1) {
+                params[key].splice(i, 1);
+            }
+        } else {
+            delete params[key];
+        }
+
+        return params;
+    }
+
+    static paramExists(params, key, value) {
+        if (params[key]) {
+            const i = params[key].indexOf(value);
+            return i !== -1;
+        } else {
+            return false;
+        }
+    }
+
+    static getQueryString(params) {}
+}

--- a/galaxyui/src/app/react/lib/param-helper.ts
+++ b/galaxyui/src/app/react/lib/param-helper.ts
@@ -3,10 +3,10 @@ import { cloneDeep } from 'lodash';
 export class ParamHelper {
     // Helper class for managing param object.
     // Param object is just a dictionary of lists where the keys map to
-    // parameter names that contain a list of values for the given parameter
+    // parameter names that contain a value or list of values
     static setParam(p, key, value) {
         const params = cloneDeep(p);
-        params[key] = [value];
+        params[key] = value;
 
         return params;
     }
@@ -14,9 +14,13 @@ export class ParamHelper {
     static appendParam(p, key, value) {
         const params = cloneDeep(p);
         if (params[key]) {
-            params[key].push(value);
+            if (Array.isArray(params[key])) {
+                params[key].push(value);
+            } else {
+                params[key] = [params[key], value];
+            }
         } else {
-            params[key] = [value];
+            params[key] = value;
         }
 
         return params;
@@ -24,7 +28,7 @@ export class ParamHelper {
 
     static deleteParam(p, key, value?) {
         const params = cloneDeep(p);
-        if (value && params[key].length > 1) {
+        if (value && Array.isArray(params[key]) && params[key].length > 1) {
             const i = params[key].indexOf(value);
             if (i !== -1) {
                 params[key].splice(i, 1);

--- a/galaxyui/src/app/react/lib/param-helper.ts
+++ b/galaxyui/src/app/react/lib/param-helper.ts
@@ -49,5 +49,20 @@ export class ParamHelper {
         }
     }
 
-    static getQueryString(params) {}
+    static getQueryString(params) {
+        let paramString = '';
+        for (const key of Object.keys(params)) {
+            if (Array.isArray(params[key])) {
+                for (const val of params[key]) {
+                    paramString += key + '=' + val + '&';
+                }
+            } else {
+                paramString += key + '=' + params[key] + '&';
+            }
+        }
+
+        // Remove trailing '&'
+        paramString = paramString.substring(0, paramString.length - 1);
+        return paramString;
+    }
 }

--- a/galaxyui/src/app/react/shared-types/pf-toolbar.ts
+++ b/galaxyui/src/app/react/shared-types/pf-toolbar.ts
@@ -25,6 +25,7 @@ export class AppliedFilter {
 // Configuration for sort widget on patternfly toolbar
 export class SortConfig {
     fields: SortFieldOption[];
+    // isAscending -> true = '', false ='-'
     isAscending: boolean;
 }
 


### PR DESCRIPTION
Added `ParamFilter` and `ParamPaginator` react component which are a light wrapper on top of the standard patternfly toolbar that derives their state from a `params` object containing the query parameters for a page.

A common design pattern within galaxy is to have a series of patternfly widgets such as patternfly filters and patternfly pagination bars that are directly hooked up the a page's parameters such that:
- On page load, the query parameters define the state of the page's widgets
- On widget change the page's query params are updated in the browser window and used to query the API with the new parameters.

This component should allow us to predictably map query parameters to common UI elements without any extra code to translate between the two as we've had to do in the past.

This also adds a `ParamHelper` object with several helper functions that can be used to predictably manage query parameters across all our pages.