### PR TITLE
Fix flake8 not using default ignore codes

### DIFF
--- a/galaxy/importer/linters/__init__.py
+++ b/galaxy/importer/linters/__init__.py
@@ -50,7 +50,7 @@ class Flake8Linter(BaseLinter):
 
     def _check_files(self, paths):
         cmd = [self.cmd, '--exit-zero', '--isolated',
-               '--ignore', FLAKE8_IGNORE_ERRORS,
+               '--extend-ignore', FLAKE8_IGNORE_ERRORS,
                '--select', FLAKE8_SELECT_ERRORS,
                '--max-line-length', str(FLAKE8_MAX_LINE_LENGTH),
                '--'] + paths

--- a/galaxy/importer/tests/test_linters.py
+++ b/galaxy/importer/tests/test_linters.py
@@ -61,7 +61,6 @@ def test_flake8_fail():
 
         expected = [
             "{0}:3:9: F821 undefined name 'x'",
-            "{0}:5:11: W504 line break after binary operator",
             "{0}:6:9: F821 undefined name 'y'",
             "{0}:7:1: E101 indentation contains mixed spaces and tabs",
             "{0}:7:1: W191 indentation contains tabs",


### PR DESCRIPTION
The flake8 invocation in the the linting now extends the
default list of errors to ignore via '--extend-ignore' instead
of overwriting them via '--ignore'.

The default list of errors to ignore include
E121,E123,E126,E226,E24,E704,W503,W504
which include some of the more "controversial" potential
warnings, and many of these were causing role and collection
linting to fail.

Fixes: ansible/galaxy#2199