### PR TITLE
default to the v2 requirements.yml layout

### DIFF
--- a/docs/docsite/rst/using/installing.rst
+++ b/docs/docsite/rst/using/installing.rst
@@ -111,6 +111,8 @@ The following example provides a guide for listing roles in a *requirements.yml*
 
 .. code-block:: yaml
 
+    roles:
+
     # from galaxy
     - src: yatesr.timezone
 
@@ -148,7 +150,9 @@ file. For large projects, this provides the ability to split a large file into m
 For example, a project may have a *requirements.yml* file, and a *webserver.yml* file. The following
 shows the contents of the *requirements.yml* file:
 
-.. code-block:: bash
+.. code-block:: yaml
+
+    roles:
 
     # from galaxy
     - src: yatesr.timezone
@@ -156,7 +160,9 @@ shows the contents of the *requirements.yml* file:
 
 Below are the contents of the *webserver.yml* file:
 
-.. code-block:: bash
+.. code-block:: yaml
+
+    roles:
 
     # from github
     - src: https://github.com/bennojoy/nginx


### PR DESCRIPTION
Since https://github.com/ansible/ansible/commit/e747487720ce682798cfdbbfecb9b7299f9a6a2b (Ansible 2.9), `ansible-galaxy` supports a newer `requirements.yml` format that can list both roles and collections (called v2).

When you want to add collections to an existing (v1) `requirements.yml`, you end up moving the roles into a `roles` section, which is not obvious for new users.
Let's document the new format as the default so that people don't have to change it after the fact.

+label: docsite_pr