### PR TITLE
Render tables in README files

### DIFF
--- a/galaxy/importer/utils/readme.py
+++ b/galaxy/importer/utils/readme.py
@@ -93,7 +93,7 @@ def render_html(readme_file):
         # https://github.com/Python-Markdown/markdown/issues/225
         html = bleach.clean(
             unsafe_html,
-            tags=markdown_tags + ['pre'],
+            tags=markdown_tags + ['pre', 'table', 'thead', 'th', 'tr', 'td'],
             attributes=markdown_attrs,
             styles=[],
             strip=True

--- a/galaxyui/src/styles.less
+++ b/galaxyui/src/styles.less
@@ -207,6 +207,17 @@ a.failed {
             height: 100%;
         }
     }
+
+    .readme table {
+        tr:nth-child(2n) {
+            background-color: #f2f2f2;
+        }
+        td,
+        th {
+            border: 1px solid #ccc;
+            padding: 5px;
+        }
+    }
 }
 
 /* Authors */


### PR DESCRIPTION
Before:
![2245-before](https://user-images.githubusercontent.com/1630348/75382488-9376ae00-58a8-11ea-9863-a4bbadad4b8b.png)

After:
![image](https://user-images.githubusercontent.com/1630348/75451108-eea6b000-593d-11ea-821a-f149cd2f795b.png)

Fixes #2245.