### PR TITLE
Fix source handling for private repositories

### DIFF
--- a/docs/docsite/rst/using/installing.rst
+++ b/docs/docsite/rst/using/installing.rst
@@ -135,7 +135,7 @@ The following example provides a guide for listing roles in a *requirements.yml*
       scm: hg
 
     # from GitLab or other git-based scm
-    - src: git@gitlab.company.com:mygroup/ansible-base.git
+    - src: git+ssh://git@gitlab.company.com/mygroup/ansible-base.git
       scm: git
       version: "0.1"  # quoted, so YAML doesn't parse this as a floating-point value
 


### PR DESCRIPTION
Use correct format for private repositories as stated here:
https://github.com/ansible/ansible/issues/8937#issuecomment-55097691

Tested with bitbucket.org

+label: docsite_pr

Signed-off-by: Stefan Simon <stefan.simon@bytepoets.com>