### PR TITLE
Fix download_count for ansible-galaxy collection

### DIFF
--- a/galaxy/api/download/tests/test_download_views.py
+++ b/galaxy/api/download/tests/test_download_views.py
@@ -34,7 +34,7 @@ UserModel = get_user_model()
 
 class TestArtifactDownloadView(APITestCase):
     download_url = '/download/{filename}'
-    mazer_user_agent = 'Mazer/0.4.0 (linux; python:3.6.8) ansible_galaxy/0.4.0'
+    user_agent = 'ansible-galaxy/2.9.4.post0 (Linux; python:3.6.10)'
 
     @classmethod
     def setUpClass(cls):
@@ -95,7 +95,7 @@ class TestArtifactDownloadView(APITestCase):
 
         old_download_count = self.collection.download_count
         url = self.download_url.format(filename=self.filename)
-        response = self.client.get(url, HTTP_USER_AGENT=self.mazer_user_agent)
+        response = self.client.get(url, HTTP_USER_AGENT=self.user_agent)
         assert response.status_code == http_codes.HTTP_302_FOUND
 
         location = response['Location']

--- a/galaxy/api/download/views.py
+++ b/galaxy/api/download/views.py
@@ -41,7 +41,7 @@ class ArtifactDownloadView(APIView):
             raise NotFound(f'Artifact "{filename}" does not exist.')
 
         user_agent = request.META.get('HTTP_USER_AGENT', '')
-        if user_agent.startswith('Mazer/'):
+        if user_agent.startswith('ansible-galaxy/'):
             version.collection.inc_download_count()
 
         ca = version.get_content_artifact()


### PR DESCRIPTION
The view for collection artifact downloads used by
'ansible-galaxy collection install' was only incrementing
downloads that match the 'Mazer/' user-agent. That user-agent
is no longer used, so update it to the user-agent string used
for ansible-galaxy starting with ansible 2.9.3 ('ansible-galaxy/')

Fixes: ansible/galaxy#2177