### PR TITLE
Add support for creating namespaces via CLI

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -334,6 +334,18 @@ the creation process. You'll be prompted for the vital details as depicted below
 
 The Django admin site can be accessed at `http://localhost:8000/admin <http://localhost:8000/admin>`_.
 
+Create a namespace
+^^^^^^^^^^^^^^^^^^
+
+From the root of the project tree, run ``make dev/namespace`` to start
+the creation process. You'll see the details as depicted below:
+
+.. code-block:: console
+
+    $ make USERNAME=admin NAMESPACE=demo dev/createnamespace
+    Create namespace
+    Namespace created successfully
+
 Connect to GitHub
 -----------------
 

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,11 @@ docker/test-flake8:
 .PHONY: dev/build
 dev/build: build/docker-dev
 
+.PHONY: dev/createnamespace
+dev/createnamespace:
+	@echo "Create namespace"
+	@$(DOCKER_COMPOSE) exec -T galaxy $(GALAXY_VENV)/bin/python ./manage.py create_namespace $(NAMESPACE) $(USERNAME)
+
 .PHONY: dev/createsuperuser
 dev/createsuperuser:
 	@echo "Create Superuser"

--- a/galaxy/main/management/commands/create_namespace.py
+++ b/galaxy/main/management/commands/create_namespace.py
@@ -1,0 +1,30 @@
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management.base import BaseCommand
+from django.contrib.auth import get_user_model
+
+from galaxy.main.models import Namespace
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = ('For each repo, deletes all import_task_messages '
+            'except for messages in latest import_task.')
+
+    def add_arguments(self, parser):
+        parser.add_argument('namespace')
+        parser.add_argument('username')
+
+    def handle(self, *args, **kwargs):
+        namespace = kwargs.get('namespace')
+        username = kwargs.get('username')
+
+        try:
+            _user = User.objects.get(username=username)
+        except ObjectDoesNotExist:
+            raise Exception("User not found.")
+
+        _namespace = Namespace.objects.create(name=namespace)
+        _namespace.owners.set([_user])
+
+        print('Namespace created successfully')


### PR DESCRIPTION
This adds a new command to allow for creating a namespace via CLI. A
user will now be able to use:

  make USERNAME=admin NAMESPACE=demo dev/createnamespace

To create a new namespace called 'demo' which the 'admin' user is owner
of.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>