### PR TITLE
Fix collection detail breaking when no description is set. (#1906)

### DIFF
--- a/galaxyui/src/app/content-detail/content-header/content-header.component.ts
+++ b/galaxyui/src/app/content-detail/content-header/content-header.component.ts
@@ -137,7 +137,8 @@ export class ContentHeaderComponent implements OnInit {
             iconClass: 'pficon-repository',
             tooltip: 'Collection',
             name: this.collection.name,
-            description: this.collection.latest_version.metadata.description,
+            description:
+                this.collection.latest_version.metadata.description || '',
             downloadCount: this.collection.download_count,
             formatType: 'Collection',
             deprecated: this.collection.deprecated,


### PR DESCRIPTION
(cherry picked from commit 65f6692c7c0a546c7c08404a5f0855294a4153bc)

Backport #1906 