### PR TITLE
Creating Role: Fix Galaxy Tags API URL

### DIFF
--- a/docs/docsite/rst/contributing/creating_role.rst
+++ b/docs/docsite/rst/contributing/creating_role.rst
@@ -147,7 +147,7 @@ platforms
 
 galaxy_tags
     Optional. Provide a list of tags. A tag is a single word that helps categorize your role. You can invent tags, or guess at tags other might be
-    using to describe similar roles, but why do that, when you can see what others are using by `browsing existing tags here <https://galaxy-qa.ansible.com/api/v1/tags/>`_.
+    using to describe similar roles, but why do that, when you can see what others are using by `browsing existing tags here <https://galaxy.ansible.com/api/v1/tags/>`_.
 
     As with *platforms*, you can search by name here as well. For example, to see if the 'database' tag exists, add ``?name_icontains=database``
     to the query. The full URL will be `https://galaxy.ansible.com/api/v1/tags/?name__icontains=database <https://galaxy.ansible.com/api/v1/tags/?name__icontains=database>`_.


### PR DESCRIPTION
galaxy-qa.ansible.com results in a DNS error
Use galaxy.ansible.com instead