### PR TITLE
Pin setuptools in docker base image

### DIFF
--- a/scripts/docker/dev/Dockerfile
+++ b/scripts/docker/dev/Dockerfile
@@ -51,7 +51,7 @@ RUN python3.6 -m venv "${GALAXY_VENV}" \
     && "${GALAXY_VENV}/bin/pip" install -U \
         'pip' \
         'wheel' \
-        'setuptools' \
+        'setuptools>=57,<58' \
     && "${GALAXY_VENV}/bin/pip" install -r /tmp/requirements.txt
 
 COPY scripts/docker/dev/entrypoint.sh /entrypoint

--- a/scripts/docker/release/Dockerfile.base
+++ b/scripts/docker/release/Dockerfile.base
@@ -20,5 +20,5 @@ RUN python3.6 -m venv ${GALAXY_VENV} \
     && "${GALAXY_VENV}/bin/pip" install -U \
         'pip' \
         'wheel' \
-        'setuptools' \
+        'setuptools>=57,<58' \
     && "${GALAXY_VENV}/bin/pip" install -r /tmp/requirements.txt


### PR DESCRIPTION
Attempt to fix build server conflict with use_2to3, may add pyproject.toml if also necessary.