### PR TITLE
add link back to Galaxy from docs

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/layout.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/layout.html
@@ -130,14 +130,11 @@
         </ul>
     </div>
 
-  <a class="DocSite-nav" href="/docs" style="padding-bottom: 30px;">
+  <a class="DocSite-nav" href="/" style="padding-bottom: 30px;">
 
     <img class="DocSiteNav-logo"
       src="{{ pathto('_static/', 1) }}images/galaxy-logo-03.svg"
       alt="Ansible Logo">
-    <div class="DocSiteNav-title">
-      Documentation
-    </div>
   </a>
 
 
@@ -154,7 +151,7 @@
         <a class="DocSiteProduct-header DocSiteProduct-header--core" href="/docs/">
             <div class="DocSiteProduct-productName">
                 <div class="DocSiteProduct-logoText">
-                    Ansible Galaxy
+                    Ansible Galaxy Documentation
                     <!--div class="DocSiteProduct-CurrentVersion" align="right">
                       devel
                   </div-->


### PR DESCRIPTION
PR #1374 removed the link that allows a user to go from Galaxy docs back to the Galaxy itself. This PR:

- removes 'documentation' from next to the galaxy logo and places in within the teal Galaxy documentation navigation window.
- Sets the url  on the Galaxy logo to go back to galaxy vs docs.  

BEFORE:

![image](https://user-images.githubusercontent.com/30267855/59223347-b0901300-8b99-11e9-8dbd-f0c4cf1746bf.png)


AFTER:
![image](https://user-images.githubusercontent.com/30267855/59223048-ff897880-8b98-11e9-85e2-aaff75ea891d.png)

Note that line 154 keeps the documentation (docs) link within the teal navigation window so the original issue is still fixed with this patch.
