### PR TITLE
Add format() to nested directory error

### DIFF
--- a/galaxy/importer/finders.py
+++ b/galaxy/importer/finders.py
@@ -118,8 +118,10 @@ class FileSystemFinder(BaseFinder):
         for file_name in os.listdir(content_dir):
             file_path = os.path.join(content_dir, file_name)
             if os.path.isdir(file_path):
-                self.log.warning("Directory detected: '{0}'. "
-                                 "Nested modules are not supported.".format(file_path))
+                self.log.warning(
+                    "Directory detected: '{0}'. "
+                    "Nested modules are not supported.".format(
+                        file_path))
                 continue
             if (not os.path.isfile(file_path)
                     or not file_name.endswith('.py')

--- a/galaxy/importer/finders.py
+++ b/galaxy/importer/finders.py
@@ -119,7 +119,7 @@ class FileSystemFinder(BaseFinder):
             file_path = os.path.join(content_dir, file_name)
             if os.path.isdir(file_path):
                 self.log.warning("Directory detected: '{0}'. "
-                                 "Nested modules are not supported.")
+                                 "Nested modules are not supported.".format(file_path))
                 continue
             if (not os.path.isfile(file_path)
                     or not file_name.endswith('.py')


### PR DESCRIPTION
The nested directory error outputs `{0}` which implies it's missing a format statement. This pull request adds an update statement with what I expect is the right argument.