### PR TITLE
Add ApiV2RootApiView and reverse() to it in /api/ available_versions

### DIFF
--- a/galaxy/api/v2/urls.py
+++ b/galaxy/api/v2/urls.py
@@ -15,12 +15,13 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-from django.urls import path
+from django.urls import path, re_path as url
 
 from galaxy.api.v2 import views
 
 app_name = 'api'
 urlpatterns = [
+    url(r'^$', views.ApiV2RootView.as_view(), name='api_v2_root_view'),
     # Collection Imports URLs
     path('collection-imports/<int:pk>/',
          views.CollectionImportView.as_view(),

--- a/galaxy/api/v2/views/api.py
+++ b/galaxy/api/v2/views/api.py
@@ -15,28 +15,22 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
-from .collection import (  # noqa: F401
-    CollectionListView,
-    CollectionDetailView,
-)
-from .collection_import import (  # noqa: F401
-    CollectionImportView
-)
-from .collection_version import (  # noqa: F401
-    CollectionArtifactView,
-    VersionListView,
-    VersionDetailView,
-)
+from collections import OrderedDict
 
-from .api import (  # noqa: F401
-    ApiV2RootView,
-)
-__all__ = (
-    'ApiV2RootView',
-    'CollectionListView',
-    'CollectionDetailView',
-    'CollectionImportView',
-    'CollectionArtifactView',
-    'VersionListView',
-    'VersionDetailView',
-)
+from django.urls import reverse
+
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from galaxy.api.views import base_views
+
+
+class ApiV2RootView(base_views.APIView):
+    permission_classes = (AllowAny,)
+    view_name = 'Version 2'
+
+    def get(self, request, format=None):
+        # list top level resources
+        data = OrderedDict()
+        data['collections'] = reverse('api:v2:collection-list')
+
+        return Response(data)

--- a/galaxy/api/views/views.py
+++ b/galaxy/api/views/views.py
@@ -121,7 +121,7 @@ class ApiRootView(base_views.APIView):
             current_version='v1',
             available_versions=dict(
                 v1=current,
-                v2='/api/v2',
+                v2=reverse('api:v2:api_v2_root_view'),
             ),
             server_version=version.get_package_version('galaxy'),
             version_name=version.get_version_name(),


### PR DESCRIPTION
An extension to https://github.com/ansible/galaxy/pull/1996

This makes the 'v2':'/api/v2' link in GET /api clickable.