### PR TITLE
Add reference to explain missing provider

### DIFF
--- a/docs/docsite/rst/contributing/importing.rst
+++ b/docs/docsite/rst/contributing/importing.rst
@@ -55,6 +55,8 @@ available, as depicted below:
 
 .. image:: login-06.png
 
+.. _updating_github_permissions:
+
 Updating GitHub Permissions
 ---------------------------
 

--- a/docs/docsite/rst/contributing/namespaces.rst
+++ b/docs/docsite/rst/contributing/namespaces.rst
@@ -36,7 +36,8 @@ Clicking the *X* next to the name on the right will remove it.
 .. image:: mycontent-09.png
 
 At the top of the list of Provider namespace is a search box. If you don't see an organization listed, try typing the name in the
-box and pressing Enter.
+box and pressing Enter. (In case the organization is still missing, please ensure that the Ansible Galaxy GitHub app has access to
+your organization as described in :ref:`updating_github_permissions`.)
 
 Click the *Save* button at the bottom of the page to update the namespace with your changes, as shown below:
 


### PR DESCRIPTION
In issue #2829 I was trying to add a GitHub organization as a provider namespace by following the "namespace" instructions. I did not realize that this requires authorization from the Ansible Galaxy GitHub app because those steps appear in the "importing" instructions. In this PR I add a reference from the "namespace" instructions to the "importing" instructions. (Had there been such a link, I probably would not have opened #2829.)