### PR TITLE
Removed redundant code for validating GitHub API availability

### DIFF
--- a/galaxy/api/views/token.py
+++ b/galaxy/api/views/token.py
@@ -76,14 +76,6 @@ class TokenView(base_views.APIView):
             raise ValidationError({'detail': "Invalid request."})
 
         try:
-            git_status = requests.get(get_github_api_url())
-            git_status.raise_for_status()
-        except Exception:
-            raise ValidationError({
-                'detail': "Error accessing GitHub API. Please try again later."
-            })
-
-        try:
             header = dict(Authorization='token ' + github_token)
             gh_user = requests.get(
                 get_github_api_url() + '/user', headers=header


### PR DESCRIPTION
In GHE (and I assume Github Enterprise Cloud), accessing `https://github.domain/api/v3` without authentication token returns following:

```
{
  "message": "Must authenticate to access this API.",
  "documentation_url": "https://developer.github.com/enterprise/2.17/v3"
}
```

Current code already checks if a token is supplied, and later code for `/user/` API is using it and when API is unavailable is handling such errors. Ideally, I believe message property can be in `ValidationError` if necessary

Signed-off-by: Egor Margineanu <egor.margineanu@gmail.com>