### PR TITLE
Pin ansible version

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -8,7 +8,7 @@ aiohttp==3.5.4            # via -r requirements/requirements.in
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
 ansible-lint==4.2.0       # via -r requirements/requirements.in, galaxy-importer
-ansible==2.9.6            # via -r requirements/requirements.in, ansible-lint, galaxy-importer
+ansible==2.9.2            # via -r requirements/requirements.in, ansible-lint, galaxy-importer
 anyjson==0.3.3            # via kombu
 asn1crypto==0.24.0        # via cryptography
 async-timeout==3.0.1      # via aiohttp

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,7 +1,7 @@
 # Common
 # NOTE(cutwater): Probably some of requirements below are obsolete.
 #                 Review required.
-ansible>=2.7.16
+ansible==2.9.2
 bleach>=3.1.1
 bleach-whitelist==0.0.10
 galaxy-importer==0.2.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,7 +8,7 @@ aiohttp==3.5.4            # via -r requirements/requirements.in
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
 ansible-lint==4.2.0       # via -r requirements/requirements.in, galaxy-importer
-ansible==2.9.6            # via -r requirements/requirements.in, ansible-lint, galaxy-importer
+ansible==2.9.2            # via -r requirements/requirements.in, ansible-lint, galaxy-importer
 anyjson==0.3.3            # via kombu
 asn1crypto==0.24.0        # via cryptography
 async-timeout==3.0.1      # via aiohttp


### PR DESCRIPTION
Pin ansible version to avoid OCP uid issue until this is released: https://github.com/ansible/ansible/pull/68466

Supports #2303, #2324 