### PR TITLE
home.component: add a card with export regulation notice

### DIFF
--- a/galaxyui/src/app/home/home.component.html
+++ b/galaxyui/src/app/home/home.component.html
@@ -52,5 +52,21 @@
                 </pfng-card>
             </div>
         </div>
+        <div class="col-md-12">
+            <div class="home-card" id="card-4">
+                <pfng-card
+                    [headerTemplate]="legalHeader"
+                    [config]="legalConfig">
+                    <ng-template #legalHeader>
+                        <div class="card-header">
+                            <span class="header-icon"><i class="fa fa-gavel fa-2x"></i></span> <span class="header-text">Legal</span>
+                        </div>
+                    </ng-template>
+                    <div class="card-content">
+                      By contributing to and/or downloading Ansible Galaxy content, you acknowledge that you understand all of the following: Ansible Galaxy software and technical information may be subject to the U.S. Export Administration Regulations (the "EAR") and other U.S. and foreign laws and may not be exported, re-exported or transferred (a) to a prohibited destination country under the EAR or U.S. sanctions regulations (currently Cuba, Iran, North Korea, Syria, and the Crimea Region of Ukraine, subject to change as posted by the United States government); (b) to any prohibited destination or to any end user who has been prohibited from participating in U.S. export transactions by any federal agency of the U.S. government; or (c) for use in connection with the design, development or production of nuclear, chemical or biological weapons, or rocket systems, space launch vehicles, or sounding rockets, or unmanned air vehicle systems. You may not contribute to Ansible Galaxy or download Ansible Galaxy software or technical information if you are located in one of these countries or otherwise subject to these restrictions. You may not provide Ansible Galaxy software or technical information to individuals or entities located in one of these countries or otherwise subject to these restrictions. You are also responsible for compliance with foreign law requirements applicable to the import, export and use of Ansible Galaxy software and technical information.
+                    </div>
+                </pfng-card>
+            </div>
+        </div>
     </div>
 </div>

--- a/galaxyui/src/app/home/home.component.ts
+++ b/galaxyui/src/app/home/home.component.ts
@@ -20,10 +20,12 @@ export class HomeComponent implements OnInit, AfterViewInit {
     downloadConfig: CardConfig;
     shareConfig: CardConfig;
     featureConfig: CardConfig;
+    legalConfig: CardConfig;
 
     downloadContent: string;
     shareContent: string;
     featuredBlogContent: string;
+
     headerTitle = 'Home';
     headerIcon = 'fa fa-home';
     searchText = '';
@@ -59,6 +61,10 @@ export class HomeComponent implements OnInit, AfterViewInit {
         } as CardConfig;
 
         this.featureConfig = {
+            titleBorder: true,
+        } as CardConfig;
+
+        this.legalConfig = {
             titleBorder: true,
         } as CardConfig;
     }


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-745

![galaxy-legal](https://user-images.githubusercontent.com/289743/124327132-213a6b80-db77-11eb-9ff1-250fe3035051.png)

This adds a Legal card to the `home.component`, with the following notice:

> By contributing to and/or downloading Ansible Galaxy content, you acknowledge that you understand all of the following: Ansible Galaxy software and technical information may be subject to the U.S. Export Administration Regulations (the "EAR") and other U.S. and foreign laws and may not be exported, re-exported or transferred (a) to a prohibited destination country under the EAR or U.S. sanctions regulations (currently Cuba, Iran, North Korea, Syria, and the Crimea Region of Ukraine, subject to change as posted by the United States government); (b) to any prohibited destination or to any end user who has been prohibited from participating in U.S. export transactions by any federal agency of the U.S. government; or (c) for use in connection with the design, development or production of nuclear, chemical or biological weapons, or rocket systems, space launch vehicles, or sounding rockets, or unmanned air vehicle systems. You may not contribute to Ansible Galaxy or download Ansible Galaxy software or technical information if you are located in one of these countries or otherwise subject to these restrictions. You may not provide Ansible Galaxy software or technical information to individuals or entities located in one of these countries or otherwise subject to these restrictions. You are also responsible for compliance with foreign law requirements applicable to the import, export and use of Ansible Galaxy software and technical information.
