### PR TITLE
Increase max artifact upload size

### DIFF
--- a/galaxy/constants.py
+++ b/galaxy/constants.py
@@ -23,7 +23,7 @@ from pulpcore import constants as pulp_const
 
 
 MAX_TAGS_COUNT = 20
-MAX_UPLOAD_FILE_SIZE_BYTES = 2 * 1000 * 1000  # 2MB
+MAX_UPLOAD_FILE_SIZE_BYTES = 20 * 1000 * 1000  # 20MB
 PROVIDER_GITHUB = 'GitHub'
 ROLE_TAG_REGEXP = re.compile(r'^[a-z0-9]+$')
 NAME_REGEXP = re.compile(r'^(?!.*__)[a-z]+[0-9a-z_]*$')


### PR DESCRIPTION
Increase max artifact size from 2 MB to 20 MB.