### PR TITLE
Use relative paths for 'available_versions' paths

### DIFF
--- a/galaxy/api/views/views.py
+++ b/galaxy/api/views/views.py
@@ -115,13 +115,12 @@ class ApiRootView(base_views.APIView):
 
     def get(self, request, format=None):
         # list supported API versions
-        current = reverse('api:api_v1_root_view', args=[])
         data = dict(
             description='GALAXY REST API',
             current_version='v1',
             available_versions=dict(
-                v1=current,
-                v2=reverse('api:v2:api_v2_root_view'),
+                v1="v1/",
+                v2="v2/",
             ),
             server_version=version.get_package_version('galaxy'),
             version_name=version.get_version_name(),


### PR DESCRIPTION
This is to allow the ApiRootView to be somewhere
other than /api.

Needed for ansible-galaxy compat with galaxy v1/v2 and automation hub v3.
(ah hub api root is /api/automation-hub/ not /api/)