### PR TITLE
Removing user from new namespace request auto-add

### DIFF
--- a/.github/ISSUE_TEMPLATE/New_namespace.md
+++ b/.github/ISSUE_TEMPLATE/New_namespace.md
@@ -3,7 +3,7 @@ name: Request a Namespace
 about: Request a new namespace for one of your GitHub Orgs
 title: 'namespace: FIXME'
 labels: area/namespace
-assignees: thedoubl3j, alisonlhart, chynasan, traytorous
+assignees: alisonlhart, chynasan, traytorous
 
 ---
 


### PR DESCRIPTION
Removing Jake from the rule to add PE users to galaxy namespace issues automatically.