### PR TITLE
Upgrade django-allauth

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file=requirements/dev-requirements.txt requirements/dev-requirements.in
 #
+-e git+https://github.com/pennersr/django-allauth.git@83a0f77688f7d89939db454e3708d34e523accf3#egg=django-allauth  # via -r requirements/requirements.in
 aiohttp==3.5.4            # via -r requirements/requirements.in
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
@@ -31,7 +32,6 @@ cryptography==2.4.2       # via ansible, pyopenssl
 defusedxml==0.5.0         # via python3-openid
 deprecated==1.2.4         # via pygithub
 dj-database-url==0.5.0    # via -r requirements/requirements.in
-django-allauth==0.37.1    # via -r requirements/requirements.in
 django-bootstrap-form==3.4  # via -r requirements/requirements.in
 django-celery==3.2.2      # via -r requirements/requirements.in
 django-debug-toolbar==1.11  # via -r requirements/dev-requirements.in
@@ -48,10 +48,11 @@ drf-yasg==1.12.1          # via pulpcore
 dynaconf==1.2.0           # via pulpcore
 entrypoints==0.3          # via flake8
 flake8==3.7.9             # via -r requirements/requirements.in, galaxy-importer
-galaxy-importer==0.2.3
+galaxy-importer==0.2.3    # via -r requirements/requirements.in
 gunicorn==19.7.1          # via -r requirements/requirements.in, pulpcore
 honcho==1.0.1             # via -r requirements/dev-requirements.in
-idna==2.7                 # via cryptography, requests, yarl
+idna-ssl==1.1.0           # via aiohttp
+idna==2.7                 # via cryptography, idna-ssl, requests, yarl
 imagesize==1.1.0          # via sphinx
 importlib-metadata==1.5.2  # via pluggy, pytest
 inflection==0.3.1         # via drf-yasg
@@ -109,6 +110,7 @@ sphinx==1.7.9             # via -r requirements/requirements.in
 sphinxcontrib-websupport==1.1.0  # via sphinx
 sqlparse==0.2.4           # via django, django-debug-toolbar
 toml==0.10.0              # via dynaconf
+typing-extensions==3.7.4.2  # via aiohttp
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via botocore, requests
 wcwidth==0.1.9            # via pytest

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -20,7 +20,8 @@ semantic_version
 
 # Django
 Django>=2.2.10,<3.0
-django-allauth>=0.37,<0.38
+# django-allauth>=0.37,<0.38
+-e git+https://github.com/pennersr/django-allauth.git@83a0f77688f7d89939db454e3708d34e523accf3#egg=django-allauth
 # TODO(cutwater): Review usage of this package
 django-bootstrap-form
 django-filter

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file=requirements/requirements.txt requirements/requirements.in
 #
+-e git+https://github.com/pennersr/django-allauth.git@83a0f77688f7d89939db454e3708d34e523accf3#egg=django-allauth  # via -r requirements/requirements.in
 aiohttp==3.5.4            # via -r requirements/requirements.in
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
@@ -30,7 +31,6 @@ cryptography==2.4.2       # via ansible, pyopenssl
 defusedxml==0.5.0         # via python3-openid
 deprecated==1.2.4         # via pygithub
 dj-database-url==0.5.0    # via -r requirements/requirements.in
-django-allauth==0.37.1    # via -r requirements/requirements.in
 django-bootstrap-form==3.4  # via -r requirements/requirements.in
 django-celery==3.2.2      # via -r requirements/requirements.in
 django-filter==2.0.0      # via -r requirements/requirements.in, pulpcore
@@ -46,9 +46,10 @@ drf-yasg==1.12.1          # via pulpcore
 dynaconf==1.2.0           # via pulpcore
 entrypoints==0.3          # via flake8
 flake8==3.7.9             # via -r requirements/requirements.in, galaxy-importer
-galaxy-importer==0.2.3
+galaxy-importer==0.2.3    # via -r requirements/requirements.in
 gunicorn==19.7.1          # via -r requirements/requirements.in, pulpcore
-idna==2.7                 # via cryptography, requests, yarl
+idna-ssl==1.1.0           # via aiohttp
+idna==2.7                 # via cryptography, idna-ssl, requests, yarl
 imagesize==1.1.0          # via sphinx
 inflection==0.3.1         # via drf-yasg
 influxdb==5.2.1           # via -r requirements/requirements.in
@@ -96,6 +97,7 @@ sphinx==1.7.9             # via -r requirements/requirements.in
 sphinxcontrib-websupport==1.1.0  # via sphinx
 sqlparse==0.3.1           # via django
 toml==0.10.0              # via dynaconf
+typing-extensions==3.7.4.2  # via aiohttp
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via botocore, requests
 webencodings==0.5.1       # via bleach


### PR DESCRIPTION
Upgrade django-allauth to git commit 83a0f776.
It includes fix for GitHub described in
https://github.com/pennersr/django-allauth/issues/2457.

Issue: #2224