### PR TITLE
Fix the check for max size of docs files

### DIFF
--- a/galaxy/importer/utils/readme.py
+++ b/galaxy/importer/utils/readme.py
@@ -34,7 +34,7 @@ README_MIMETYPES = {
     '.md': 'text/markdown',
     '.rst': 'text/x-rst',
 }
-README_MAX_SIZE = 512 ** 2  # 512 KiB
+README_MAX_SIZE = 512 * 1024  # 512 KiB
 
 ReadmeFile = collections.namedtuple(
     'ReadmeFile', ['text', 'mimetype', 'hash']
@@ -66,8 +66,11 @@ def get_readme(directory, root_dir=None, filename=None):
 
     if os.path.getsize(filename) > README_MAX_SIZE:
         raise FileSizeError(
-            'Readme file "{0}" is bigger than 512 KiB.'
-            .format(os.path.relpath(filename, root_dir or directory)))
+            'Readme file "{0}" is bigger than {1} KiB.'.format(
+                os.path.relpath(filename, root_dir or directory),
+                int(README_MAX_SIZE / 1024),
+            )
+        )
 
     mimetype, encoding = mimetypes.guess_type(filename)
 


### PR DESCRIPTION
The check for role README max file size during the Community Galaxy
import process uses the wrong calculation to to check for 512 KiB,
imports currently fail when greater than 256 KiB.

AAH-297