### PR TITLE
Add banner linking to beta-galaxy

### DIFF
--- a/galaxyui/src/app/app.component.html
+++ b/galaxyui/src/app/app.component.html
@@ -68,6 +68,14 @@
         </div>
     </pfng-vertical-navigation>
     <div #contentContainer id="app-container" class="app-container container-fluid container-pf-nav-pf-vertical">
+        <h3>
+            <div class="alert alert-success">
+                <span class="pficon pficon-info"></span>
+                <a href="https://beta-galaxy.ansible.com">
+                    A new Galaxy is coming: Click Here to Experience the New and Improved Ansible Galaxy Website!
+                </a>
+            </div>
+        </h3>
         <router-outlet (activate)='routerActivate($event)'></router-outlet>
         <user-notifications></user-notifications>
     </div>


### PR DESCRIPTION
Issue: [AAH-1893](https://issues.redhat.com/browse/AAH-1893)
beta-galaxy PR: https://github.com/ansible/ansible-hub-ui/pull/4128

![20230814183037](https://github.com/ansible/galaxy/assets/289743/890e4d5f-cbb7-4db8-b415-7b1ec5ef9224)
![20230814183051](https://github.com/ansible/galaxy/assets/289743/7b2575b7-e37a-40df-a6c5-51862d8de6c1)

(using pf3 alerts (https://pf3.patternfly.org/v3/pattern-library/widgets/#alerts), as they appear to be the closest banner-like thing available in that version (classification banners are not in the version we're using either))