### PR TITLE
Collection tag formatting enforcement to match namespace

### DIFF
--- a/galaxy/api/internal/serializers/search.py
+++ b/galaxy/api/internal/serializers/search.py
@@ -54,7 +54,6 @@ class SearchRequestSerializer(serializers.Serializer):
         default=None,
     )
     tags = SeparatedStringField(
-        child=fields.RegexField(regex=constants.TAG_REGEXP),
         default=None,
     )
     contributor_type = fields.ChoiceField(

--- a/galaxy/constants.py
+++ b/galaxy/constants.py
@@ -25,7 +25,7 @@ from pulpcore import constants as pulp_const
 MAX_TAGS_COUNT = 20
 MAX_UPLOAD_FILE_SIZE_BYTES = 2 * 1000 * 1000  # 2MB
 PROVIDER_GITHUB = 'GitHub'
-TAG_REGEXP = re.compile('^[a-z0-9]+$')
+ROLE_TAG_REGEXP = re.compile(r'^[a-z0-9]+$')
 NAME_REGEXP = re.compile(r'^(?!.*__)[a-z]+[0-9a-z_]*$')
 MATCH_LEADING_NUMBER_REGEXP = re.compile(r'^[0-9]')
 

--- a/galaxy/importer/loaders/role.py
+++ b/galaxy/importer/loaders/role.py
@@ -158,7 +158,7 @@ class RoleMetaParser(object):
     def _validate_tag(self, tag):
         if not isinstance(tag, str):
             return False
-        if not re.match(constants.TAG_REGEXP, tag):
+        if not re.match(constants.ROLE_TAG_REGEXP, tag):
             return False
         return True
 

--- a/galaxy/importer/models.py
+++ b/galaxy/importer/models.py
@@ -228,9 +228,7 @@ class BaseCollectionInfo(object):
     def _check_tags(self, attribute, value):
         """Check value against tag regular expression."""
         for tag in value:
-            # TODO update tag format once resolved
-            # https://github.com/ansible/galaxy/issues/1563
-            if not re.match(constants.TAG_REGEXP, tag):
+            if not re.match(constants.NAME_REGEXP, tag):
                 self.value_error(f"'tag' has invalid format: {tag}")
 
     def __attrs_post_init__(self):

--- a/galaxy/importer/tests/test_collection_info.py
+++ b/galaxy/importer/tests/test_collection_info.py
@@ -50,21 +50,24 @@ invalid_names = [
 
 valid_tags = [
     'deployment',
-    'fedora',
-    'fedora29'
-    '4ubuntu',
+    'fedora_29',
+    'fedora29',
     'alloneword',
-    '007',
-    '0x4e3'
+    'a007',
+    'good_tag',
+    'deploy_',
 ]
 
 invalid_tags = [
-    'bad_tag',
+    'bad__tag',
     'bad-tag',
     'bad tag',
     'bad.tag',
-    '_deploy',
+    '__deploy',
     'inv@lid/char',
+    '007',
+    '0x4e3',
+    '4ubuntu',
 ]
 
 valid_semver = [
@@ -155,11 +158,11 @@ def test_invalid_tags(base_col_info):
 
 
 def test_max_tags(galaxy_col_info):
-    galaxy_col_info['tags'] = [str(i) for i in range(90, 110)]
+    galaxy_col_info['tags'] = [f'a{i}' for i in range(90, 110)]
     res = GalaxyCollectionInfo(**galaxy_col_info)
-    assert [str(x) for x in range(90, 110)] == res.tags
+    assert [f'a{x}' for x in range(90, 110)] == res.tags
 
-    galaxy_col_info['tags'] = [str(i) for i in range(90, 111)]
+    galaxy_col_info['tags'] = [f'a{i}' for i in range(90, 111)]
     with pytest.raises(ValueError) as exc:
         GalaxyCollectionInfo(**galaxy_col_info)
     assert 'Expecting no more than ' in str(exc)


### PR DESCRIPTION
This PR updates importer validation to match [spec](https://docs.ansible.com/ansible/devel/dev_guide/collections_galaxy_meta.html#structure): collection `tags` in `galaxy.yml` now follow the same formatting rules as `namespace`. The changes are that the collection tag will now allow underscores and now disallow starting with a number.

This does not make any changes to role tags.

The `SearchRequestSerializer` has a tag field that is shared with collections and roles. This PR removes the pre-search regex format validation on the tag field, since the tags have different characteristics (role tags allow starting with number and disallow underscores). If we want to keep that validation, for the serializer we can create an `OR` compiled regex using the 2 patterns: `TAGS_GENERIC = re.compile('(' + ROLE_PATTERN + '|' + COLLECTION_PATTERN + ')')`

Closes #1976 