### PR TITLE
Added support for Github Enterprise instances

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ Christopher Chase <cchase@redhat.com>
 David Newswanger <dnewswan@redhat.com>
 David Zager <dzager@redhat.com>
 Dostonbek <toirovd@berea.edu>
+Egor Margineanu <egor.margineanu@gmail.com>
 Ivan <iremizov@gmail.com>
 Ivan Remizov <iremizov@gmail.com>
 James Cammarata <jimi@sngx.net>

--- a/galaxy/api/githubapi.py
+++ b/galaxy/api/githubapi.py
@@ -59,7 +59,8 @@ class GithubAPI(object):
                 "User does not have a GitHub OAuth token"
             )
         try:
-            client = Github(base_url=settings.GITHUB_SERVER, login_or_token=gh_token.token)
+            client = Github(base_url=settings.GITHUB_SERVER,
+                            login_or_token=gh_token.token)
         except GithubException as exc:
             raise Exception("Failed to connect to the GitHub API {0} - {1}"
                             .format(exc.data, exc.status))

--- a/galaxy/api/githubapi.py
+++ b/galaxy/api/githubapi.py
@@ -23,6 +23,7 @@ from github import Github
 from github.GithubException import GithubException
 
 from allauth.socialaccount.models import SocialToken
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from galaxy.main.models import Provider
 
@@ -58,7 +59,7 @@ class GithubAPI(object):
                 "User does not have a GitHub OAuth token"
             )
         try:
-            client = Github(gh_token.token)
+            client = Github(base_url=settings.GITHUB_SERVER, login_or_token=gh_token.token)
         except GithubException as exc:
             raise Exception("Failed to connect to the GitHub API {0} - {1}"
                             .format(exc.data, exc.status))

--- a/galaxy/api/githubapi.py
+++ b/galaxy/api/githubapi.py
@@ -23,8 +23,8 @@ from github import Github
 from github.GithubException import GithubException
 
 from allauth.socialaccount.models import SocialToken
-from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+from galaxy.common.github import get_github_api_url
 from galaxy.main.models import Provider
 
 
@@ -59,7 +59,7 @@ class GithubAPI(object):
                 "User does not have a GitHub OAuth token"
             )
         try:
-            client = Github(base_url=settings.GITHUB_SERVER,
+            client = Github(base_url=get_github_api_url(),
                             login_or_token=gh_token.token)
         except GithubException as exc:
             raise Exception("Failed to connect to the GitHub API {0} - {1}"

--- a/galaxy/api/serializers/repository.py
+++ b/galaxy/api/serializers/repository.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
+from django.conf.settings import SOCIALACCOUNT_PROVIDERS as providers
 from django.urls import reverse
 from rest_framework import serializers as drf_serializers
 
@@ -166,7 +167,7 @@ class RepositorySerializer(serializers.BaseSerializer):
     def get_external_url(self, instance):
         server = ''
         if instance.provider_namespace.provider.name.lower() == 'github':
-            server = 'https://github.com'
+            server = ('https://github.com', providers.github.GITHUB_URL)['GITHUB_URL' in providers.github]
         return '{0}/{1}/{2}'.format(
             server,
             instance.provider_namespace.name,

--- a/galaxy/api/serializers/repository.py
+++ b/galaxy/api/serializers/repository.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-from django.conf.settings import SOCIALACCOUNT_PROVIDERS as providers
+from django.conf import settings
 from django.urls import reverse
 from rest_framework import serializers as drf_serializers
 
@@ -167,6 +167,7 @@ class RepositorySerializer(serializers.BaseSerializer):
     def get_external_url(self, instance):
         server = ''
         if instance.provider_namespace.provider.name.lower() == 'github':
+            providers = settings.SOCIALACCOUNT_PROVIDERS
             server = (
                 'https://github.com',
                 providers.github.GITHUB_URL

--- a/galaxy/api/serializers/repository.py
+++ b/galaxy/api/serializers/repository.py
@@ -167,7 +167,10 @@ class RepositorySerializer(serializers.BaseSerializer):
     def get_external_url(self, instance):
         server = ''
         if instance.provider_namespace.provider.name.lower() == 'github':
-            server = ('https://github.com', providers.github.GITHUB_URL)['GITHUB_URL' in providers.github]
+            server = (
+                'https://github.com',
+                providers.github.GITHUB_URL
+            )['GITHUB_URL' in providers.github]
         return '{0}/{1}/{2}'.format(
             server,
             instance.provider_namespace.name,

--- a/galaxy/api/serializers/repository.py
+++ b/galaxy/api/serializers/repository.py
@@ -167,11 +167,15 @@ class RepositorySerializer(serializers.BaseSerializer):
     def get_external_url(self, instance):
         server = ''
         if instance.provider_namespace.provider.name.lower() == 'github':
-            providers = settings.SOCIALACCOUNT_PROVIDERS
-            server = (
-                'https://github.com',
-                providers.github.GITHUB_URL
-            )['GITHUB_URL' in providers.github]
+            if 'github' in settings.SOCIALACCOUNT_PROVIDERS:
+                if 'GITHUB_URL' in settings.SOCIALACCOUNT_PROVIDERS['github']:
+                    server = settings \
+                        .SOCIALACCOUNT_PROVIDERS['github'] \
+                        .GITHUB_URL
+                else:
+                    server = 'https://github.com'
+            else:
+                server = 'https://github.com'
         return '{0}/{1}/{2}'.format(
             server,
             instance.provider_namespace.name,

--- a/galaxy/api/serializers/repository.py
+++ b/galaxy/api/serializers/repository.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-from django.conf import settings
 from django.urls import reverse
 from rest_framework import serializers as drf_serializers
 
+from galaxy.common.github import get_github_web_url
 from galaxy.main.models import Repository
 from . import serializers
 
@@ -165,19 +165,8 @@ class RepositorySerializer(serializers.BaseSerializer):
         }
 
     def get_external_url(self, instance):
-        server = ''
-        if instance.provider_namespace.provider.name.lower() == 'github':
-            if 'github' in settings.SOCIALACCOUNT_PROVIDERS:
-                if 'GITHUB_URL' in settings.SOCIALACCOUNT_PROVIDERS['github']:
-                    server = settings \
-                        .SOCIALACCOUNT_PROVIDERS['github'] \
-                        .GITHUB_URL
-                else:
-                    server = 'https://github.com'
-            else:
-                server = 'https://github.com'
         return '{0}/{1}/{2}'.format(
-            server,
+            get_github_web_url(),
             instance.provider_namespace.name,
             instance.original_name)
 

--- a/galaxy/api/serializers/roles.py
+++ b/galaxy/api/serializers/roles.py
@@ -33,6 +33,7 @@ class BaseRoleSerializer(BaseSerializer):
     REPOSITORY_MOVED_FIELDS = (
         'github_user',
         'github_repo',
+        'github_server',
         ('github_branch', 'import_branch'),
         'stargazers_count',
         'forks_count',

--- a/galaxy/api/views/token.py
+++ b/galaxy/api/views/token.py
@@ -78,6 +78,12 @@ class TokenView(base_views.APIView):
         try:
             git_status = requests.get(get_github_api_url())
             git_status.raise_for_status()
+        except requests.exceptions.RequestException as err:
+            if err.response.status_code == 101:
+
+            raise ValidationError({
+                'detail': "Error accessing GitHub API. Please try again later."
+            })
         except Exception:
             raise ValidationError({
                 'detail': "Error accessing GitHub API. Please try again later."

--- a/galaxy/api/views/token.py
+++ b/galaxy/api/views/token.py
@@ -78,12 +78,6 @@ class TokenView(base_views.APIView):
         try:
             git_status = requests.get(get_github_api_url())
             git_status.raise_for_status()
-        except requests.exceptions.RequestException as err:
-            if err.response.status_code == 101:
-
-            raise ValidationError({
-                'detail': "Error accessing GitHub API. Please try again later."
-            })
         except Exception:
             raise ValidationError({
                 'detail': "Error accessing GitHub API. Please try again later."

--- a/galaxy/api/views/token.py
+++ b/galaxy/api/views/token.py
@@ -2,7 +2,6 @@ import logging
 import requests
 
 from allauth.socialaccount.models import SocialAccount
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 
@@ -14,6 +13,7 @@ from rest_framework.authentication import SessionAuthentication
 
 from galaxy.api.views import base_views
 from galaxy.api.serializers import TokenSerializer
+from galaxy.common.github import get_github_api_url
 
 __all__ = [
     'TokenView',
@@ -76,7 +76,7 @@ class TokenView(base_views.APIView):
             raise ValidationError({'detail': "Invalid request."})
 
         try:
-            git_status = requests.get(settings.GITHUB_SERVER)
+            git_status = requests.get(get_github_api_url())
             git_status.raise_for_status()
         except Exception:
             raise ValidationError({
@@ -86,7 +86,7 @@ class TokenView(base_views.APIView):
         try:
             header = dict(Authorization='token ' + github_token)
             gh_user = requests.get(
-                settings.GITHUB_SERVER + '/user', headers=header
+                get_github_api_url() + '/user', headers=header
             )
             gh_user.raise_for_status()
             gh_user = gh_user.json()

--- a/galaxy/common/github.py
+++ b/galaxy/common/github.py
@@ -1,0 +1,36 @@
+# (c) 2012-2018, Ansible by Red Hat
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+from allauth.socialaccount import app_settings
+from allauth.socialaccount.providers.github.provider import GitHubProvider
+
+provider_id = GitHubProvider.id
+settings = app_settings.PROVIDERS.get(provider_id, {})
+
+
+def get_github_web_url():
+    if 'GITHUB_URL' in settings:
+        return settings.get('GITHUB_URL').rstrip('/')
+    else:
+        return 'https://github.com'
+
+
+def get_github_api_url():
+    if 'GITHUB_URL' in settings:
+        return '{0}/api/v3'.format(get_github_web_url())
+    else:
+        return 'https://api.github.com'

--- a/galaxy/main/models/repository.py
+++ b/galaxy/main/models/repository.py
@@ -108,7 +108,10 @@ class Repository(BaseModel):
     @property
     def clone_url(self):
         return "{server}/{user}/{repo}.git".format(
-            server=('https://github.com', providers.github.GITHUB_URL)['GITHUB_URL' in providers.github],
+            server=(
+                'https://github.com',
+                providers.github.GITHUB_URL
+            )['GITHUB_URL' in providers.github],
             user=self.provider_namespace.name,
             repo=self.original_name
         )
@@ -123,7 +126,8 @@ class Repository(BaseModel):
 
     @property
     def github_server(self):
-        return ('https://github.com', providers.github.GITHUB_URL)['GITHUB_URL' in providers.github]
+        return ('https://github.com',
+                providers.github.GITHUB_URL)['GITHUB_URL' in providers.github]
 
     @property
     def content_counts(self):

--- a/galaxy/main/models/repository.py
+++ b/galaxy/main/models/repository.py
@@ -1,6 +1,7 @@
 import operator
 
 from django.conf import settings
+from django.conf.settings import SOCIALACCOUNT_PROVIDERS as providers
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.db import models
 from django.urls import reverse
@@ -106,7 +107,8 @@ class Repository(BaseModel):
 
     @property
     def clone_url(self):
-        return "https://github.com/{user}/{repo}.git".format(
+        return "{server}/{user}/{repo}.git".format(
+            server=('https://github.com', providers.github.GITHUB_URL)['GITHUB_URL' in providers.github],
             user=self.provider_namespace.name,
             repo=self.original_name
         )
@@ -118,6 +120,10 @@ class Repository(BaseModel):
     @property
     def github_repo(self):
         return self.original_name
+
+    @property
+    def github_server(self):
+        return ('https://github.com', providers.github.GITHUB_URL)['GITHUB_URL' in providers.github]
 
     @property
     def content_counts(self):

--- a/galaxy/main/models/repository.py
+++ b/galaxy/main/models/repository.py
@@ -1,7 +1,6 @@
 import operator
 
 from django.conf import settings
-from django.conf.settings import SOCIALACCOUNT_PROVIDERS as providers
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.db import models
 from django.urls import reverse
@@ -107,6 +106,7 @@ class Repository(BaseModel):
 
     @property
     def clone_url(self):
+        providers = settings.SOCIALACCOUNT_PROVIDERS
         return "{server}/{user}/{repo}.git".format(
             server=(
                 'https://github.com',
@@ -126,6 +126,7 @@ class Repository(BaseModel):
 
     @property
     def github_server(self):
+        providers = settings.SOCIALACCOUNT_PROVIDERS
         return ('https://github.com',
                 providers.github.GITHUB_URL)['GITHUB_URL' in providers.github]
 

--- a/galaxy/main/models/repository.py
+++ b/galaxy/main/models/repository.py
@@ -106,12 +106,18 @@ class Repository(BaseModel):
 
     @property
     def clone_url(self):
-        providers = settings.SOCIALACCOUNT_PROVIDERS
+        server = ''
+        if 'github' in settings.SOCIALACCOUNT_PROVIDERS:
+            if 'GITHUB_URL' in settings.SOCIALACCOUNT_PROVIDERS['github']:
+                server = settings \
+                    .SOCIALACCOUNT_PROVIDERS['github'] \
+                    .GITHUB_URL
+            else:
+                server = 'https://github.com'
+        else:
+            server = 'https://github.com'
         return "{server}/{user}/{repo}.git".format(
-            server=(
-                'https://github.com',
-                providers.github.GITHUB_URL
-            )['GITHUB_URL' in providers.github],
+            server=server,
             user=self.provider_namespace.name,
             repo=self.original_name
         )
@@ -126,9 +132,17 @@ class Repository(BaseModel):
 
     @property
     def github_server(self):
-        providers = settings.SOCIALACCOUNT_PROVIDERS
-        return ('https://github.com',
-                providers.github.GITHUB_URL)['GITHUB_URL' in providers.github]
+        server = ''
+        if 'github' in settings.SOCIALACCOUNT_PROVIDERS:
+            if 'GITHUB_URL' in settings.SOCIALACCOUNT_PROVIDERS['github']:
+                server = settings \
+                    .SOCIALACCOUNT_PROVIDERS['github'] \
+                    .GITHUB_URL
+            else:
+                server = 'https://github.com'
+        else:
+            server = 'https://github.com'
+        return server
 
     @property
     def content_counts(self):

--- a/galaxy/main/models/repository.py
+++ b/galaxy/main/models/repository.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.urls import reverse
 
 from galaxy import constants
+from galaxy.common.github import get_github_web_url
 from galaxy.main import fields
 
 from .base import BaseModel
@@ -106,18 +107,8 @@ class Repository(BaseModel):
 
     @property
     def clone_url(self):
-        server = ''
-        if 'github' in settings.SOCIALACCOUNT_PROVIDERS:
-            if 'GITHUB_URL' in settings.SOCIALACCOUNT_PROVIDERS['github']:
-                server = settings \
-                    .SOCIALACCOUNT_PROVIDERS['github'] \
-                    .GITHUB_URL
-            else:
-                server = 'https://github.com'
-        else:
-            server = 'https://github.com'
         return "{server}/{user}/{repo}.git".format(
-            server=server,
+            server=get_github_web_url(),
             user=self.provider_namespace.name,
             repo=self.original_name
         )
@@ -132,17 +123,7 @@ class Repository(BaseModel):
 
     @property
     def github_server(self):
-        server = ''
-        if 'github' in settings.SOCIALACCOUNT_PROVIDERS:
-            if 'GITHUB_URL' in settings.SOCIALACCOUNT_PROVIDERS['github']:
-                server = settings \
-                    .SOCIALACCOUNT_PROVIDERS['github'] \
-                    .GITHUB_URL
-            else:
-                server = 'https://github.com'
-        else:
-            server = 'https://github.com'
-        return server
+        return get_github_web_url()
 
     @property
     def content_counts(self):

--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -278,7 +278,8 @@ SOCIALACCOUNT_PROVIDERS = {
         'SCOPE': ['r_emailaddress']
     },
     'github': {
-        'SCOPE': ['user:email', 'read:org']
+        'SCOPE': ['user:email', 'read:org'],
+        'GITHUB_URL': 'https://github.ibm.com'
     },
 }
 

--- a/galaxy/settings/default.py
+++ b/galaxy/settings/default.py
@@ -278,8 +278,7 @@ SOCIALACCOUNT_PROVIDERS = {
         'SCOPE': ['r_emailaddress']
     },
     'github': {
-        'SCOPE': ['user:email', 'read:org'],
-        'GITHUB_URL': 'https://github.ibm.com'
+        'SCOPE': ['user:email', 'read:org']
     },
 }
 

--- a/galaxy/worker/tasks/repository.py
+++ b/galaxy/worker/tasks/repository.py
@@ -90,12 +90,14 @@ def _import_repository(import_task, logger):
     logger.info(' ')
 
     token = _get_social_token(import_task)
-    gh_api = github.Github(token)
+    gh_api = github.Github(base_url=settings.GITHUB_SERVER, login_or_token=token)
     gh_repo = gh_api.get_repo(repo_full_name)
 
     try:
         repo_info = i_repo.import_repository(
-            repository.clone_url,
+            gh_repo.clone_url.replace("https://", "https://{token}@".format(
+                token=token
+            )),
             branch=import_task.import_branch,
             temp_dir=settings.CONTENT_DOWNLOAD_DIR,
             logger=logger)
@@ -315,8 +317,8 @@ def _update_repo_info(repository, gh_repo, commit_info, repo_description):
     repository.commit = commit_info.sha
     repository.commit_message = commit_info.message[:255]
     repository.commit_url = \
-        'https://api.github.com/repos/{0}/git/commits/{1}'.format(
-            gh_repo.full_name, commit_info.sha)
+        '{0}/repos/{1}/git/commits/{2}'.format(
+            settings.GITHUB_SERVER, gh_repo.full_name, commit_info.sha)
     repository.commit_created = commit_info.committer_date
 
 

--- a/galaxy/worker/tasks/repository.py
+++ b/galaxy/worker/tasks/repository.py
@@ -90,7 +90,8 @@ def _import_repository(import_task, logger):
     logger.info(' ')
 
     token = _get_social_token(import_task)
-    gh_api = github.Github(base_url=settings.GITHUB_SERVER, login_or_token=token)
+    gh_api = github.Github(base_url=settings.GITHUB_SERVER,
+                           login_or_token=token)
     gh_repo = gh_api.get_repo(repo_full_name)
 
     try:

--- a/galaxy/worker/tasks/repository.py
+++ b/galaxy/worker/tasks/repository.py
@@ -27,6 +27,7 @@ from django.utils import timezone
 from allauth.socialaccount import models as auth_models
 
 from galaxy import constants
+from galaxy.common.github import get_github_api_url
 from galaxy.importer import repository as i_repo
 from galaxy.importer import exceptions as i_exc
 from galaxy.main import models
@@ -90,7 +91,7 @@ def _import_repository(import_task, logger):
     logger.info(' ')
 
     token = _get_social_token(import_task)
-    gh_api = github.Github(base_url=settings.GITHUB_SERVER,
+    gh_api = github.Github(base_url=get_github_api_url(),
                            login_or_token=token)
     gh_repo = gh_api.get_repo(repo_full_name)
 
@@ -319,7 +320,7 @@ def _update_repo_info(repository, gh_repo, commit_info, repo_description):
     repository.commit_message = commit_info.message[:255]
     repository.commit_url = \
         '{0}/repos/{1}/git/commits/{2}'.format(
-            settings.GITHUB_SERVER, gh_repo.full_name, commit_info.sha)
+            get_github_api_url(), gh_repo.full_name, commit_info.sha)
     repository.commit_created = commit_info.committer_date
 
 


### PR DESCRIPTION
With this pull request I'm proposing change which would add support for Github Enterprise instances.
Main set of changes focuses on removing hard-coded references to `github.com` and ensure correct address is return by API for `ansible-galaxy` CLI utility.

A patch for ansible/ansible will be submitted later to add support for GHE as well.

Signed-off-by: Egor Margineanu <egor.margineanu@gmail.com>