### PR TITLE
Improve importer error logging

### DIFF
--- a/galaxy/importer/finders.py
+++ b/galaxy/importer/finders.py
@@ -136,9 +136,11 @@ class FileSystemFinder(BaseFinder):
             if not os.path.isdir(file_path):
                 continue
             meta_path = _find_metadata(file_path, ROLE_META_FILES)
-            if not meta_path:
-                raise exc.RoleMetadataNotFound('Role metadata not found')
             rel_path = os.path.relpath(file_path, self.path)
+            if not meta_path:
+                raise exc.RoleMetadataNotFound(
+                    'Role metadata not found in directory: "{0}"'.format(
+                        rel_path))
             yield Result(content_type, rel_path,
                          extra={'metadata_path': meta_path})
 


### PR DESCRIPTION
Exceptions will now include the filesystem path where importer is unable to find metadata. 
`Role metadata not found in directory: "roles/role_missing_metadata"`

Fixes #2232 

Signed-off-by: Brian McLaughlin <bmclaugh@redhat.com>
