### PR TITLE
Fix lookup of duplicate repo namespaces on combined view

### DIFF
--- a/galaxy/api/internal/views/combined.py
+++ b/galaxy/api/internal/views/combined.py
@@ -163,8 +163,15 @@ class CombinedDetail(base.APIView):
                 provider_namespace__namespace__name__iexact=namespace,
                 name__iexact=name
             )
-            namespace_obj = models.Namespace.objects.get(
-                name__iexact=namespace)
+
+            # NOTE: in legacy data setup, there may be mutiple namespaces with
+            # the same name under different case, this chooses the lower case
+            namespace_obj = None
+            namespace_objects = models.Namespace.objects.filter(
+                name__iexact=namespace).order_by('name')
+            if namespace_objects.exists():
+                namespace_obj = namespace_objects[0]
+
             content = models.Content.objects.filter(
                 repository__name__iexact=name,
                 repository__provider_namespace__namespace__name__iexact=namespace # noqa


### PR DESCRIPTION
Corrects server error `MultipleObjectsReturned at /api/internal/ui/repo-or-collection-detail/` when there are multiple namespace names under different cases:
`/api/internal/ui/repo-or-collection-detail/?namespace=[namespace_name]&name=[repo_role_name]`

Fixes: #1920 