### PR TITLE
In dev deploy, ping influxdb container to 1.8.4

### DIFF
--- a/scripts/docker/dev/compose.yml
+++ b/scripts/docker/dev/compose.yml
@@ -24,7 +24,7 @@ services:
       - POSTGRES_PASSWORD=galaxy
 
   influxdb:
-    image: influxdb:latest
+    image: influxdb:1.8.4
     ports:
       - '8086:8086'
     environment:


### PR DESCRIPTION
Influxdb 'latest' container is 2.x.x and has
incompatible API.