### PR TITLE
Explain role names installed from Git URLs

### DIFF
--- a/docs/docsite/rst/contributing/creating_role.rst
+++ b/docs/docsite/rst/contributing/creating_role.rst
@@ -166,7 +166,7 @@ Prior to Galaxy v3.0, the role import process would alter the GitHub repository 
 apply a regular expression, and remove 'ansible-' and 'role-' from the repository name. For example, a repository name of
 *ansible-role-apache* would become *apache*.
 
-Starting in v3.0, Galaxy no longer perform this calculation. Instead, the default role name is the unaltered repository name, with a
+Starting in v3.0, Galaxy no longer performs this calculation. Instead, the default role name is the unaltered repository name, with a
 couple minor exceptions, including: converting the name to all lowercase, and replacing any '-' or '.' characters with '_'.
 
 To override the default name, set the ``role_name`` attribute in the role ``meta/main.yml`` file. The following snippet from a
@@ -193,4 +193,4 @@ To override the default name, set the ``role_name`` attribute in the role ``meta
 
 .. note::
 
-    `role_name` is not used at all if the role is installed using its Git URL. Instead, the name of the repo is used.
+    `role_name` is ignored when installing a role using its Git URL. Instead, the role name defaults to the repository name.

--- a/docs/docsite/rst/using/installing.rst
+++ b/docs/docsite/rst/using/installing.rst
@@ -58,7 +58,7 @@ role.
 
 .. code-block:: bash
 
-   $ ansible-galaxy install geerlingguy.apache,v1.0.0
+   $ ansible-galaxy install geerlingguy.apache,1.0.0
 
 It's also possible to point directly to the git repository and specify a branch name or commit hash as the version.
 For example, the following installs a specific commit:
@@ -66,6 +66,15 @@ For example, the following installs a specific commit:
 .. code-block:: bash
 
    $ ansible-galaxy install git+https://github.com/geerlingguy/ansible-role-apache.git,0b7cd353c0250e87a26e0499e59e7fd265cc2f25
+
+The name of a role installed from a repository defaults to the name of the repository (in this case ``ansible-role-apache``).
+A different name can be specified after the version:
+
+.. code-block:: bash
+
+   $ ansible-galaxy install git+https://github.com/geerlingguy/ansible-role-apache.git,master,geerlingguy.apache
+
+This command installs the latest commit from ``master`` with the same role name ``geerlingguy.apache`` used by Galaxy.
 
 Listing Your Installed Roles
 ----------------------------


### PR DESCRIPTION
Explain how to override the repository name when installing a role from a SCM URL.

Documents a viable workaround for #939.