### PR TITLE
Feature: monitor endpoint for galaxy

### DIFF
--- a/galaxy/api/urls.py
+++ b/galaxy/api/urls.py
@@ -325,6 +325,9 @@ api_urls = [
     # url(r'^v1/', include('galaxy.api.v1.urls')),
     path('v2/', include('galaxy.api.v2.urls', namespace='v2')),
     path('internal/', include('galaxy.api.internal.urls', namespace='int')),
+
+    # Monitoring endpoint
+    url(r'^monitor/', views.MonitorRootView.as_view()),
 ]
 
 

--- a/galaxy/api/views/views.py
+++ b/galaxy/api/views/views.py
@@ -51,6 +51,13 @@ from galaxy.main.celerytasks import tasks as celerytasks
 from galaxy.main import models
 from galaxy.common import version, sanitize_content_name
 
+# monitor
+from kombu import Connection as RabbitMQ
+from django.db.migrations.executor import MigrationExecutor
+from django.db import connections, DatabaseError, DEFAULT_DB_ALIAS
+import influxdb
+import redis
+
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +73,7 @@ __all__ = [
     'ImportTaskLatestList',
     'ImportTaskList',
     'ImportTaskNotificationList',
+    'MonitorRootView',
     'PlatformDetail',
     'PlatformList',
     'ProviderRootView',
@@ -107,6 +115,71 @@ def filter_rating_queryset(qs):
     )
 
 # -----------------------------------------------------------------------------
+
+
+class MonitorRootView(base_views.APIView):
+    """ Monitor resources """
+    permission_classes = (AllowAny,)
+
+    monitor_response = OrderedDict()
+
+    def get(self, request, format=None):
+        if not settings.GALAXY_METRICS_ENABLED:
+            self.monitor_response['influx'] = 'n/a'
+        else:
+            influxdb_client = influxdb.InfluxDBClient(
+                host=settings.INFLUX_DB_HOST,
+                port=settings.INFLUX_DB_PORT,
+                username=settings.INFLUX_DB_USERNAME,
+                password=settings.INFLUX_DB_PASSWORD
+            )
+
+            try:
+                influxdb_client.ping()
+                self.monitor_response['influx'] = 'ok'
+            except influxdb.client.InfluxDBClientError:
+                self.monitor_response['influx'] = 'error'
+
+            influxdb_client.close()
+
+        try:
+            connection = connections[DEFAULT_DB_ALIAS]
+            connection.prepare_database()
+            executor = MigrationExecutor(connection)
+            targets = executor.loader.graph.leaf_nodes()
+
+            if not executor.migration_plan(targets):
+                self.monitor_response['migrations'] = 'ok'
+            else:
+                self.monitor_response['migrations'] = 'needed'
+
+            self.monitor_response['postgresql'] = 'ok'
+        except DatabaseError:
+            self.monitor_response['postgresql'] = 'error'
+
+        redis_client = redis.Redis(
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            db=0
+        )
+
+        try:
+            redis_client.ping()
+            self.monitor_response['redis'] = 'ok'
+        except redis.exceptions.RedisError:
+            self.monitor_response['redis'] = 'error'
+
+        rabbit_client = RabbitMQ(settings.BROKER_URL)
+
+        rabbit_client.connect()
+        if rabbit_client.connected:
+            self.monitor_response['rabbitmq'] = 'ok'
+        else:
+            self.monitor_response['rabbitmq'] = 'error'
+
+        rabbit_client.close()
+
+        return Response(self.monitor_response)
 
 
 class ApiRootView(base_views.APIView):


### PR DESCRIPTION
Endpoint: /api/monitor/

Checks:

 - influxdb connection
 - rabbitmq connection
 - postgresql connection (and migration state)
 - redis connection

---

![image](https://user-images.githubusercontent.com/27003/71324834-30e9e600-24e4-11ea-8334-caa9c25f4d7f.png)

---

Motivation: I couldn't find one, and thought this would be a good idea to have.
You can stick this into a monitoring tool and look for "error" and hopefully get
someone on it, before Galaxy is brittle for over a day.

Related: ansible/galaxy#2170

---

I ran all tests locally, and formatters and prettifiers. Kudos for the docs and the setup.