### PR TITLE
Don't assign Namespace assigns

### DIFF
--- a/.github/ISSUE_TEMPLATE/New_namespace.md
+++ b/.github/ISSUE_TEMPLATE/New_namespace.md
@@ -3,7 +3,6 @@ name: Request a Namespace
 about: Request a new namespace for one of your GitHub Orgs
 title: 'namespace: FIXME'
 labels: area/namespace
-assignees: traytorous, epacific1, gundalow, samccann, Andersson007, oraNod, anweshadas
 
 ---
 


### PR DESCRIPTION
Don't auto assign Galaxy namespace requests.
Slack notifies us of work.
The ticket owner MUST assign the ticket to themselves when they start working on it.