### PR TITLE
Prevent role rename if metadata and database role names match

### DIFF
--- a/galaxy/importer/repository.py
+++ b/galaxy/importer/repository.py
@@ -16,6 +16,7 @@
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
 import logging
+import re
 
 from galaxy import constants
 from galaxy.importer import loaders
@@ -28,63 +29,85 @@ from galaxy.importer import exceptions as exc
 default_logger = logging.getLogger(__name__)
 
 
-def import_repository(url, branch=None, temp_dir=None, logger=None):
+def import_repository(
+    url, branch=None, temp_dir=None, logger=None, repo_obj=None
+):
     with git.make_clone_dir(temp_dir) as clone_dir:
         try:
             git.clone_repository(url, clone_dir, branch=branch)
         except Exception as e:
             raise exc.RepositoryError(e)
-        return load_repository(clone_dir, logger)
+        return load_repository(clone_dir, logger, repo_obj)
 
 
-def load_repository(directory, logger=None):
+def load_repository(directory, logger=None, repo_obj=None):
     """
     :param directory: Repository directory path.
     :type logger: logging.Logger
     :param logger: Optional logger instance.
+    :param repo_obj: Repository object.
     """
     logger = logger or default_logger
-    return RepositoryLoader(directory, logger=logger).load()
+    return RepositoryLoader(directory, logger=logger, repo_obj=repo_obj).load()
 
 
 class RepositoryLoader(object):
     """Loads repository and content info."""
 
-    def __init__(self, path, name=None, logger=None):
+    def __init__(self, path, name=None, logger=None, repo_obj=None):
         """
         :param str path: Path to the repository directory.
         :param str name: Repository name.
         :param logging.Logger: Logger instance.
+        :param repo_obj: Repository object.
         """
         self.path = path
         self.name = name
         self.metadata = None
         self.log = logger or default_logger
+        self.repo_obj = repo_obj
 
     def load(self):
         branch = git.get_current_branch(directory=self.path)
         commit = git.get_commit_info(directory=self.path)
         role = self._find_contents()
-        result = list(self._load_contents(role))
+        loader_result = list(self._load_contents(role))
 
-        name = None
-        description = None
-        if result[0][0].name:
-            name = result[0][0].name
-        if result[0][0].description:
-            description = result[0][0].description
+        role = loader_result[0][0]
+        metadata_role_name = getattr(role, 'name', None)
+        self._validate_metadata_role_name(metadata_role_name)
 
-        quality_score = self._get_repo_quality_score(result)
+        quality_score = self._get_repo_quality_score(loader_result)
 
         return models.Repository(
             branch=branch,
             commit=commit,
             format=constants.RepositoryFormat.ROLE,
-            contents=[v[0] for v in result],
-            name=name,
-            description=description,
+            contents=[role],
+            name=metadata_role_name,
+            description=getattr(role, 'description', None),
             quality_score=quality_score,
         )
+
+    def _validate_metadata_role_name(self, metadata_role_name):
+        """Validate meta/main.yml role_name.
+
+        If role is not new, and metadata_role_name matches existing name,
+        then do not validate. This allows legacy role names with dashes.
+        """
+
+        if not metadata_role_name:
+            return
+
+        if self.repo_obj.content_objects.filter():
+            role_obj = self.repo_obj.content_objects.get()
+            if getattr(role_obj, 'name') == metadata_role_name:
+                self.log.debug('metadata role_name matches existing role name')
+                return
+
+        if not re.match(constants.NAME_REGEXP, metadata_role_name):
+            raise exc.RepositoryError(
+                'meta/main.yml role_name does not match NAME_REGEXP')
 
     def _find_contents(self):
         try:

--- a/galaxy/importer/tests/test_role_loader.py
+++ b/galaxy/importer/tests/test_role_loader.py
@@ -152,6 +152,7 @@ class TestRoleLoader(unittest.TestCase):
         load_metadata_mock.return_value = ({
             'galaxy_info': {
                 'description': 'A test role',
+                'role_name': 'test_role',
                 'author': 'John Smith',
                 'license': 'foo',
                 'min_ansible_version': '2.4.0',

--- a/galaxy/worker/tasks/repository.py
+++ b/galaxy/worker/tasks/repository.py
@@ -98,7 +98,9 @@ def _import_repository(import_task, logger):
             repository.clone_url,
             branch=import_task.import_branch,
             temp_dir=settings.CONTENT_DOWNLOAD_DIR,
-            logger=logger)
+            logger=logger,
+            repo_obj=repository,
+        )
     except i_exc.ImporterError as e:
         raise exc.LegacyTaskError(str(e))
 


### PR DESCRIPTION
* Centralize the validation of meta/main.yml `role_name`
* Skip validation if metadata `role_name` already matches database role name

Resolves: https://github.com/ansible/galaxy/issues/2622
JIRA tracker issue: AAH-388