### PR TITLE
Update galaxy-importer dependency to 0.2.7

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -48,7 +48,7 @@ drf-yasg==1.12.1          # via pulpcore
 dynaconf==1.2.0           # via pulpcore
 entrypoints==0.3          # via flake8
 flake8==3.7.9             # via -r requirements/requirements.in, galaxy-importer
-galaxy-importer==0.2.3    # via -r requirements/requirements.in
+galaxy-importer==0.2.7    # via -r requirements/requirements.in
 gunicorn==19.7.1          # via -r requirements/requirements.in, pulpcore
 honcho==1.0.1             # via -r requirements/dev-requirements.in
 idna-ssl==1.1.0           # via aiohttp

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,7 +4,7 @@
 ansible>=2.9.7
 bleach>=3.1.1
 bleach-whitelist==0.0.10
-galaxy-importer==0.2.3
+galaxy-importer==0.2.7
 gunicorn==19.7.1
 markdown
 marshmallow

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -46,7 +46,7 @@ drf-yasg==1.12.1          # via pulpcore
 dynaconf==1.2.0           # via pulpcore
 entrypoints==0.3          # via flake8
 flake8==3.7.9             # via -r requirements/requirements.in, galaxy-importer
-galaxy-importer==0.2.3    # via -r requirements/requirements.in
+galaxy-importer==0.2.7    # via -r requirements/requirements.in
 gunicorn==19.7.1          # via -r requirements/requirements.in, pulpcore
 idna-ssl==1.1.0           # via aiohttp
 idna==2.7                 # via cryptography, idna-ssl, requests, yarl


### PR DESCRIPTION
galaxy-importer version 0.2.7 includes replacing tarfile module with tar
subprocess

Signed-off-by: Andrew Crosby <acrosby@redhat.com>