### PR TITLE
Use more recent version of importer

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,7 +2,7 @@
 # NOTE(cutwater): Probably some of requirements below are obsolete.
 #                 Review required.
 ansible-core>=2.11,<2.12
-galaxy-importer==0.4.0.post1
+galaxy-importer==0.4.7
 gunicorn==19.7.1
 markdown
 marshmallow


### PR DESCRIPTION
Current version of importer use an old version of linter that could be misleading regarding the linting requirement for galaxy.
On our side we used a recent version of linter (6.17) to prepare the galaxy publication and had different message when publishing.
I've bumped to the oldest version that changes the range of linter, but if it's ok on your side we could even use the latest version `0.4.11`
Thanks in advance