### PR TITLE
Revert "Revert "Use relative paths for 'available_versions' paths (#2009)" (#2050)"

### DIFF
--- a/galaxy/api/views/views.py
+++ b/galaxy/api/views/views.py
@@ -115,13 +115,12 @@ class ApiRootView(base_views.APIView):
 
     def get(self, request, format=None):
         # list supported API versions
-        current = reverse('api:api_v1_root_view', args=[])
         data = dict(
             description='GALAXY REST API',
             current_version='v1',
             available_versions=dict(
-                v1=current,
-                v2=reverse('api:v2:api_v2_root_view'),
+                v1="v1/",
+                v2="v2/",
             ),
             server_version=version.get_package_version('galaxy'),
             version_name=version.get_version_name(),


### PR DESCRIPTION
Go back to using relative paths for 'available_versions'
ala automation-hub.

This reverts commit ae8d4e177d842e459cdc02c25b92db0018fa5924

ae8d4e177d842e459cdc02c25b92db0018fa5924 is a revert of b0e572afc1797e4c3b2f7915f62005c154aa81d9. So this is a revert
of a revert.
 
[The revert of a revert is maybe a bit ridiculous and it might make more sense to just add a fresh commit with the change. I can do that if preferred.]
