### PR TITLE
Fix travis webhook import task token issue

### DIFF
--- a/galaxy/settings/production.py
+++ b/galaxy/settings/production.py
@@ -211,9 +211,7 @@ WAIT_FOR = [
 ADMIN_URL_PATH = os.environ.get('GALAXY_ADMIN_PATH', 'admin')
 ADMIN_URL_PATTERN = r'^{}/'.format(ADMIN_URL_PATH)
 
-GITHUB_TASK_USERS = ['galaxytasks02', 'galaxytasks03',
-                     'galaxytasks04', 'galaxytasks05',
-                     'galaxytasks09']
+GITHUB_TASK_USERS = ['galaxytasks09']
 
 GALAXY_URL = 'https://{site}'
 


### PR DESCRIPTION
Travis webhook token import task uses `galaxytasks02` which has an auth issue, this PR switches to `galaxytasks09` where token auth is working.

Works https://github.com/ansible/galaxy/issues/2369