### PR TITLE
Revert "Use relative paths for 'available_versions' paths (#2009)"

### DIFF
--- a/galaxy/api/views/views.py
+++ b/galaxy/api/views/views.py
@@ -115,12 +115,13 @@ class ApiRootView(base_views.APIView):
 
     def get(self, request, format=None):
         # list supported API versions
+        current = reverse('api:api_v1_root_view', args=[])
         data = dict(
             description='GALAXY REST API',
             current_version='v1',
             available_versions=dict(
-                v1="v1/",
-                v2="v2/",
+                v1=current,
+                v2=reverse('api:v2:api_v2_root_view'),
             ),
             server_version=version.get_package_version('galaxy'),
             version_name=version.get_version_name(),


### PR DESCRIPTION
This reverts commit 6cadfadbe9c6d6299cf12ba0c4f6151b11fd8e82.

6cadfad was based on assumption that ansible-galaxy 2.9+ would
configure v2 galaxy servers with full path to api root view
same way as v3 servers.

ie, an ansible.cfg like:

[galaxy_server.galaxy]
url=https://galaxy.ansible.com/api/

But that is incorrect, and ansible-galaxy needs v2 galaxy
servers configured like:

[galaxy_server.galaxy]
url=https://galaxy.ansible.com/

Which means the 'available_versions' for 'v2' servers
like galaxy.ansible.com need to include '/api/v2'.
ie, the way it was before.

Fixes: ansible/ansible#63047
https://github.com/ansible/ansible/issues/63047